### PR TITLE
Fix dd blocksize parameter

### DIFF
--- a/installation/installing-images/mac.md
+++ b/installation/installing-images/mac.md
@@ -28,9 +28,14 @@ On Mac OS you have the choice of the command line `dd` tool or using the graphic
 
     e.g. `diskutil unmountDisk /dev/disk4`
 
-    `sudo dd bs=1M if=image.img of=/dev/DISK`
+    `sudo dd bs=1m if=image.img of=/dev/DISK`
 
-    e.g. `sudo dd bs=1M if=2014-01-07-wheezy-raspbian.img of=/dev/disk4`
+    e.g. `sudo dd bs=1m if=2014-01-07-wheezy-raspbian.img of=/dev/disk4`
+
+    This may result in an ``dd: invalid number '1m'`` error if you have GNU
+    coreutils installed. In that case you need to use ``1M``:
+
+    `sudo dd bs=1M if=image.img of=/dev/DISK`
 
     This will take a few minutes.
 


### PR DESCRIPTION
When specifying a blocksize in megabytes you need to use a capital M. Otherwise you get this error:

```
wichert@kim $ dd bs=1m if=2014-01-07-wheezy-raspbian.img of=/dev/disk1
dd: invalid number '1m'
```
