### PR TITLE
Update raspistill.md

### DIFF
--- a/usage/camera/raspicam/raspistill.md
+++ b/usage/camera/raspicam/raspistill.md
@@ -62,7 +62,13 @@ Then run with:
 
 ### More options
 
-For a full list of possible options, run `raspistill` with no arguments, then use <kbd>shift</kbd>+<kbd>page up</kbd> and <kbd>shift</kbd>+<kbd>page down</kbd> to scroll up and down.
+For a full list of possible options, run `raspistill` with no arguments. To scroll, redirect stderr to stdout and pipe the output to `less`:
+
+```
+raspistill 2>&1 | less
+```
+
+Use the arrow keys to scroll and type `q` to exit.
 
 ## Full documentation
 


### PR DESCRIPTION
`less` didn't work for me. When trying to use the arrow keys it scrolled to an empty buffer and there was no way to get back. Might be related to the Norwegian keyboard layout, but I've never had an issue with `less` and Norwegian keyboards on other linux distros. Anyways I guess shift + page up and shift + page down should be more robust.
