### PR TITLE
Make format of commands for Mac installation guide consistent

### DIFF
--- a/installation/installing-images/mac.md
+++ b/installation/installing-images/mac.md
@@ -28,14 +28,14 @@ On Mac OS you have the choice of the command line `dd` tool or using the graphic
 
     e.g. `diskutil unmountDisk /dev/disk4`
 
-    `sudo dd bs=1m if=image.img of=/dev/DISK`
+    `sudo dd bs=1m if=image.img of=/dev/<disk# from diskutil>`
 
     e.g. `sudo dd bs=1m if=2014-09-09-wheezy-raspbian.img of=/dev/disk4`
 
     This may result in an ``dd: invalid number '1m'`` error if you have GNU
     coreutils installed. In that case you need to use ``1M``:
 
-    `sudo dd bs=1M if=image.img of=/dev/DISK`
+    `sudo dd bs=1M if=image.img of=/dev/<disk# from diskutil>`
 
     This will take a few minutes.
 


### PR DESCRIPTION
Just to avoid confusion. If a user looks at the example commands below, it becomes apparent what `DISK` is referring to. I just thought keeping the format the same might help.