### PR TITLE
Improved Mac OS SD format

### DIFF
--- a/installation/noobs.md
+++ b/installation/noobs.md
@@ -33,7 +33,7 @@ For Windows users we recommend formatting your SD card using the SD Association'
 
 ##### Mac OS
 
-The [SD Association's Formatting Tool](https://www.sdcard.org/downloads/formatter_4/) is also available for Mac users, although the default OSX Disk Utility is also capable of formatting the entire disk. To do this, select the SD card volume and choose `Erase` with `MS-DOS` format.
+The [SD Association's Formatting Tool](https://www.sdcard.org/downloads/formatter_4/) is also available for Mac users, although the default OSX Disk Utility is also capable of formatting the entire disk. To do this, select the SD card volume and choose `Partition` and select at least `1` parition and select `MS-DOS` format. Click the options button, and verify that the mode is `Master Boot Record`, then perform the partition with the `apply` button.
 
 ##### Linux
 


### PR DESCRIPTION
The Mac OS SD format instructions left out the critical step of installing the Master Boot Record without which NOOBS fails.  This was likely overlooked before because many cards come pre-formatted with the MS-DOS master boot record and merely need to be erased, but SD cards previosly used for NOOBS or MAC OSX may need to be repartitioned and at that moment it's critical to re-install the MBR or NOOBS will not boot on a Rasberry Pi.
