### PR TITLE
Update with Raspberry 2 compiling instructions

### DIFF
--- a/linux/kernel/building.md
+++ b/linux/kernel/building.md
@@ -20,9 +20,17 @@ $ sudo apt-get install bc
 
 Configure the kernel - as well as the default configuration you may wish to [configure your kernel in more detail](configuring.md) or [apply patches from another source](patching.md) to add or remove required functionality:
 
+#Raspberry 1 Default Configuration
+
 ```
 $ cd linux
 $ make bcmrpi_defconfig
+```
+
+#Raspberry 2 Default Configuration
+```
+$ cd linux
+$ make bcm2709_defconfig
 ```
 
 Build the kernel; this step takes a **lot** of time...


### PR DESCRIPTION
It took me too long to figure out why my Kernel wasn't loading.

It'd save a lot of wasted hours for users if they knew how to compile for their perspective RPi device version.