### PR TITLE
Update with Raspberry 2 compiling instructions

### DIFF
--- a/linux/kernel/building.md
+++ b/linux/kernel/building.md
@@ -20,9 +20,19 @@ $ sudo apt-get install bc
 
 Configure the kernel - as well as the default configuration you may wish to [configure your kernel in more detail](configuring.md) or [apply patches from another source](patching.md) to add or remove required functionality:
 
+Run the following commands depending on your Raspberry Pi version.
+
+####Raspberry Pi 1 Default Build Configuration
+
 ```
 $ cd linux
 $ make bcmrpi_defconfig
+```
+
+####Raspberry Pi 2 Default Build Configuration
+```
+$ cd linux
+$ make bcm2709_defconfig
 ```
 
 Build the kernel; this step takes a **lot** of time...


### PR DESCRIPTION
It took me too long to figure out why my kernel wasn't loading after compiling.

The default configuration commands for the Raspberry Pi 2 are not documented.

This needs to be changed to guide users properly depending on their Raspberry device version.