### PR TITLE
Add warning about VGA adapters

### DIFF
--- a/setup/monitor-connection.md
+++ b/setup/monitor-connection.md
@@ -12,7 +12,7 @@ For monitors with a DVI port, you can use an HDMI-to-DVI cable.
 
 ### VGA
 
-For monitors with VGA only, you can use an HDMI-to-VGA adapter.
+For monitors with VGA only, you can use an HDMI-to-VGA adapter. We suggest using only powered HDMI-to-VGA adapters (with an external power source). Using an unpowered adapter may damage your Pi and therefore is not advised.
 
 ## Composite Port
 


### PR DESCRIPTION
Some people may be tempted to use cheap unpowered VGA adapters to connect their Pi to an older display device. These adapters often draw too much power from the HDMI port (much more than the HDMI specification allows) and may damage the Pi.