### PR TITLE
Update remote-access/vnc/README.md

### DIFF
--- a/remote-access/vnc/README.md
+++ b/remote-access/vnc/README.md
@@ -87,8 +87,8 @@ cd /etc/init.d/
 #! /bin/sh
 # /etc/init.d/vncboot
 
-USER=root
-HOME=/root
+USER=pi
+HOME=/home/pi
 
 export USER HOME
 
@@ -96,7 +96,7 @@ case "$1" in
  start)
   echo "Starting VNC Server"
   #Insert your favoured settings for a VNC session
-  /usr/bin/vncserver :0 -geometry 1280x800 -depth 16 -pixelformat rgb565
+  su - pi -c "/usr/bin/vncserver :0 -geometry 1280x800 -depth 16 -pixelformat rgb565"
   ;;
 
  stop)


### PR DESCRIPTION
Updated the shell script to reflect that on a fresh install people will pe using the user "pi" for all their setup needs. Setting this up as root, which is not even set by default kind of defeats the whole purpose of the pi user.