### PR TITLE
replaces bs=1m with bs=1M

### DIFF
--- a/installation/installing-images/mac.md
+++ b/installation/installing-images/mac.md
@@ -11,7 +11,7 @@ On Mac OS you have the choice of the command line `dd` tool or using the graphic
 - From the terminal run:
 
     ```
-    sudo dd bs=1m if=path_of_your_image.img of=/dev/diskn
+    sudo dd bs=1M if=path_of_your_image.img of=/dev/diskn
     ```
 
     Remember to replace `n` with the number that you noted before!


### PR DESCRIPTION
On OS X Yosemite 10.10.3 with `dd (coreutils) 8.23` installed, the lower case `m` gave an error: 

    dd: invalid number ‘1m’

Uppercase `M` works just file.