### PR TITLE
Update mac.md to include status tip #230

### DIFF
--- a/installation/installing-images/mac.md
+++ b/installation/installing-images/mac.md
@@ -15,6 +15,9 @@ On Mac OS you have the choice of the command line `dd` tool or using the graphic
     ```
 
     Remember to replace `n` with the number that you noted before!
+    
+    This will take a few minutes, depending on the image file size.
+    You can check the progress by sending a `SIGINFO` signal pressing <kbd>Ctrl</kbd>+<kbd>T</kbd>.
 
 ## Command line
 


### PR DESCRIPTION
Fixes Issue #230. Adds the helpful tip for checking write status to the Graphical Interface section. It's a helpful tip and users may overlook the tip in the command line section.