### PR TITLE
Update cmio-camera.md GPIO pin warning

### DIFF
--- a/hardware/computemodule/cmio-camera.md
+++ b/hardware/computemodule/cmio-camera.md
@@ -117,4 +117,4 @@ pin_define@CAMERA_1_SCL_PIN { type = "internal"; number = <29>; };
 
 [Enable both cameras](dt-blob-dualcam.dts)
 
-*As of 2015-04-17 some users are reporting issues with GPIO pin 2 and 3 for camera control. Pin 4 and 5 is reported to work. The issue is being investigated.*
+*As of 2015-04-17 some users are reporting issues with GPIO pin 2 and 3 for camera control. Pin 4 and 5 is reported to work with the dual cam setup, but not with single cam. The issue is being investigated.*


### PR DESCRIPTION
Is there anywhere I can discuss this or provide debug information?

After power up, the GPIO pins are set differently from the device tree - the kernel must be overriding the setting.

2&3 are set to be SDA1. I tried to setup GPIO 44&45 to SDA1 but SDA1 just appears on 44/45 AND 2/3.

Separately, I cannot get the single cam to work no matter what I do.