### PR TITLE
Improved description of image installation for mac

### DIFF
--- a/installation/installing-images/mac.md
+++ b/installation/installing-images/mac.md
@@ -16,11 +16,11 @@ On Mac OS you have the choice of the command line `dd` tool or using the graphic
 
     Remember to replace `n` with the number that you noted before!
 
-- If this command fails, try using `disk` instead of `rdisk`:
+   - If this command fails, try using `disk` instead of `rdisk`:
     
-    ```
-    sudo dd bs=1m if=path_of_your_image.img of=/dev/diskn
-    ```
+       ```
+       sudo dd bs=1m if=path_of_your_image.img of=/dev/diskn
+       ```
 
 ## Command line
 
@@ -28,33 +28,36 @@ On Mac OS you have the choice of the command line `dd` tool or using the graphic
 
     `diskutil list`
 
-- Identify the disk (not partition) of your SD card e.g. `disk4` (not `disk4s1`):
+- Identify the disk (not partition) of your SD card e.g. `disk4` (not `disk4s1`).
+- Unmount your SD card by using the disk identifier to prepare copying data to it:
 
     `diskutil unmountDisk /dev/disk<disk# from diskutil>`
 
     e.g. `diskutil unmountDisk /dev/disk4`
+    
+- Copy the data to your SD card:
 
     `sudo dd bs=1m if=image.img of=/dev/rdisk<disk# from diskutil>`
 
     e.g. `sudo dd bs=1m if=2015-05-05-raspbian-wheezy.img of=/dev/rdisk4`
 
-    This may result in an ``dd: invalid number '1m'`` error if you have GNU
+    - This may result in an ``dd: invalid number '1m'`` error if you have GNU
     coreutils installed. In that case you need to use ``1M``:
 
-    `sudo dd bs=1M if=image.img of=/dev/rdisk<disk# from diskutil>`
+       `sudo dd bs=1M if=image.img of=/dev/rdisk<disk# from diskutil>`
 
     This will take a few minutes, depending on the image file size.
     You can check the progress by sending a `SIGINFO` signal pressing <kbd>Ctrl</kbd>+<kbd>T</kbd>.
     
-    If this command still fails, try using `disk` instead of `rdisk`:
+    - If this command still fails, try using `disk` instead of `rdisk`:
     
-    ```
-    e.g. `sudo dd bs=1m if=2015-05-05-raspbian-wheezy.img of=/dev/disk4`
-    ```
-    or
-    ```
-    e.g. `sudo dd bs=1M if=2015-05-05-raspbian-wheezy.img of=/dev/disk4`
-    ```
+       ```
+       e.g. `sudo dd bs=1m if=2015-05-05-raspbian-wheezy.img of=/dev/disk4`
+       ```
+       or
+       ```
+       e.g. `sudo dd bs=1M if=2015-05-05-raspbian-wheezy.img of=/dev/disk4`
+       ```
 
 ## Alternative method
 

--- a/installation/installing-images/mac.md
+++ b/installation/installing-images/mac.md
@@ -24,18 +24,18 @@ On Mac OS you have the choice of the command line `dd` tool or using the graphic
 
 - Identify the disk (not partition) of your SD card e.g. `disk4` (not `disk4s1`):
 
-    `diskutil unmountDisk /dev/<disk# from diskutil>`
+    `diskutil unmountDisk /dev/disk<disk# from diskutil>`
 
     e.g. `diskutil unmountDisk /dev/disk4`
 
-    `sudo dd bs=1m if=image.img of=/dev/<disk# from diskutil>`
+    `sudo dd bs=1m if=image.img of=/dev/disk<disk# from diskutil>`
 
     e.g. `sudo dd bs=1m if=2015-05-05-raspbian-wheezy.img of=/dev/disk4`
 
     This may result in an ``dd: invalid number '1m'`` error if you have GNU
     coreutils installed. In that case you need to use ``1M``:
 
-    `sudo dd bs=1M if=image.img of=/dev/<disk# from diskutil>`
+    `sudo dd bs=1M if=image.img of=/dev/disk<disk# from diskutil>`
 
     This will take a few minutes, depending on the image file size.
     You can check the progress by sending a `SIGINFO` signal pressing <kbd>Ctrl</kbd>+<kbd>T</kbd>.

--- a/installation/installing-images/mac.md
+++ b/installation/installing-images/mac.md
@@ -11,10 +11,16 @@ On Mac OS you have the choice of the command line `dd` tool or using the graphic
 - From the terminal run:
 
     ```
-    sudo dd bs=1m if=path_of_your_image.img of=/dev/diskn
+    sudo dd bs=1m if=path_of_your_image.img of=/dev/rdiskn
     ```
 
     Remember to replace `n` with the number that you noted before!
+
+- If this command fails, try using `disk` instead of `rdisk`:
+    
+    ```
+    sudo dd bs=1m if=path_of_your_image.img of=/dev/diskn
+    ```
 
 ## Command line
 
@@ -28,17 +34,27 @@ On Mac OS you have the choice of the command line `dd` tool or using the graphic
 
     e.g. `diskutil unmountDisk /dev/disk4`
 
-    `sudo dd bs=1m if=image.img of=/dev/disk<disk# from diskutil>`
+    `sudo dd bs=1m if=image.img of=/dev/rdisk<disk# from diskutil>`
 
-    e.g. `sudo dd bs=1m if=2015-05-05-raspbian-wheezy.img of=/dev/disk4`
+    e.g. `sudo dd bs=1m if=2015-05-05-raspbian-wheezy.img of=/dev/rdisk4`
 
     This may result in an ``dd: invalid number '1m'`` error if you have GNU
     coreutils installed. In that case you need to use ``1M``:
 
-    `sudo dd bs=1M if=image.img of=/dev/disk<disk# from diskutil>`
+    `sudo dd bs=1M if=image.img of=/dev/rdisk<disk# from diskutil>`
 
     This will take a few minutes, depending on the image file size.
     You can check the progress by sending a `SIGINFO` signal pressing <kbd>Ctrl</kbd>+<kbd>T</kbd>.
+    
+    If this command still fails, try using `disk` instead of `rdisk`:
+    
+    ```
+    e.g. `sudo dd bs=1m if=2015-05-05-raspbian-wheezy.img of=/dev/disk4`
+    ```
+    or
+    ```
+    e.g. `sudo dd bs=1M if=2015-05-05-raspbian-wheezy.img of=/dev/disk4`
+    ```
 
 ## Alternative method
 


### PR DESCRIPTION
I improved the guide for installing images on mac os:
- fixing the description of the general use of the `dd`-command
- adding some headlines in the terminal method
- use `/dev/rdiskn` instead of `/dev/diskn` in the `dd`-command. This benefits in dramatically increased data rates.

See the description of my commits for further information, and feel free to suggest further improvements in the comments or by creating another pull request. I would really like to see my changes accepted! :smiley: Thanks!

And, as always: You're great, folks. Keep it going! :wink: