### PR TITLE
Extra description for formatting SD card on Windows

### DIFF
--- a/installation/noobs.md
+++ b/installation/noobs.md
@@ -31,7 +31,7 @@ To set up a blank SD card with NOOBS:
 
 ##### Windows
 
-For Windows users we recommend formatting your SD card using the SD Association's Formatting Tool, which can be downloaded from [sdcard.org](https://www.sdcard.org/downloads/formatter_4/). You will need to set "FORMAT SIZE ADJUSTMENT" option to "ON" in the "Options" menu to ensure that the entire SD card volume is formatted, and not just a single partition.
+For Windows users we recommend formatting your SD card using the SD Association's Formatting Tool, which can be downloaded from [sdcard.org](https://www.sdcard.org/downloads/formatter_4/). You will need to set "FORMAT SIZE ADJUSTMENT" option to "ON" in the "Options" menu to ensure that the entire SD card volume is formatted, and not just a single partition; the updated size will be shown after the format is complete.
 
 ##### Mac OS
 


### PR DESCRIPTION
When formatting an SD card using the sdcard.org tool on Windows, the documentation already says that you need to select a specific option in order to use all the space on the card.  It's a little confusing however, because the tool doesn't show the full size until after the format is complete, so it's not clear that you've done it correctly until then.  This is just some reassuring text to say that this will happen.
