### PR TITLE
Eject the card in the command line instructions

### DIFF
--- a/installation/installing-images/mac.md
+++ b/installation/installing-images/mac.md
@@ -62,7 +62,7 @@ On Mac OS you have the choice of the command line `dd` tool or using the graphic
 - After the `dd` command finishes, eject the card:
 
     ```
-    sudo diskutil eject /dev/rdisk3
+    sudo diskutil eject /dev/rdisk4
     ```
 
     (or: open Disk Utility and eject the SD card)

--- a/installation/installing-images/mac.md
+++ b/installation/installing-images/mac.md
@@ -59,6 +59,14 @@ On Mac OS you have the choice of the command line `dd` tool or using the graphic
        e.g. `sudo dd bs=1M if=2015-09-24-raspbian-jessie.img of=/dev/disk4`
        ```
 
+- After the `dd` command finishes, eject the card:
+
+    ```
+    sudo diskutil eject /dev/rdisk3
+    ```
+
+    (or: open Disk Utility and eject the SD card)
+
 ## Alternative method
 
 **Note: Some users have reported issues with using Mac OS X to create SD cards.**


### PR DESCRIPTION
At the bottom of the "Alternative method", the last step is to eject the card. Should this advice be added to the "Command line" instructions as well?