### PR TITLE
The built-in 'ssh-copy-id' command is a bit simpler.

### DIFF
--- a/remote-access/ssh/passwordless.md
+++ b/remote-access/ssh/passwordless.md
@@ -57,7 +57,7 @@ ssh-rsa <REALLY LONG STRING OF RANDOM CHARACTERS> eben@pi
 To copy your public key to your Raspberry Pi, use the following command to append the public key to your `authorized_keys` file on the Pi, sending it over SSH:
 
 ```
-cat ~/.ssh/id_rsa.pub | ssh <USERNAME>@<IP-ADDRESS> 'cat >> .ssh/authorized_keys'
+ssh-copy-id ~/.ssh/id_rsa.pub <USERNAME>@<IP-ADDRESS>
 ```
 
 Note that this time you will have to authenticate with your password.


### PR DESCRIPTION
ssh-copy-id installs your public key in a remote machine's authorized_keys automatically. No need to mess with permissions etc. 