### PR TITLE
Update nginx.md

### DIFF
--- a/remote-access/web-server/nginx.md
+++ b/remote-access/web-server/nginx.md
@@ -28,7 +28,7 @@ Browse to the default web page either on the Pi or from another computer on the 
 
 ### Changing the default web page
 
-NGINX defaults its web page location to `/usr/share/nginx/www` on Raspbian. Navigate to this folder and edit or replace index.html as you like.
+NGINX defaults its web page location to `/usr/share/nginx/www` on Raspbian. Navigate to this folder and edit or replace index.html as you like. You can confirm the default page location at `/etc/nginx/sites-available` on the line the starts with 'root'. This tutorial assumes it is `/usr/share/nginx/www`.
 
 
 ## Additional - Install PHP


### PR DESCRIPTION
Clarified where the root directory is. Since I installed nginx through the Raspbian repo manually, my version of Raspbian had the root directory located in /var/www/html/. 