### PR TITLE
Fix instructions for Linux installs: remove truncate bit, add expand filesystem notes

### DIFF
--- a/installation/installing-images/linux.md
+++ b/installation/installing-images/linux.md
@@ -30,17 +30,11 @@ Please note that the use of the `dd` tool can overwrite any partition of your ma
 
 - You can check what's written to the SD card by `dd`-ing from the card back to another image on your hard disk, truncating the new image to the same size as the original, and then running `diff` (or `md5sum`) on those two images.
 
-- The SD card might be bigger than the original image, and dd will make a copy of the whole card. We must therefore truncate the new image to the size of the original image.  Make sure you replace the input file if= argument with the right device name. `diff` should report that the files are identical.
-
-    ```bash
-    dd bs=4M if=/dev/sdd of=from-sd-card.img
-    truncate --reference 2015-11-21-raspbian-jessie.img from-sd-card.img
-    diff -s from-sd-card.img 2015-11-21-raspbian-jessie.img
-    ```
-
 - Run `sync`; this will ensure the write cache is flushed and that it is safe to unmount your SD card.
 
 - Remove the SD card from the card reader.
+
+- The SD card might be bigger than the original image, and dd will only write to the card as big as the image is. If desired, one can expand the filesystem on the SD card to make use of all available space. This can be done by booting into the raspberry pi, running `sudo raspi-config`, selecting the "Expand Filesystem" option, and rebooting.
 
 ---
 


### PR DESCRIPTION
Remove old instructions, and mention the ability to expand the filesystem
