### PR TITLE
Revert "Include Pi 2 in the cross-compiling instructions"

### DIFF
--- a/linux/kernel/building.md
+++ b/linux/kernel/building.md
@@ -105,8 +105,6 @@ Then for both:
 make ARCH=arm CROSS_COMPILE=arm-linux-gnueabihf- zImage modules dtbs
 ```
 
-For the Raspberry Pi 2, use `bcm2709_defconfig` instead of `bcmrpi_defconfig` on the second line.
-
 Note: To speed up compilation on multiprocessor systems, and get some improvement on single processor ones, use ```-j n``` where n is number of processors * 1.5. Alternatively, feel free to experiment and see what works!
 
 ### Install directly onto the SD card


### PR DESCRIPTION
Reverts raspberrypi/documentation#218