### PR TITLE
Missing instructions about creating .ssh on Pi

### DIFF
--- a/remote-access/ssh/passwordless.md
+++ b/remote-access/ssh/passwordless.md
@@ -58,7 +58,7 @@ If your Pi does not have an .ssh directory you will need to set one up so that y
 
 ```
 cd ~
-mkdir .ssh
+install -d -m 700 ~/.ssh
 touch .ssh/authorized_keys
 ```
 

--- a/remote-access/ssh/passwordless.md
+++ b/remote-access/ssh/passwordless.md
@@ -59,7 +59,6 @@ If your Pi does not have an .ssh directory you will need to set one up so that y
 ```
 cd ~
 install -d -m 700 ~/.ssh
-touch .ssh/authorized_keys
 ```
 
 To copy your public key to your Raspberry Pi, use the following command to append the public key to your `authorized_keys` file on the Pi, sending it over SSH:

--- a/remote-access/ssh/passwordless.md
+++ b/remote-access/ssh/passwordless.md
@@ -54,6 +54,14 @@ ssh-rsa <REALLY LONG STRING OF RANDOM CHARACTERS> eben@pi
 
 ## Copy your public key to your Raspberry Pi
 
+If your Pi does not have an .ssh directory you will need to set one up so that you can copy the key from your computer.
+
+```
+cd ~
+mkdir .ssh
+touch .ssh/authorized_keys
+```
+
 To copy your public key to your Raspberry Pi, use the following command to append the public key to your `authorized_keys` file on the Pi, sending it over SSH:
 
 ```


### PR DESCRIPTION
The copy command chain will fail if .ssh hasn't been created on the Pi.