### PR TITLE
Include BCM2836 default configuration command.

### DIFF
--- a/linux/kernel/configuring.md
+++ b/linux/kernel/configuring.md
@@ -12,10 +12,18 @@ The menuconfig tool requires the ncurses development headers to compile properly
 $ sudo apt-get install libncurses5-dev
 ```
 
-You will also need to download and prepare your kernel sources as described in the [build guide](building.md). In particular ensure you have installed the default configuration for the Raspberry Pi with the following command:
+You will also need to download and prepare your kernel sources as described in the [build guide](building.md). In particular ensure you have installed the default configuration:
 
+For all Raspberry PI 1 (includes compute module) 
 ```
+$ KERNEL=kernel
 $ make bcmrpi_defconfig
+```
+
+For all Raspberry PI 2
+```
+$ KERNEL=kernel7
+$ make bcm2709_defconfig
 ```
 
 ## Using menuconfig

--- a/linux/kernel/configuring.md
+++ b/linux/kernel/configuring.md
@@ -14,13 +14,13 @@ $ sudo apt-get install libncurses5-dev
 
 You will also need to download and prepare your kernel sources as described in the [build guide](building.md). In particular ensure you have installed the default configuration:
 
-For all Raspberry PI 1 (includes compute module) 
+For all Raspberry Pi 1 (includes Compute Module and Pi Zero) 
 ```
 $ KERNEL=kernel
 $ make bcmrpi_defconfig
 ```
 
-For all Raspberry PI 2/3
+For all Raspberry Pi 2/3
 ```
 $ KERNEL=kernel7
 $ make bcm2709_defconfig

--- a/linux/kernel/configuring.md
+++ b/linux/kernel/configuring.md
@@ -20,7 +20,7 @@ $ KERNEL=kernel
 $ make bcmrpi_defconfig
 ```
 
-For all Raspberry PI 2
+For all Raspberry PI 2/3
 ```
 $ KERNEL=kernel7
 $ make bcm2709_defconfig


### PR DESCRIPTION
Hi,

I noticed the documentation here https://www.raspberrypi.org/documentation/linux/kernel/configuring.md doesn't instruct users how to load the default config for rPi2's so I have updated it. 