### PR TITLE
Update docs for handling kernel-updates

### DIFF
--- a/linux/kernel/updating.md
+++ b/linux/kernel/updating.md
@@ -1,12 +1,12 @@
 # Updating the Kernel
 
-If you are using the Raspberry Pi stock kernel, your system can be kept up to date by the `rpi-update` utility:
+It is highly recommended to update your kernel as part of your regular system updates instead of manually updating it.
 
-```
-$ sudo rpi-update
-```
+The Raspberry Pi Foundation kernel is part of the `raspberrypi-bootloader` package. This package also contains the necessary bootloader files for the Broadcom chip.
 
-This will install the latest packages, including the Linux kernel image. You will have to reboot your Pi after upgrading the kernel to switch to the updated kernel.
+You can also manually update the Rasperry Pi stock kernel, but this is not recommended. The `rpi-update` utility will download the latest version and copy all files into your system. Make sure it does not conflict with your distribution packages. It does not provide a way of automatically uninstalling the files.
+
+You will have to reboot your Pi after upgrading the kernel to switch to the updated kernel.
 
 If you are using a compiled kernel you will need to [rebuild](building.md) your kernel again.
 


### PR DESCRIPTION
Updated the documentation to reflect the latest way of handling kernel updates. The rpi-update tool simply replaces kernel files and modules without a warning (adding such is part of the PR Hexxeh/rpi-update#201 ). This might leave files behind that are not managed via apt (cruft) and sometimes can cause issues for inexperienced users.

rpi-update should not longer be recommended by the documentation unless it handles the updates more cleanly (e.g. allows clean removal) or warns the user at least what he is about to do.