### PR TITLE
MP4 output example with raspivid command

### DIFF
--- a/usage/camera/raspicam/raspivid.md
+++ b/usage/camera/raspicam/raspivid.md
@@ -36,15 +36,15 @@ Use the arrow keys to scroll and type `q` to exit.
 
 ### MP4 Video Format
 
-The Pi captures video as a raw H264 video stream. Many media players will refuse to play it (or play it at an incorrect speed) unless it is "wrapped" in a suitable container format like MP4. The easiest way to obtain an MP4 file from the raspivid command is using MP4Box.
+The Pi captures video as a raw H264 video stream. Many media players will refuse to play it, or play it at an incorrect speed, unless it is "wrapped" in a suitable container format like MP4. The easiest way to obtain an MP4 file from the raspivid command is using MP4Box.
 
-First install MP4Box with this command:
+Install MP4Box with this command:
 
 ```bash
 sudo apt-get install -y gpac
 ```
 
-Then capture your raw video with raspivid and wrap it in an MP4 container like this:
+Capture your raw video with raspivid and wrap it in an MP4 container like this:
 
 ```bash
 # Capture 30 seconds of raw video at 640x480 and 150kB/s bit rate into a pivideo.h264 file:
@@ -55,7 +55,7 @@ MP4Box -add pivideo.h264 pivideo.mp4
 rm pivideo.h264
 ```
 
-Or simply wrap MP4 around your existing raspivid output like this:
+Alternatively, wrap MP4 around your existing raspivid output, like this:
 
 ```bash
 MP4Box -add video.h264 video.mp4

--- a/usage/camera/raspicam/raspivid.md
+++ b/usage/camera/raspicam/raspivid.md
@@ -44,13 +44,16 @@ First install MP4Box with this command:
 sudo apt-get install -y gpac
 ```
 
-Then capture your raw video with raspivid and wrap it in an MP4 container all at once this:
+Then capture your raw video with raspivid and wrap it in an MP4 container like this:
 
 ```bash
-raspivid -t 30000 -w 640 -h 480 -fps 25 -b 1200000 -p 0,0,640,480 -o pivideo.h264 && MP4Box -add pivideo.h264 pivideo.mp4 && rm pivideo.h264
+# Capture 30 seconds of raw video at 640x480 and 150kB/s bit rate into a pivideo.h264 file:
+raspivid -t 30000 -w 640 -h 480 -fps 25 -b 1200000 -p 0,0,640,480 -o pivideo.h264 
+# Wrap the raw video with an MP4 container: 
+MP4Box -add pivideo.h264 pivideo.mp4
+# Remove the source raw file, leaving the remaining pivideo.mp4 file to play
+rm pivideo.h264
 ```
-
-(the above command captures a 30 second video at 640x480 size with a 150kB/s bitrate, then adds an MP4 wrapper and removes the original raw video file afterwards) 
 
 Or simply wrap MP4 around your existing raspivid output like this:
 

--- a/usage/camera/raspicam/raspivid.md
+++ b/usage/camera/raspicam/raspivid.md
@@ -34,6 +34,30 @@ raspivid 2>&1 | less
 
 Use the arrow keys to scroll and type `q` to exit.
 
+### MP4 Video Format
+
+The Pi captures video as a raw H264 video stream. Many media players will refuse to play it (or play it at an incorrect speed) unless it is "wrapped" in a suitable container format like MP4. The easiest way to obtain an MP4 file from the raspivid command is using MP4Box.
+
+First install MP4Box with this command:
+
+```bash
+sudo apt-get install -y gpac
+```
+
+Then capture your raw video with raspivid and wrap it in an MP4 container all at once this:
+
+```bash
+raspivid -t 30000 -w 640 -h 480 -fps 25 -b 1200000 -p 0,0,640,480 -o pivideo.h264 && MP4Box -add pivideo.h264 pivideo.mp4 && rm pivideo.h264
+```
+
+(the above command captures a 30 second video at 640x480 size with a 150kB/s bitrate, then adds an MP4 wrapper and removes the original raw video file afterwards) 
+
+Or simply wrap MP4 around your existing raspivid output like this:
+
+```bash
+MP4Box -add video.h264 video.mp4
+```
+
 ## Full documentation
 
 Full documentation of the camera can be found at [hardware/camera](../../../hardware/camera.md).


### PR DESCRIPTION
Added an example of wrapping the raw h264 raspivid output in an mp4 container so that raspivid output can be played back easily once recorded.

As per issue #345
