### PR TITLE
Fix typo in viewable area vertical dimension

### DIFF
--- a/hardware/display/README.md
+++ b/hardware/display/README.md
@@ -50,5 +50,5 @@ Read our troubleshooting steps, tips and tricks here: [Raspberry Pi Display Trou
 ## Module mechanical specification
 
 * Outer dimensions: 192.96 x 112.76mm
-* Viewable area: 154.08 x 95.92mm
+* Viewable area: 154.08 x 85.92mm
 * [Download mechanical drawing (PDF, 592kb)](7InchDisplayDrawing-14092015.pdf)


### PR DESCRIPTION
The associated mechanical drawing (PDF) gives the vertical viewable dimension as 85.92mm, not 95.92mm, and my touchscreen and calipers suggest the PDF has the correct value.