### PR TITLE
Update docs for nginx install

### DIFF
--- a/remote-access/web-server/nginx.md
+++ b/remote-access/web-server/nginx.md
@@ -28,7 +28,7 @@ Browse to the default web page either on the Pi or from another computer on the 
 
 ### Changing the default web page
 
-NGINX defaults its web page location to `/usr/share/nginx/www` on Raspbian. Navigate to this folder and edit or replace index.html as you like. You can confirm the default page location at `/etc/nginx/sites-available` on the line which starts with 'root', should you need to.
+NGINX defaults its web page location to `/usr/share/nginx/html` on Raspbian. Navigate to this folder and edit or replace index.html as you like. You can confirm the default page location at `/etc/nginx/sites-available`, in the default file, on the line which starts with 'root', should you need to.
 
 
 ## Additional - Install PHP


### PR DESCRIPTION
Having recently installed nginx on a raspberry pi, I noticed the default location for the web page is now /usr/share/nginx/html  not /usr/share/nginx/www like previously described.  Also I clarified that the options are visible in the file named "default" in the /etc/nginx/sites-available directory.

Closes #370
