### PR TITLE
Mac native client expects port number + display

### DIFF
--- a/remote-access/vnc/mac.md
+++ b/remote-access/vnc/mac.md
@@ -1,6 +1,6 @@
 ## Connecting to a Pi over VNC using Mac OS
 
-For Mac OS you will not need any extra software. Just select ``Go -> Connect to server ...`` (&#8984; K) from the Finder menu, enter ``vnc://raspberrypi.local:1`` as the Server Address and click ``Connect``. Here ``:1`` must correspond to the display on which you started the VNC server on your Pi. If there is a problem, try replacing ``raspberrypi.local`` with the IP address of your Pi.
+For Mac OS you will not need any extra software. Just select ``Go -> Connect to server ...`` (&#8984; K) from the Finder menu, enter ``vnc://raspberrypi.local:5901`` as the Server Address and click ``Connect``. Here ``:5901`` must correspond to the display on which you started the VNC server on your Pi plus the VNC service port number (5900). For example, display 1 + 5900 = 5901. If there is a problem, try replacing ``raspberrypi.local`` with the IP address of your Pi.
 
 Alternatively, you can use a program called RealVNC which is known to work with the Raspberry Pi VNC server; it can be downloaded from [realvnc.com](http://www.realvnc.com/download/vnc/latest).
 


### PR DESCRIPTION
The native Mac VNC client via Finder -> Connect to server, expects the VNC service port number + the display number. The default service port number for VNC is 5900 and the example display is 1; 5901 should be used to coordinate with the working example.