### PR TITLE
Fix to command to restore a compressed image

### DIFF
--- a/linux/filesystem/backup.md
+++ b/linux/filesystem/backup.md
@@ -67,7 +67,7 @@ sudo dd bs=4M if=/dev/sdb | gzip > rasbian.img.gz
 To restore, pipe the output of `gunzip` to `dd`:
 
 ```bash
-sudo gunzip --stdout rasbian.img.gz | dd bs=4M of=/dev/sdb
+gunzip --stdout rasbian.img.gz | sudo dd bs=4M of=/dev/sdb
 ```
 
 See more about [installing SD card images](../../installation/installing-images/README.md).

--- a/linux/filesystem/backup.md
+++ b/linux/filesystem/backup.md
@@ -67,7 +67,7 @@ sudo dd bs=4M if=/dev/sdb | gzip > rasbian.img.gz
 To restore, pipe the output of `gunzip` to `dd`:
 
 ```bash
-sudo gunzip --stdout rasbian.img.gz | dd bs=4m of=/dev/sdb
+sudo gunzip --stdout rasbian.img.gz | dd bs=4M of=/dev/sdb
 ```
 
 See more about [installing SD card images](../../installation/installing-images/README.md).


### PR DESCRIPTION
"bs=4m" is not understood by dd, the correct way to write it is as in the previous command, with a capital M.