### PR TITLE
Add warning to not use rpi-update anymore to docs

### DIFF
--- a/linux/kernel/updating.md
+++ b/linux/kernel/updating.md
@@ -1,13 +1,12 @@
 # Updating the Kernel
 
-It is highly recommended to update your kernel as part of your regular system updates instead of manually updating it.
-
 The Raspberry Pi Foundation kernel is part of the `raspberrypi-bootloader` package. This package also contains the necessary bootloader files for the Broadcom chip.
 
-You can also manually update the Rasperry Pi stock kernel, but this is not recommended. The `rpi-update` utility will download the latest version and copy all files into your system. Make sure it does not conflict with your distribution packages. It does not provide a way of automatically uninstalling the files.
+Your kernel will be updated automatically as part of your regular system updates.
+
+Please do *not* use utilities like `rpi-update`. These are no longer maintained and will simply copy all files into your system without any backup and possible conflicts with your package manager. 
+
+If you manually compiled your kernel, you will need to [rebuild](building.md) your kernel again.
+Custom [configurations](configuring.md) can usually be copied over between minor kernel updates, but it's safer to use the diff utility to see what's changed and repeat your changes on the new configuration.
 
 You will have to reboot your Pi after upgrading the kernel to switch to the updated kernel.
-
-If you are using a compiled kernel you will need to [rebuild](building.md) your kernel again.
-
-Custom [configurations](configuring.md) can usually be copied over between minor kernel updates, but it's safer to use the diff utility to see what's changed and repeat your changes on the new configuration.


### PR DESCRIPTION
rpi-update does not provide a way of rolling back changes. Generally it causes more support issues from people messing up their kernel config than it solves problems. It might be useful for different distributions or use-cases, but not for a regular noobs/raspbian user! Update docs accordingly.
See https://github.com/Hexxeh/rpi-update/pull/201