### PR TITLE
Added the dtoverlay for the audioinjector.net raspberry pi sound card.

### DIFF
--- a/configuration/device-tree.md
+++ b/configuration/device-tree.md
@@ -19,6 +19,7 @@ The main impact of using Device Tree is to change from *everything on*, relying 
 #dtoverlay=hifiberry-digi
 #dtoverlay=iqaudio-dac
 #dtoverlay=iqaudio-dacplus
+#dtoverlay=audioinjector-wm8731-audio
 
 # Uncomment this to enable the lirc-rpi module
 #dtoverlay=lirc-rpi


### PR DESCRIPTION
Altered the device tree configuration page to show how to setup the device tree overlay for the Audio Injector Raspberry Pi sound card.