### PR TITLE
New boot modes: GPIO pull up typo.

### DIFF
--- a/hardware/raspberrypi/bootmodes/bootflow.md
+++ b/hardware/raspberrypi/bootmodes/bootflow.md
@@ -6,7 +6,7 @@ Next the boot ROM checks each of the boot sources for a file called bootcode.bin
 
 * 2837 boots
 * Reads boot ROM enabled boot modes from OTP
-* Uses gpio_bootmode to disable some modes by reading GPIOs 22-26 or 39-43 to see if the default values do not equal the default pull to '0'.  If it is low it will disable that boot mode for each of SD1, SD2, NAND, SPI, USB. If the value read is a '1' then that boot mode is enabled, note this cannot enable boot modes that have not already been enabled in the OTP. The default pull resistance is around 50k ohms, so a smaller pull up of 5K should suffice to enable the boot mode but still allow the GPIO to be operational without consuming too much power.
+* Disables some modes if `gpio_bootmode` is set and any of the GPIOs 22-26 (or 39-43) do not show the default pull to '0'.  The boot modes that can be disabled are SD1, SD2, NAND, SPI, USB.  Please note this cannot enable boot modes that have not already been enabled in the OTP.  The default pull resistance is around 50k ohms, so a smaller pull up of 5K should suffice to disable each boot mode but still allow the GPIO to be operational without consuming too much power.
 * If enabled: Check primary SD for bootcode.bin
   * Success - Boot
   * Fail - timeout (5 seconds)
@@ -34,7 +34,7 @@ Next the boot ROM checks each of the boot sources for a file called bootcode.bin
 NOTES: 
 
 * If there is no SD card inserted the SD boot mode takes five seconds to fail. To reduce this and fall back to USB more quickly, you can either insert an SD card with nothing on it or use the `program_gpio_bootmode` OTP to only enable USB.
-* The default pull for the GPIOs is defined on page 102 of the [ARM Peripherals datasheet](https://www.raspberrypi.org/documentation/hardware/raspberrypi/bcm2835/BCM2835-ARM-Peripherals.pdf) if the value at boot time does not equal the default pull then that boot mode is enabled.
+* The default pull for the GPIOs is defined on page 102 of the [ARM Peripherals datasheet](https://www.raspberrypi.org/documentation/hardware/raspberrypi/bcm2835/BCM2835-ARM-Peripherals.pdf) if the value at boot time does not equal the default pull then that boot mode is disabled.
 * USB enumeration is a mechanism of enabling the power to the downstream devices on a hub then waiting for the devices to pull the D+ and D- lines to indicate it is either USB 1 or USB 2. This can take time and on some devices it can take up to 3 seconds for a hard disk drive to spin up and start the enumeration process. Because this is the only way of detecting the hardware is attached we have to sit waiting for a minimum amount of time (2 seconds) if the device fails to respond after this maximum timeout it is possible to increase the timeout to 5 seconds using `program_usb_timeout=1` in config.txt
 * MSD takes precedence over ethernet boot
 * It is no longer necessary for the first partition to be the FAT partition, the MSD boot will continue to search for a FAT partition beyond the first one.


### PR DESCRIPTION
OTP fuses must be blown to enable new boot modes . GPIO pull-ups can then be used to disable these modes.
