### PR TITLE
raspiyuv: padding 16 -> padding 32; see issue raspberrypi/userland#329

### DIFF
--- a/raspbian/applications/camera.md
+++ b/raspbian/applications/camera.md
@@ -477,7 +477,7 @@ Extra Options :
 ```
 This option forces the image to be saved as RGB data with 8 bits per channel, rather than YUV420.
 
-Note that the image buffers saved in `raspistillyuv` are padded to a horizontal size divisible by 16 (so there may be unused bytes at the end of each line to make the width divisible by 16). Buffers are also padded vertically to be divisible by 16, and in the YUV mode, each plane of Y,U,V is padded in this way.
+Note that the image buffers saved in `raspistillyuv` are padded to a horizontal size divisible by 32 (so there may be unused bytes at the end of each line to make the width divisible by 32). Buffers are also padded vertically to be divisible by 16, and in the YUV mode, each plane of Y,U,V is padded in this way.
 
 
 ### raspivid


### PR DESCRIPTION
According to the current docs `raspistillyuv` is padding images to be divisible by 16. However, it actually pads the image to be a multiple of 32.

Details can be found in the discussion at raspberrypi/userland#329.