### PR TITLE
Move note about dcfldd up

### DIFF
--- a/installation/installing-images/linux.md
+++ b/installation/installing-images/linux.md
@@ -14,7 +14,7 @@ Please note that the use of the `dd` tool can overwrite any partition of your ma
 
 - If your SD card shows up more than once in the output of `df` due to having multiple partitions on the SD card, you should unmount all of these partitions.
 
-- In the terminal, write the image to the card with the command below, making sure you replace the input file `if=` argument with the path to your `.img` file, and the `/dev/sdd` in the output file `of=` argument with the right device name. This is very important, as you will lose all data on the hard drive if you provide the wrong device name. Make sure the device name is the name of the whole SD card as described above, not just a partition of it; for example, `sdd`, not `sdds1` or `sddp1`, and `mmcblk0`, not `mmcblk0p1`.
+- In the terminal, write the image to the card with the command below, making sure you replace the input file `if=` argument with the path to your `.img` file, and the `/dev/sdd` in the output file `of=` argument with the right device name. This is very important, as you will lose all data on the hard drive if you provide the wrong device name. Make sure the device name is the name of the whole SD card as described above, not just a partition of it; for example, `sdd`, not `sdds1` or `sddp1`, and `mmcblk0`, not `mmcblk0p1`. Instead of `dd` you can use `dcfldd`; it will give a progress report about how much has been written.
 
     ```bash
     dd bs=4M if=2016-05-27-raspbian-jessie.img of=/dev/sdd
@@ -25,8 +25,6 @@ Please note that the use of the `dd` tool can overwrite any partition of your ma
 - Also note that if you are not logged in as root you will need to prefix this with `sudo`.
 
 - The `dd` command does not give any information of its progress and so may appear to have frozen; it could take more than five minutes to finish writing to the card. If your card reader has an LED it may blink during the write process. To see the progress of the copy operation you can run `pkill -USR1 -n -x dd` in another terminal, prefixed with `sudo` if you are not logged in as root. The progress will be displayed in the original window and not the window with the `pkill` command; it may not display immediately, due to buffering.
-
-- Instead of `dd` you can use `dcfldd`; it will give a progress report about how much has been written.
 
 - You can check what's written to the SD card by `dd`-ing from the card back to another image on your hard disk, truncating the new image to the same size as the original, and then running `diff` (or `md5sum`) on those two images.
 


### PR DESCRIPTION
Put `dcfldd` before the actual command, as most users will probably first run the `dd` command and then continue reading, so they find out about `dcfldd` too late. (Or at least I did)
