### PR TITLE
Display/port wrong on ElCap & Sierra

### DIFF
--- a/remote-access/vnc/mac.md
+++ b/remote-access/vnc/mac.md
@@ -1,6 +1,6 @@
 ## Connecting to a Pi over VNC using Mac OS
 
-For Mac OS you will not need any extra software. Just select ``Go -> Connect to server ...`` (&#8984; K) from the Finder menu, enter ``vnc://raspberrypi.local:1`` as the Server Address and click ``Connect``. Here ``:1`` must correspond to the display on which you started the VNC server on your Pi. If there is a problem, try replacing ``raspberrypi.local`` with the IP address of your Pi.
+For Mac OS you will not need any extra software. Just select ``Go -> Connect to server ...`` (&#8984; K) from the Finder menu, enter ``vnc://raspberrypi.local:5901`` as the Server Address and click ``Connect``. Here, the ``1`` in the port number ``:59xx`` must correspond to the display on which you started the VNC server on your Pi. If there is a problem, try replacing ``raspberrypi.local`` with the IP address of your Pi.
 
 Alternatively, you can use a program called RealVNC which is known to work with the Raspberry Pi VNC server; it can be downloaded from [realvnc.com](http://www.realvnc.com/download/vnc/latest).
 


### PR DESCRIPTION
When I use the macOS built-in VNC viewer, I have to specify the -full- port, not just the display number. So, 59xx where xx = the display number.