### PR TITLE
insert explicit line continuation characters

### DIFF
--- a/linux/kernel/building.md
+++ b/linux/kernel/building.md
@@ -88,7 +88,8 @@ For Pi 1 or Compute Module:
 ```bash
 cd linux
 KERNEL=kernel
-make ARCH=arm CROSS_COMPILE=arm-linux-gnueabihf- bcmrpi_defconfig
+make ARCH=arm CROSS_COMPILE=arm-linux-gnueabihf- \
+bcmrpi_defconfig
 ```
 
 For Pi 2/3:
@@ -96,13 +97,15 @@ For Pi 2/3:
 ```bash
 cd linux
 KERNEL=kernel7
-make ARCH=arm CROSS_COMPILE=arm-linux-gnueabihf- bcm2709_defconfig
+make ARCH=arm CROSS_COMPILE=arm-linux-gnueabihf- \
+bcm2709_defconfig
 ```
 
 Then for both:
 
 ```bash
-make ARCH=arm CROSS_COMPILE=arm-linux-gnueabihf- zImage modules dtbs
+make ARCH=arm CROSS_COMPILE=arm-linux-gnueabihf- \
+zImage modules dtbs
 ```
 
 Note: To speed up compilation on multiprocessor systems, and get some improvement on single processor ones, use ```-j n``` where n is number of processors * 1.5. Alternatively, feel free to experiment and see what works!
@@ -146,7 +149,8 @@ sudo mount /dev/sdb2 mnt/ext4
 Next, install the modules:
 
 ```bash
-sudo make ARCH=arm CROSS_COMPILE=arm-linux-gnueabihf- INSTALL_MOD_PATH=mnt/ext4 modules_install
+sudo make ARCH=arm CROSS_COMPILE=arm-linux-gnueabihf- \
+INSTALL_MOD_PATH=mnt/ext4 modules_install
 ```
 
 Finally, copy the kernel and Device Tree blobs onto the SD card, making sure to back up your old kernel:


### PR DESCRIPTION
Some shell command lines are wrapped automatically and then look like two lines. This causes the build process to be carried out entirely different than intended and ultimately to fail with no clear cause. I've built kernels since the mid 90s, but this tripped me for a few rather frustrating minutes. Occurs at least on OS X using Chrome or Safari in the default zoom level, most likely also on other platforms and browsers.

Inserting `\` line continuation characters makes it clear to anyone even remotely familiar with the shell that these lines belong together - moreover, the process no longer fails for anyone simply copy & pasting from web page to terminal.
