### PR TITLE
OS X Screen Sharing problem due to screen number

### DIFF
--- a/remote-access/vnc/mac.md
+++ b/remote-access/vnc/mac.md
@@ -1,6 +1,6 @@
 ## Connecting to a Pi over VNC using Mac OS
 
-For Mac OS you will not need any extra software. Just select ``Go -> Connect to server ...`` (&#8984; K) from the Finder menu, enter ``vnc://raspberrypi.local:1`` as the Server Address and click ``Connect``. Here ``:1`` must correspond to the display on which you started the VNC server on your Pi. If there is a problem, try replacing ``raspberrypi.local`` with the IP address of your Pi.
+For Mac OS you will not need any extra software. Just select ``Go -> Connect to server ...`` (&#8984; K) from the Finder menu, enter ``vnc://raspberrypi.local:1`` as the Server Address and click ``Connect``. Here ``:1`` must correspond to the display on which you started the VNC server on your Pi. If that fails, try replacing ``:1`` with ``:5901``, or ``:0`` with ``:5900``, ``:2`` with ``:5902``, etc. If there is still a problem, try replacing ``raspberrypi.local`` with the IP address of your Pi.
 
 Alternatively, you can use a program called RealVNC which is known to work with the Raspberry Pi VNC server; it can be downloaded from [realvnc.com](http://www.realvnc.com/download/vnc/latest).
 


### PR DESCRIPTION
After encountering an issue while following this documentation, I found the problem and the solution. I've added to the documentation accordingly.

The OS X built in VNC client (Screen Sharing) doesn't appear to like screen numbers (:0, :1, :2), and only understands explicit port numbers (:5900, :5901, :5902). Tested on OS X 10.9.5.