### PR TITLE
Update SPI Readme

### DIFF
--- a/hardware/raspberrypi/spi/README.md
+++ b/hardware/raspberrypi/spi/README.md
@@ -13,12 +13,7 @@
 
 The Raspberry Pi is equipped with one [SPI](https://en.wikipedia.org/wiki/Serial_Peripheral_Interface_Bus) bus that has 2 chip selects.
 
-The SPI master driver is disabled by default on Raspian. To enable it, remove the blacklisting for `spi-bcm2708` in `/etc/modprobe.d/raspi-blacklist.conf`, or use [raspi-config](../../../configuration/raspi-config.md).
-Reboot or load the driver manually with:
-
-```bash
-$ sudo modprobe spi-bcm2708
-```
+The SPI master driver is disabled by default on Raspbian. To enable it, use [raspi-config](../../../configuration/raspi-config.md), or ensure the line `dtparam=spi=on` isn't commented out in `/boot/config.txt`, and reboot. If the SPI driver was loaded, you should see the device `/dev/spidev0.0`.
 
 The SPI bus is available on the P1 Header:
 


### PR DESCRIPTION
The modprobe method no longer works with Raspbian, the new method is to use device tree overlays (simply though the boot config).