### PR TITLE
add a note to the expand-filesystem option

### DIFF
--- a/configuration/raspi-config.md
+++ b/configuration/raspi-config.md
@@ -55,7 +55,7 @@ Generally speaking, `raspi-config` aims to provide the functionality to make the
 <a name="expand-filesystem"></a>
 ### Expand filesystem
 
-If you have installed Raspbian using NOOBS, the filesystem will have been expanded automatically. If for some reason you have not done this, you should use this option to expand your installation to fill the whole SD card, giving you more space to use for files. You will need to reboot the Raspberry Pi to make this available. Note that there is no confirmation: selecting the option begins the partition expansion immediately.
+If you have installed Raspbian using NOOBS, the filesystem will have been expanded automatically. There may be a rare occasion where this is not the case, e.g. if you have copied a smaller SD card onto a larger one. In this case, you should use this option to expand your installation to fill the whole SD card, giving you more space to use for files. You will need to reboot the Raspberry Pi to make this available. Note that there is no confirmation: selecting the option begins the partition expansion immediately.
 
 <a name="change-user-password"></a>
 ### Change user password

--- a/configuration/raspi-config.md
+++ b/configuration/raspi-config.md
@@ -55,7 +55,9 @@ Generally speaking, `raspi-config` aims to provide the functionality to make the
 <a name="expand-filesystem"></a>
 ### Expand filesystem
 
-If you installed Raspbian using NOOBS, you can ignore this section as the file system was expanded automatically during installation. However, if you wrote the image to an SD card yourself, then a portion of the card will be unused; this can be any amount over 3GB. Choosing this option will expand your installation to fill the rest of the SD card, giving you more space to use for files. You will need to reboot the Raspberry Pi to make this available. Note there is no confirmation; selecting the option begins the partition expansion immediately.
+(This section is here for historical reason, you can ignore it as the file system is now automatically expanded during Raspbian installation.)
+
+Choosing this option will expand your installation to fill the whole SD card, giving you more space to use for files. You will need to reboot the Raspberry Pi to make this available. Note there is no confirmation; selecting the option begins the partition expansion immediately.
 
 <a name="change-user-password"></a>
 ### Change user password

--- a/configuration/raspi-config.md
+++ b/configuration/raspi-config.md
@@ -55,9 +55,7 @@ Generally speaking, `raspi-config` aims to provide the functionality to make the
 <a name="expand-filesystem"></a>
 ### Expand filesystem
 
-(This section is here for historical reason, you can ignore it as the file system is now automatically expanded during Raspbian installation.)
-
-Choosing this option will expand your installation to fill the whole SD card, giving you more space to use for files. You will need to reboot the Raspberry Pi to make this available. Note there is no confirmation; selecting the option begins the partition expansion immediately.
+If you have installed Raspbian using NOOBS, the filesystem will have been expanded automatically. If for some reason you have not done this, you should use this option to expand your installation to fill the whole SD card, giving you more space to use for files. You will need to reboot the Raspberry Pi to make this available. Note that there is no confirmation: selecting the option begins the partition expansion immediately.
 
 <a name="change-user-password"></a>
 ### Change user password


### PR DESCRIPTION
Currently, Raspbian passes a custom init script to the kernel during first boot (`/usr/lib/raspi-config/init_resize.sh`) which already expands the root partition. I assume this config command is not much relevant anymore.