### PR TITLE
Fix misspelling of 'sudo'

### DIFF
--- a/hardware/sense-hat/README.md
+++ b/hardware/sense-hat/README.md
@@ -65,7 +65,7 @@ Taken from this [forum post](https://www.raspberrypi.org/forums/viewtopic.php?f=
 Install the necessary software and run the calibration program as follows:
 
 ````
-sudp apt-get update
+sudo apt-get update
 sudo apt-get install octave -y
 cd
 cp /usr/share/librtimulib-utils/RTEllipsoidFit ./ -a


### PR DESCRIPTION
Was 'sudp' (a 'p' instead of an 'o')