### PR TITLE
provides a command to get dd to print progress

### DIFF
--- a/installation/installing-images/linux.md
+++ b/installation/installing-images/linux.md
@@ -26,6 +26,12 @@ Please note that the use of the `dd` tool can overwrite any partition of your ma
 
 - The `dd` command does not give any information of its progress and so may appear to have frozen; it could take more than five minutes to finish writing to the card. If your card reader has an LED it may blink during the write process. To see the progress of the copy operation you can run `pkill -USR1 -n -x dd` in another terminal, prefixed with `sudo` if you are not logged in as root. The progress will be displayed in the original window and not the window with the `pkill` command; it may not display immediately, due to buffering.
 
+- If you want dd to show progress use this command instead.
+
+    ```bash
+    dd status=progress bs=4M if=2016-11-25-raspbian-jessie.img of=/dev/sdd
+    ```
+
 - Instead of `dd` you can use `dcfldd`; it will give a progress report about how much has been written.
 
 - You can check what's written to the SD card by `dd`-ing from the card back to another image on your hard disk, truncating the new image to the same size as the original, and then running `diff` (or `md5sum`) on those two images.


### PR DESCRIPTION
from the man page for dd:

       status=LEVEL
              The  LEVEL  of  information  to print to stderr; 'none' suppresses everything but error messages,
              'noxfer' suppresses the final transfer statistics, 'progress' shows periodic transfer statistics