### PR TITLE
Fixes #490 by adding small introduction to using wpa_passphrase with wpa_supplicant configuration

### DIFF
--- a/configuration/wireless/wireless-cli.md
+++ b/configuration/wireless/wireless-cli.md
@@ -11,7 +11,7 @@ To scan for WiFi networks, use the command `sudo iwlist wlan0 scan`. This will l
 
 1. `IE: IEEE 802.11i/WPA2 Version 1` is the authentication used; in this case it's WPA2, the newer and more secure wireless standard which replaces WPA. This guide should work for WPA or WPA2, but may not work for WPA2 enterprise; for WEP hex keys, see the last example [here](http://www.freebsd.org/cgi/man.cgi?query=wpa_supplicant.conf&sektion=5&apropos=0&manpath=NetBSD+6.1.5). You'll also need the password for the wireless network. For most home routers, this is found on a sticker on the back of the router. The ESSID (ssid) for the network in this case is `testing` and the password (psk) is `testingPassword`.
 
-1. If `security` is a concern entering a password as plain text is not recommended. You can use the `wpa_passphrase` to create a unique token and enter it instead. As arguments the command requires the ESSID and the password. With the example from above calling the command will be `wpa_passphrase "testing" "testingPassword` which will output a ready-to-use wpa-compliant network profile:
+1. If `security` is a concern, entering a password as plain text is not recommended. You can use `wpa_passphrase` to create a unique token and enter it instead. As arguments, the command requires the ESSID and the password. With the example from above, calling the command will be `wpa_passphrase "testing" "testingPassword` which will output a ready-to-use wpa-compliant network profile:
 
   ```
   network={
@@ -21,7 +21,7 @@ To scan for WiFi networks, use the command `sudo iwlist wlan0 scan`. This will l
   }
   ```
   
-  As you can see the password `testingPassword` is still visible as a comment namely `#psk="testingPassword"`. When pasting the produced profile in your configuration file make sure to remove this line (otherwise the whole procedure of generating the secret token would be pointless). The tool requires a password with at least 8 and up to 63 characters. You can also extract the content of a text file and use it as input of `wpa_passphrase` if the password is stored as plain text inside a file somewhere by calling `wpa_passphrase "testing" << file_where_password_is_stored`.
+  As you can see, the password `testingPassword` is still visible as a comment, namely `#psk="testingPassword"`. When pasting the produced profile in your configuration file, make sure to remove this line (otherwise the whole procedure of generating the secret token would be pointless). The tool requires a password with at between eight and 63 characters. You can also extract the content of a text file and use it as input of `wpa_passphrase` if the password is stored as plain text inside a file somewhere by calling `wpa_passphrase "testing" << file_where_password_is_stored`.
   
   
 ## Adding the network details to the Raspberry Pi

--- a/configuration/wireless/wireless-cli.md
+++ b/configuration/wireless/wireless-cli.md
@@ -7,10 +7,23 @@ This method is suitable if you don't have access to the graphical user interface
 
 To scan for WiFi networks, use the command `sudo iwlist wlan0 scan`. This will list all available WiFi networks, along with other useful information. Look out for:
 
-1. `ESSID:"testing"`. This is the name of the WiFi network.   
+1. `ESSID:"testing"` is the name of the WiFi network.   
 
-1. `IE: IEEE 802.11i/WPA2 Version 1`. This is the authentication used; in this case it's WPA2, the newer and more secure wireless standard which replaces WPA. This guide should work for WPA or WPA2, but may not work for WPA2 enterprise; for WEP hex keys, see the last example [here](http://www.freebsd.org/cgi/man.cgi?query=wpa_supplicant.conf&sektion=5&apropos=0&manpath=NetBSD+6.1.5). You'll also need the password for the WiFi network. For most home routers this is located on a sticker on the back of the router. The ESSID (ssid) for the network in this case is `testing` and the password (psk) is `testingPassword`.
+2. `IE: IEEE 802.11i/WPA2 Version 1` is the authentication used; in this case it's WPA2, the newer and more secure wireless standard which replaces WPA. This guide should work for WPA or WPA2, but may not work for WPA2 enterprise; for WEP hex keys, see the last example [here](http://www.freebsd.org/cgi/man.cgi?query=wpa_supplicant.conf&sektion=5&apropos=0&manpath=NetBSD+6.1.5). You'll also need the password for the WiFi network. For most home routers this is located on a sticker on the back of the router. The ESSID (ssid) for the network in this case is `testing` and the password (psk) is `testingPassword`.
 
+3. If `security` is a concern entering a password as plain text is not recommended. You can use the `wpa_passphrase` to create a unique token and enter it instead. As arguments the command requires the ESSID and the password. With the example from above calling the command will be `wpa_passphrase "testing" "testingPassword` which will output a ready-to-use wpa-compliant network profile:
+
+  ```
+  network={
+	  ssid="testing"
+	  #psk="testingPassword"
+	  psk=131e1e221f6e06e3911a2d11ff2fac9182665c004de85300f9cac208a6a80531
+  }
+  ```
+  
+  As you can see the password `testingPassword` is still visible as a comment namely `#psk="testingPassword"`. When pasting the produced profile in your configuration file make sure to remove this line (otherwise the whole procedure of generating the secret token would be pointless). The tool requires a password with at least 8 and up to 63 characters. You can also extract the content of a text file and use it as input of `wpa_passphrase` if the password is stored as plain text inside a file somewhere by calling `wpa_passphrase "testing" << file_where_password_is_stored`.
+  
+  
 ## Adding the network details to the Raspberry Pi
    
 Open the `wpa-supplicant` configuration file in nano:
@@ -34,6 +47,8 @@ network={
     psk="testingPassword"
 }
 ```
+
+If you are using `wpa_passphrase` you can redirect its output to your configuration file by calling `wpa_passphrase "testing" >> /etc/wpa_supplicant/wpa_supplicant.conf`. Note that this requires you to change to `root` (by executing `sudo su`) or find another way to redirect the output since the file we write to can be altered only by a user with administrative privileges. Last but not least make sure you use `>>` (which is used to append text to an existing file) since `>` will erase all contents and **then** append the output to the specified file.
    
 Now save the file by pressing **Ctrl+X** then **Y**, then finally press **Enter**.  
 

--- a/configuration/wireless/wireless-cli.md
+++ b/configuration/wireless/wireless-cli.md
@@ -9,9 +9,9 @@ To scan for WiFi networks, use the command `sudo iwlist wlan0 scan`. This will l
 
 1. `ESSID:"testing"` is the name of the WiFi network.   
 
-2. `IE: IEEE 802.11i/WPA2 Version 1` is the authentication used; in this case it's WPA2, the newer and more secure wireless standard which replaces WPA. This guide should work for WPA or WPA2, but may not work for WPA2 enterprise; for WEP hex keys, see the last example [here](http://www.freebsd.org/cgi/man.cgi?query=wpa_supplicant.conf&sektion=5&apropos=0&manpath=NetBSD+6.1.5). You'll also need the password for the WiFi network. For most home routers this is located on a sticker on the back of the router. The ESSID (ssid) for the network in this case is `testing` and the password (psk) is `testingPassword`.
+1. `IE: IEEE 802.11i/WPA2 Version 1` is the authentication used; in this case it's WPA2, the newer and more secure wireless standard which replaces WPA. This guide should work for WPA or WPA2, but may not work for WPA2 enterprise; for WEP hex keys, see the last example [here](http://www.freebsd.org/cgi/man.cgi?query=wpa_supplicant.conf&sektion=5&apropos=0&manpath=NetBSD+6.1.5). You'll also need the password for the wireless network. For most home routers, this is found on a sticker on the back of the router. The ESSID (ssid) for the network in this case is `testing` and the password (psk) is `testingPassword`.
 
-3. If `security` is a concern entering a password as plain text is not recommended. You can use the `wpa_passphrase` to create a unique token and enter it instead. As arguments the command requires the ESSID and the password. With the example from above calling the command will be `wpa_passphrase "testing" "testingPassword` which will output a ready-to-use wpa-compliant network profile:
+1. If `security` is a concern entering a password as plain text is not recommended. You can use the `wpa_passphrase` to create a unique token and enter it instead. As arguments the command requires the ESSID and the password. With the example from above calling the command will be `wpa_passphrase "testing" "testingPassword` which will output a ready-to-use wpa-compliant network profile:
 
   ```
   network={

--- a/configuration/wireless/wireless-cli.md
+++ b/configuration/wireless/wireless-cli.md
@@ -48,7 +48,7 @@ network={
 }
 ```
 
-If you are using `wpa_passphrase` you can redirect its output to your configuration file by calling `wpa_passphrase "testing" >> /etc/wpa_supplicant/wpa_supplicant.conf`. Note that this requires you to change to `root` (by executing `sudo su`) or find another way to redirect the output since the file we write to can be altered only by a user with administrative privileges. Last but not least make sure you use `>>` (which is used to append text to an existing file) since `>` will erase all contents and **then** append the output to the specified file.
+If you are using `wpa_passphrase` you can redirect its output to your configuration file by calling `wpa_passphrase "testing" "testingPassword" >> /etc/wpa_supplicant/wpa_supplicant.conf`. Note that this requires you to change to `root` (by executing `sudo su`) or find another way to redirect the output since the file we write to can be altered only by a user with administrative privileges. Last but not least make sure you use `>>` (which is used to append text to an existing file) since `>` will erase all contents and **then** append the output to the specified file.
    
 Now save the file by pressing **Ctrl+X** then **Y**, then finally press **Enter**.  
 


### PR DESCRIPTION
Most tutorials (including the official documentation for the Raspbian) use the very simple way of entering a password in a `wpa_supplicant` profile as **plain text**. Depending on the scenario (for example a server) the user might not want to do that. Using `wpa_passphrase` ensures that we use a secret token instead of plain text password in our configuration file. This fixes the issue #490 .