### PR TITLE
Updated documentation for enabling ssh

### DIFF
--- a/remote-access/ssh/README.md
+++ b/remote-access/ssh/README.md
@@ -20,6 +20,11 @@ Otherwise, plug your Raspberry Pi directly into the router.
 ##3. Enable SSH
 As of the November 2016 release, Raspbian has the SSH server disabled by default. You will have to enable it manually. This is done using [raspi-config](../../configuration/raspi-config.md):
 
-Enter `sudo raspi-config` in the terminal, first select `Interfacing options`, then navigate to `ssh`, press `Enter` and select `Enable or disable ssh server`.
+1. Enter `sudo raspi-config` in the terminal
+2. Select `Advanced options`
+3. Navigate to and select `SSH`
+4. Choose `Yes` 
+5. Select `Ok`
+6. Choose `Finish`
 
 For headless setup, SSH can be enabled by placing a file named 'ssh', without any extension, onto the boot partition of the SD card. When the Pi boots, it looks for the 'ssh' file; if it is found, SSH is enabled and then the file is deleted. The content of the file doesn't matter: it could contain any text or nothing at all.

--- a/remote-access/ssh/README.md
+++ b/remote-access/ssh/README.md
@@ -3,6 +3,7 @@
 You can access the command line of a Raspberry Pi remotely from another computer or device on the same network using SSH.
 
 ##1. Set up your client
+
 SSH is built into Linux distributions and Mac OS. For Windows and mobile devices, third-party SSH clients are available. See the following guides for using SSH depending on the OS used by the computer or device you are connecting from:
 
 - [Linux & Mac OS](unix.md)
@@ -13,6 +14,7 @@ SSH is built into Linux distributions and Mac OS. For Windows and mobile devices
 Note that you only have access to the command line, not the full desktop environment. For the full remote desktop, see [VNC](../vnc/README.md).
 
 ##2. Set up your local network and WiFi
+
 Make sure your Raspberry Pi is properly set up and connected. If you're using [WiFi](../../configuration/wireless/wireless-cli.md), this is done using the `wpa_supplicant.conf` config file. 
 
 Otherwise, plug your Raspberry Pi directly into the router.
@@ -20,11 +22,11 @@ Otherwise, plug your Raspberry Pi directly into the router.
 ##3. Enable SSH
 As of the November 2016 release, Raspbian has the SSH server disabled by default. You will have to enable it manually. This is done using [raspi-config](../../configuration/raspi-config.md):
 
-1. Enter `sudo raspi-config` in the terminal
-2. Select `Advanced options`
-3. Navigate to and select `SSH`
-4. Choose `Yes` 
-5. Select `Ok`
-6. Choose `Finish`
+1. Enter `sudo raspi-config` in a terminal window
+1. Select `Advanced options`
+1. Navigate to and select `SSH`
+1. Choose `Yes` 
+1. Select `Ok`
+1. Choose `Finish`
 
-For headless setup, SSH can be enabled by placing a file named 'ssh', without any extension, onto the boot partition of the SD card. When the Pi boots, it looks for the 'ssh' file; if it is found, SSH is enabled and then the file is deleted. The content of the file doesn't matter: it could contain any text or nothing at all.
+For headless setup, SSH can be enabled by placing a file named 'ssh', without any extension, onto the boot partition of the SD card. When the Pi boots, it looks for the 'ssh' file; if it is found, SSH is enabled and then the file is deleted. The content of the file doesn't matter: it could contain either text or nothing at all.

--- a/remote-access/ssh/README.md
+++ b/remote-access/ssh/README.md
@@ -22,4 +22,4 @@ As of the November 2016 release, Raspbian has the SSH server disabled by default
 
 Enter `sudo raspi-config` in the terminal, first select `Interfacing options`, then navigate to `ssh`, press `Enter` and select `Enable or disable ssh server`.
 
-For headless setup, SSH can be enabled by placing a file named 'ssh', without any extension, onto the boot partition of the SD card.
+For headless setup, SSH can be enabled by placing a file named 'ssh', without any extension, onto the boot partition of the SD card. When the Pi boots, it looks for the 'ssh' file; if it is found, SSH is enabled and then the file is deleted. The content of the file doesn't matter: it could contain any text or nothing at all.


### PR DESCRIPTION
1. The interface described in the docs for `raspi-config` was different than what appears in the latest version of Raspian. I've updated the instructions to reflect that change. Like from here http://www.raspberrypi-spy.co.uk/2012/05/enable-secure-shell-ssh-on-your-raspberry-pi/

2. Moore context for the extension-less 'ssh' file you could place on the boot partition to enable ssh. I was having some network issues with my router and was confused why the 'ssh' file would disappear all the time. I found the answer via https://www.raspberrypi.org/blog/a-security-update-for-raspbian-pixel/