### PR TITLE
net_tutorial: specify nfsvers=3 in kernel cmdline

### DIFF
--- a/hardware/raspberrypi/bootmodes/net_tutorial.md
+++ b/hardware/raspberrypi/bootmodes/net_tutorial.md
@@ -204,7 +204,7 @@ sudo systemctl restart nfs-kernel-server
 Edit /tftpboot/cmdline.txt and from `root=` onwards, replace it with:
 
 ```
-root=/dev/nfs nfsroot=10.42.0.2:/nfs/client1 rw ip=dhcp rootwait elevator=deadline
+root=/dev/nfs nfsroot=10.42.0.2:/nfs/client1,nfsvers=3 rw ip=dhcp rootwait elevator=deadline
 ```
 
 You should substitute the IP address here with the IP address you have noted down.


### PR DESCRIPTION
Without nfsvers=3, NFS mounting wouldn’t work for me. On the server (Debian stretch), I’d see:

```
Jan 29 21:46:23 server kernel: svc: 10.0.0.222, port=883: unknown version (2 for prog 100003, nfsd)
```