### PR TITLE
Updated progress options for mounting raspbian using dd

### DIFF
--- a/installation/installing-images/linux.md
+++ b/installation/installing-images/linux.md
@@ -17,16 +17,14 @@ Please note that the use of the `dd` tool can overwrite any partition of your ma
 - In the terminal, write the image to the card with the command below, making sure you replace the input file `if=` argument with the path to your `.img` file, and the `/dev/sdd` in the output file `of=` argument with the right device name. This is very important, as you will lose all data on the hard drive if you provide the wrong device name. Make sure the device name is the name of the whole SD card as described above, not just a partition of it; for example, `sdd`, not `sdds1` or `sddp1`, and `mmcblk0`, not `mmcblk0p1`.
 
     ```bash
-    dd bs=4M if=2017-01-11-raspbian-jessie.img of=/dev/sdd
+    dd bs=4M if=2017-01-11-raspbian-jessie.img of=/dev/sdd status=progress
     ```
 
 - Please note that block size set to `4M` will work most of the time; if not, please try `1M`, although this will take considerably longer.
 
 - Also note that if you are not logged in as root you will need to prefix this with `sudo`.
 
-- The `dd` command does not give any information of its progress and so may appear to have frozen; it could take more than five minutes to finish writing to the card. If your card reader has an LED it may blink during the write process. To see the progress of the copy operation you can run `pkill -USR1 -n -x dd` in another terminal, prefixed with `sudo` if you are not logged in as root. The progress will be displayed in the original window and not the window with the `pkill` command; it may not display immediately, due to buffering.
-
-- Instead of `dd` you can use `dcfldd`; it will give a progress report about how much has been written.
+- `status=progress` allows us to receive visual feedback containing how many bytes have been copied. The entire operation may take around 5 minutes to complete.
 
 - You can check what's written to the SD card by `dd`-ing from the card back to another image on your hard disk, truncating the new image to the same size as the original, and then running `diff` (or `md5sum`) on those two images.
 


### PR DESCRIPTION
There's a bulky paragraph explaining how to get visual feedback when running the `dd` operation. We can actually just append `status=progress` as a simple solution to be able to monitor the progress and make sure things aren't frozen.