### PR TITLE
Tiny update to Mac OS image writing instructions

### DIFF
--- a/installation/installing-images/mac.md
+++ b/installation/installing-images/mac.md
@@ -1,6 +1,6 @@
 # Installing operating system images on Mac OS
 
-On Mac OS you can either use the command line `dd` tool or the graphical tool ImageWriter to write the image to your SD card.
+On Mac OS you can either use the command line `dd` tool or the graphical tool Etcher to write the image to your SD card.
 
 ## Installing operating system images using Etcher
 


### PR DESCRIPTION
OSX instructions now lead users to Etcher, and should mention this upfront.