### PR TITLE
Include Etcher instructions as default for image writing

### DIFF
--- a/installation/installing-images/README.md
+++ b/installation/installing-images/README.md
@@ -10,7 +10,7 @@ Official images for recommended operating systems are available to download from
 
 Alternative distributions are available from third-party vendors.
 
-After downloading the `.zip` file, unzip it to get the image file (`.img`) for writing to your SD card.
+If you're not using Etcher (see below), you'll need to unzip `.zip` downloads to get the image file (`.img`) for writing to your SD card.
 
 Note: the Raspbian with PIXEL image contained in the ZIP archive is over 4GB in size and uses the [ZIP64](https://en.wikipedia.org/wiki/Zip_(file_format)#ZIP64) format. To uncompress the archive, a unzip tool that supports ZIP64 is required. The following zip tools support ZIP64:
 
@@ -22,7 +22,15 @@ Note: the Raspbian with PIXEL image contained in the ZIP archive is over 4GB in 
 
 With the image file of the distribution of your choice, you need to use an image writing tool to install it on your SD card.
 
-See our guide for your system:
+**Etcher** is a graphical SD card writing tool that works on Mac OS, Linux and Windows, and is the easiest option for most users. Etcher also supports writing images directly from the zip, without any unzipping required. To write your image with Etcher:
+
+- Download [Etcher](https://etcher.io/) and install it.
+- Connect an SD card reader with the SD card inside.
+- Open Etcher and select the Raspberry Pi `.img` or `.zip` file you wish to write to the SD card from your hard drive.
+- Select the SD card you wish to write your image to.
+- Review your selections and click "Flash!" to begin writing data to the SD card.
+
+For more advanced control of this process, see our system-specific guides:
 
 - [Linux](linux.md)
 - [Mac OS](mac.md)

--- a/installation/installing-images/README.md
+++ b/installation/installing-images/README.md
@@ -10,9 +10,9 @@ Official images for recommended operating systems are available to download from
 
 Alternative distributions are available from third-party vendors.
 
-If you're not using Etcher (see below), you'll need to unzip `.zip` downloads to get the image file (`.img`) for writing to your SD card.
+If you're not using Etcher (see below), you'll need to unzip `.zip` downloads to get the image file (`.img`) to write to your SD card.
 
-Note: the Raspbian with PIXEL image contained in the ZIP archive is over 4GB in size and uses the [ZIP64](https://en.wikipedia.org/wiki/Zip_(file_format)#ZIP64) format. To uncompress the archive, a unzip tool that supports ZIP64 is required. The following zip tools support ZIP64:
+**Note**: the Raspbian with PIXEL image contained in the ZIP archive is over 4GB in size and uses the [ZIP64](https://en.wikipedia.org/wiki/Zip_(file_format)#ZIP64) format. To uncompress the archive, a unzip tool that supports ZIP64 is required. The following zip tools support ZIP64:
 
 - [7-Zip](http://www.7-zip.org/) (Windows)
 - [The Unarchiver](http://unarchiver.c3.cx/unarchiver) (Mac)
@@ -20,15 +20,15 @@ Note: the Raspbian with PIXEL image contained in the ZIP archive is over 4GB in 
 
 ## Writing an image to the SD card
 
-With the image file of the distribution of your choice, you need to use an image writing tool to install it on your SD card.
+You will need to use an image writing tool to install the image you have downloaded on your SD card.
 
-**Etcher** is a graphical SD card writing tool that works on Mac OS, Linux and Windows, and is the easiest option for most users. Etcher also supports writing images directly from the zip, without any unzipping required. To write your image with Etcher:
+**Etcher** is a graphical SD card writing tool that works on Mac OS, Linux and Windows, and is the easiest option for most users. Etcher also supports writing images directly from the zip file, without any unzipping required. To write your image with Etcher:
 
 - Download [Etcher](https://etcher.io/) and install it.
 - Connect an SD card reader with the SD card inside.
-- Open Etcher and select the Raspberry Pi `.img` or `.zip` file you wish to write to the SD card from your hard drive.
+- Open Etcher and select from your hard drive the Raspberry Pi `.img` or `.zip` file you wish to write to the SD card.
 - Select the SD card you wish to write your image to.
-- Review your selections and click "Flash!" to begin writing data to the SD card.
+- Review your selections and click 'Flash!' to begin writing data to the SD card.
 
 For more advanced control of this process, see our system-specific guides:
 

--- a/installation/installing-images/linux.md
+++ b/installation/installing-images/linux.md
@@ -1,33 +1,33 @@
 # Installing operating system images on Linux
 
-[Etcher](README.md) is typically the easiest option for most users to write images to SD cards, and you should start with that if you're not sure. If you want more advanced options on Linux though you can use the standard command line tools below.
+[Etcher](README.md) is typically the easiest option for most users to write images to SD cards, so it is a good place to start. If you're looking for more advanced options on Linux, you can use the standard command line tools below.
 
-Please note that the use of the `dd` tool can overwrite any partition of your machine. If you specify the wrong device in the instructions below, you could delete your primary Linux partition. Please be careful.
+**Note**: use of the `dd` tool can overwrite any partition of your machine. If you specify the wrong device in the instructions below, you could delete your primary Linux partition. Please be careful.
 
 ### Discovering the SD card mountpoint and unmounting it
-- Run `df -h` to see what devices are currently mounted.
+- Run `df -h` to see which devices are currently mounted.
 
 - If your computer has a slot for SD cards, insert the card. If not, insert the card into an SD card reader, then connect the reader to your computer.
 
 - Run `df -h` again. The new device that has appeared is your SD card. If no device appears, then your system is not automounting devices. In this case, you will need to search for the device name using another method. The `dmesg | tail` command will display the most recent system messages, which should contain information on the naming of the SD card device. The naming of the device will follow the format described in the next paragraph. Note that if the SD card was not automounted, you do not need to unmount later.
 
-- The left column of the results from `df -h` command gives the device name of your SD card. It will be listed as something like `/dev/mmcblk0p1` or `/dev/sdX1`, where X is a lower case letter indicating the device.  The last part (`p1` or `1` respectively) is the partition number. You want to write to the whole SD card, not just one partition. You therefore need to remove that part from the name. You should see something like `/dev/mmcblk0` or `/dev/sdX` as the device name for the whole SD card. Note that the SD card can show up more than once in the output of `df`. It will do this if you have previously written a Raspberry Pi image to this SD card, because the Raspberry Pi SD images have more than one partition.
+- The left column of the results from `df -h` command gives the device name of your SD card. It will be listed as something like `/dev/mmcblk0p1` or `/dev/sdX1`, where X is a lower case letter indicating the device.  The last part (`p1` or `1` respectively) is the partition number. You want to write to the whole SD card, not just one partition. You therefore need to remove that section from the name. You should see something like `/dev/mmcblk0` or `/dev/sdX` as the device name for the whole SD card. Note that the SD card can show up more than once in the output of `df`. It will do this if you have previously written a Raspberry Pi image to this SD card, because the Raspberry Pi SD images have more than one partition.
 
 - Now you have noted the device name, you need to unmount it so that files can't be read or written to the SD card while you are copying over the SD image.
 
-- Run `umount /dev/sdX1`, replacing `sdX1` with whatever your SD card's device name is (including the partition number).
+- Run `umount /dev/sdX1`, replacing `sdX1` with whatever your SD card's device name is, including the partition number.
 
-- If your SD card shows up more than once in the output of `df` because it has multiple partitions on the SD card. You should unmount all of these partitions.
+- If your SD card shows up more than once in the output of `df`, this shows that the card has multiple partitions. You should unmount all of these partitions.
 
 ### Copying the image to the SD card
 
-- In a terminal window, write the image to the card with the command below, making sure you replace the input file `if=` argument with the path to your `.img` file, and the `/dev/sdX` in the output file `of=` argument with the correct device name. This is very important, as you will lose all data on the hard drive if you provide the wrong device name. Make sure the device name is the name of the whole SD card as described above, not just a partition of it. For example: `sdd`, not `sdds1` or `sddp1`, and `mmcblk0`, not `mmcblk0p1`.
+- In a terminal window, write the image to the card with the command below, making sure you replace the input file `if=` argument with the path to your `.img` file, and the `/dev/sdX` in the output file `of=` argument with the correct device name. This is very important, as you will lose all the data on the hard drive if you provide the wrong device name. Make sure the device name is the name of the whole SD card as described above, not just a partition. For example: `sdd`, not `sdds1` or `sddp1`, and `mmcblk0`, not `mmcblk0p1`.
 
     ```bash
     dd bs=4M if=2017-02-16-raspbian-jessie.img of=/dev/sdX
     ```
 
-- Please note that block size set to `4M` will work most of the time. If not, please try `1M`, although this will take considerably longer.
+- Please note that block size set to `4M` will work most of the time. If not,  try `1M`, although this will take considerably longer.
 
 - Also note that if you are not logged in as root you will need to prefix this with `sudo`.
 
@@ -42,15 +42,15 @@ unzip -p 2017-02-16-raspbian-jessie.zip | sudo dd of=/dev/sdX bs=4096
 
 ### Checking the image copy progress
 
-- By default, the `dd` command does not give any information about its progress and so may appear to have frozen. It can take more than five minutes to finish writing to the card. If your card reader has an LED, it may blink during the write process. 
+- By default, the `dd` command does not give any information about its progress, so it may appear to have frozen. It can take more than five minutes to finish writing to the card. If your card reader has an LED, it may blink during the write process. 
 
 - To see the progress of the copy operation, you can run the dd command with the status option.
    ```
     dd bs=4M if=2017-03-02-raspbian-jessie.img of=/dev/sdd status=progress
    ```
-- If you are using an older version of `dd`, the status option may not be available. You may be able to use the `dcfldd` command instead, which will give a progress report about how much has been written.
+- If you are using an older version of `dd`, the status option may not be available. You may be able to use the `dcfldd` command instead, which will give a progress report showing how much has been written.
 
-### Checking if the image was correctly written to the SD card
+### Checking whether the image was correctly written to the SD card
 
 - After `dd` has finished copying, you can check what has been written to the SD card by `dd`-ing from the card back to another image on your hard disk; truncating the new image to the same size as the original; and then running `diff` (or `md5sum`) on those two images.
 

--- a/installation/installing-images/linux.md
+++ b/installation/installing-images/linux.md
@@ -1,5 +1,7 @@
 # Installing operating system images on Linux
 
+[Etcher](README.md) is typically the easiest option for most users to write images to SD cards, and you should start with that if you're not sure. If you want more advanced options on Linux though you can use the standard command line tools below.
+
 Please note that the use of the `dd` tool can overwrite any partition of your machine. If you specify the wrong device in the instructions below, you could delete your primary Linux partition. Please be careful.
 
 ### Discovering the SD card mountpoint and unmounting it

--- a/installation/installing-images/mac.md
+++ b/installation/installing-images/mac.md
@@ -1,14 +1,6 @@
 # Installing operating system images on Mac OS
 
-On Mac OS you can use the command line `dd` tool, or the graphical tool Etcher to write the image to your SD card.
-
-## Installing operating system images using Etcher
-
-- Connect the SD card reader with the SD card inside. Note that it must be formatted as FAT32.
-- Download [Etcher](https://etcher.io/) and install it to your Mac's Applications folder.
-- Open `Etcher.app`, select the Raspberry Pi `.img` file you wish to write to the SD card from your Mac's hard drive.
-- After selecting the `.img` file in Step 1, you will now select the SD card you wish to write the `.img` file to.
-- Review your selections and click "Flash!" to begin writing data to the SD card. Once complete, you can eject the mounted SD card from your Mac using `Finder.app`.
+On Mac OS you can use the command line `dd` tool to write the image to your SD card.
 
 ## (Mostly) graphical interface
 

--- a/installation/installing-images/mac.md
+++ b/installation/installing-images/mac.md
@@ -1,6 +1,8 @@
 # Installing operating system images on Mac OS
 
-On Mac OS you can use the command line `dd` tool to write the image to your SD card.
+[Etcher](README.md) is typically the easiest option for most users to write images to SD cards, and you should start with that if you're not sure. If you want more advanced options on Mac OS though you can use the built-in graphical and command-line tools below.
+
+Please note that the use of the `dd` tool can overwrite any partition of your machine. If you specify the wrong device in the instructions below, you could delete your primary Mac OS partition. Please be careful.
 
 ## (Mostly) graphical interface
 

--- a/installation/installing-images/mac.md
+++ b/installation/installing-images/mac.md
@@ -1,15 +1,15 @@
 # Installing operating system images on Mac OS
 
-[Etcher](README.md) is typically the easiest option for most users to write images to SD cards, and you should start with that if you're not sure. If you want more advanced options on Mac OS though you can use the built-in graphical and command-line tools below.
+[Etcher](README.md) is typically the easiest option for most users to write images to SD cards, so it is a good place to start. If you're looking for more advanced options on Mac OS, you can use the built-in graphical and command line tools below.
 
-Please note that the use of the `dd` tool can overwrite any partition of your machine. If you specify the wrong device in the instructions below, you could delete your primary Mac OS partition. Please be careful.
+**Note**: use of the `dd` tool can overwrite any partition of your machine. If you specify the wrong device in the instructions below, you could delete your primary Mac OS partition. Please be careful.
 
 ## (Mostly) graphical interface
 
 - Connect the SD card reader with the SD card inside. Note that it must be formatted as FAT32.
-- From the Apple menu, choose "About This Mac", then click on "More info...". If you are using Mac OS X 10.8.x Mountain Lion or newer, you will then need to click on "System Report".
-- Click on "USB" (or "Card Reader" if using a built-in SD card reader), then search for your SD card in the upper-right section of the window. Click on it, then search for the BSD name in the lower-right section. It will look something like `diskn` where `n` is a number (for example, `disk4`). Make sure you take a note of this number.
-- Unmount the partition so that you will be allowed to overwrite the disk. To do this, open Disk Utility and unmount it. Do not eject it. If you eject it, you will have to reconnect it. Note that on Mac OS X 10.8.x Mountain Lion, "Verify Disk" (before unmounting) will display the BSD name as `/dev/disk1s2` or similar, allowing you to skip the previous two steps. Note down the number that appears after "disk", in this case the number "1".
+- From the Apple menu, choose 'About This Mac', then click on 'More info...'. If you are using Mac OS X 10.8.x Mountain Lion or newer, you will then need to click on 'System Report'.
+- Click on 'USB' (or 'Card Reader' if you are using a built-in SD card reader), then search for your SD card in the upper right section of the window. Click on it, then search for the BSD name in the lower right section. It will look something like `diskn` where `n` is a number (for example, `disk4`). Make sure you take a note of this number.
+- Unmount the partition so that you will be allowed to overwrite the disk. To do this, open Disk Utility and unmount it. Do not eject it. If you eject it, you will have to reconnect it. Note that on Mac OS X 10.8.x Mountain Lion, 'Verify Disk' (before unmounting) will display the BSD name as `/dev/disk1s2` or similar, allowing you to skip the previous two steps. Note down the number that appears after 'disk', in this case the number '1'.
 - From the terminal, run the following command:
 
     ```
@@ -18,7 +18,7 @@ Please note that the use of the `dd` tool can overwrite any partition of your ma
 
     Remember to replace `n` with the number that you noted before!
     
-    This will take a few minutes, depending on the image file size. You can check the progress by sending a SIGINFO signal                  (press **Ctrl+T**).
+    This will take a few minutes, depending on the image file size. You can check the progress by sending a SIGINFO signal                  (press Ctrl+T).
 
 
     - If this command fails, try using `disk` instead of `rdisk`:
@@ -26,7 +26,7 @@ Please note that the use of the `dd` tool can overwrite any partition of your ma
        ```
        sudo dd bs=1m if=path_of_your_image.img of=/dev/diskn
        ```
-This will take a few minutes, depending on the image file size. To check the progress open Activity Monitor, click the Disk tab and find the process with the name `dd`. If `dd` is not in the list, you may need to select All Processes from the View menu. The Bytes Read column will display the amount of data that has been read from the image. Compare that to the file size of the image to determine progress.
+This will take a few minutes, depending on the size of the image file. To check the progress, open Activity Monitor, click the Disk tab and find the process with the name `dd`. If `dd` is not in the list, you may need to select 'All Processes' from the View menu. The Bytes Read column will display the amount of data that has been read from the image. Compare that to the file size of the image to determine progress.
 
 
 ## Command line
@@ -35,7 +35,7 @@ This will take a few minutes, depending on the image file size. To check the pro
 
     `diskutil list`
 
-- Identify the disk (not partition) of your SD card e.g. `disk4`, not `disk4s1`.
+- Identify the disk (not the partition) of your SD card, e.g. `disk4`, not `disk4s1`.
 - Unmount your SD card by using the disk identifier, to prepare it for copying data:
 
     `diskutil unmountDisk /dev/disk<disk# from diskutil>`
@@ -46,14 +46,14 @@ This will take a few minutes, depending on the image file size. To check the pro
 
     `sudo dd bs=1m if=image.img of=/dev/rdisk<disk# from diskutil>`
 
-    where `disk` is your BSD name e.g. `sudo dd bs=1m if=2017-03-02-raspbian-jessie.img of=/dev/rdisk4`
+    where `disk` is your BSD name, e.g. `sudo dd bs=1m if=2017-03-02-raspbian-jessie.img of=/dev/rdisk4`
 
     - This may result in a ``dd: invalid number '1m'`` error if you have GNU
     coreutils installed. In that case, you need to use a block size of `1M` in the `bs=` section, as follows:
 
        `sudo dd bs=1M if=image.img of=/dev/rdisk<disk# from diskutil>`
 
-    This will take a few minutes, depending on the image file size. You can check the progress by sending a `SIGINFO` signal (press `Ctrl+T`).
+    This will take a few minutes, depending on the image file size. You can check the progress by sending a `SIGINFO` signal (press Ctrl+T).
     
     - If this command still fails, try using `disk` instead of `rdisk`, for example:
     
@@ -67,9 +67,9 @@ This will take a few minutes, depending on the image file size. To check the pro
 
 ## Alternative method
 
-**Note: Some users have reported issues with using this method to create SD cards.**
+**Note**: some users have reported issues with using this method to create SD cards.
 
-These commands and actions need to be performed from an account that has administrator privileges.
+These commands and actions must be performed from an account that has administrator privileges.
 
 - From the terminal run `df -h`.
 - Connect the SD card reader with the SD card inside.
@@ -81,7 +81,7 @@ These commands and actions need to be performed from an account that has adminis
     ```
 
     Alternatively, open Disk Utility and unmount the partition of the SD card. Do not eject it. If you eject it, you will have to reconnect it.
-- Using the device name of the partition, work out the *raw device name* for the entire disk by omitting the final `s1` and replacing `disk` with `rdisk`. This is very important, as you will lose all data on the hard drive if you provide the wrong device name. Make sure the device name is the name of the whole SD card as described above, not just a partition of it: for example, `rdisk3`, not `rdisk3s1`. Similarly, you might have another SD drive name/number like `rdisk2` or `rdisk4`. You can check again by using the `df -h` command both before and after you insert your SD card reader into your Mac. For example: `/dev/disk3s1` becomes `/dev/rdisk3`.
+- Using the device name of the partition, work out the **raw device name** for the entire disk by omitting the final `s1` and replacing `disk` with `rdisk`. This is very important, as you will lose all data on the hard drive if you provide the wrong device name. Make sure the device name is the name of the whole SD card as described above, not just a partition of it, for example, `rdisk3`, not `rdisk3s1`. Similarly, you might have another SD drive name/number like `rdisk2` or `rdisk4`. You can check again by using the `df -h` command, both before and after you insert your SD card reader into your Mac. For example: `/dev/disk3s1` becomes `/dev/rdisk3`.
 - In the terminal, write the image to the card with this command, using the raw device name from above. Read the above step carefully to make sure that you use the correct `rdisk` number here:
     
     ```
@@ -98,7 +98,7 @@ These commands and actions need to be performed from an account that has adminis
     
     That command will also set the permissions on the device to allow writing. Now try the `dd` command again.
 
-    Note that `dd` will not provide any on-screen information until there is an error or it is finished. When the process is complete, information will be shown and the disk will re-mount. If you wish to view the progress, you can use `Ctrl-T`. This generates SIGINFO, the status argument of your terminal, and will display information on the process.
+    Note that `dd` will not provide any on-screen information until there is an error, or it is finished. When the process is complete, information will be shown and the disk will re-mount. If you wish to view the progress, you can use Ctrl-T. This generates SIGINFO, the status argument of your terminal, and will display information on the process.
 - After the `dd` command finishes, eject the card:
 
     ```

--- a/installation/installing-images/windows.md
+++ b/installation/installing-images/windows.md
@@ -1,5 +1,9 @@
 # Installing operating system images using Windows
 
+[Etcher](README.md) is typically the easiest option for most users to write images to SD cards, and you should start with that if you're not sure. If you want an alternative on Windows though you can use `Win32DiskImager`:
+
+## Win32DiskImager
+
 - Insert the SD card into your SD card reader. You can use the SD card slot if you have one, or an SD adapter in a USB port. Note the drive letter assigned to the SD card. You can see the drive letter in the left hand column of Windows Explorer, for example **G:**
 - Download the Win32DiskImager utility from the [Sourceforge Project page](http://sourceforge.net/projects/win32diskimager/) as an installer file, and run it to install the software.
 - Run the `Win32DiskImager` utility from your desktop or menu.

--- a/installation/installing-images/windows.md
+++ b/installation/installing-images/windows.md
@@ -1,6 +1,6 @@
 # Installing operating system images using Windows
 
-[Etcher](README.md) is typically the easiest option for most users to write images to SD cards, and you should start with that if you're not sure. If you want an alternative on Windows though you can use `Win32DiskImager`:
+[Etcher](README.md) is typically the easiest option for most users to write images to SD cards, so it is a good place to start. If you're looking for an alternative on Windows, you can use `Win32DiskImager`:
 
 ## Win32DiskImager
 
@@ -8,7 +8,7 @@
 - Download the Win32DiskImager utility from the [Sourceforge Project page](http://sourceforge.net/projects/win32diskimager/) as an installer file, and run it to install the software.
 - Run the `Win32DiskImager` utility from your desktop or menu.
 - Select the image file you extracted earlier.
-- Select the drive letter of the SD card in the device box. Be careful to select the correct drive: if you choose the wrong drive you could destroy the data on your computer's hard disk! If you are using an SD card slot in your computer and can't see the drive in the Win32DiskImager window, try using an external SD adapter.
+- In the device box, select the drive letter of the SD card. Be careful to select the correct drive: if you choose the wrong drive you could destroy the data on your computer's hard disk! If you are using an SD card slot in your computer, and can't see the drive in the Win32DiskImager window, try using an external SD adapter.
 - Click 'Write' and wait for the write to complete.
 - Exit the imager and eject the SD card.
 


### PR DESCRIPTION
This solves #455.

I've gone for including the instructions in the top-level readme, rather than a separate file, to keep the happy path obvious and because they're very short anyway.

I've also dropped a couple of unnecessary steps from the Etcher instructions. If you're using Etcher you don't need to unzip your image first, or preformat the SD card, or eject it manually when you're done, that all happens automatically.

I've made the intro for the mac/windows/linux instructions all point back to the main readme, since I think it's likely there'll be quite a few existing direct links in to these pages, and I've tweaked their format and intro to be all consistent with one another.