### PR TITLE
'sync' after running dd

### DIFF
--- a/installation/installing-images/linux.md
+++ b/installation/installing-images/linux.md
@@ -24,7 +24,7 @@
 - In a terminal window, write the image to the card with the command below, making sure you replace the input file `if=` argument with the path to your `.img` file, and the `/dev/sdX` in the output file `of=` argument with the correct device name. This is very important, as you will lose all the data on the hard drive if you provide the wrong device name. Make sure the device name is the name of the whole SD card as described above, not just a partition. For example: `sdd`, not `sdds1` or `sddp1`, and `mmcblk0`, not `mmcblk0p1`.
 
     ```bash
-    dd bs=4M if=2017-07-05-raspbian-jessie.img of=/dev/sdX
+    dd bs=4M if=2017-07-05-raspbian-jessie.img of=/dev/sdX; sync
     ```
 
 - Please note that block size set to `4M` will work most of the time. If not,  try `1M`, although this will take considerably longer.
@@ -37,7 +37,7 @@ In Linux it is possible to combine the unzip and SD copying process into one com
 
 The following command unzips the zip file (replace 2017-07-05-raspbian-jessie.zip with the appropriate zip filename), and pipes the output directly to the dd command. This in turn copies it to the SD card, as described in the previous section.
 ```
-unzip -p 2017-07-05-raspbian-jessie.zip | sudo dd of=/dev/sdX bs=4096
+unzip -p 2017-07-05-raspbian-jessie.zip | sudo dd of=/dev/sdX bs=4M; sync
 ```
 
 ### Checking the image copy progress
@@ -46,7 +46,7 @@ unzip -p 2017-07-05-raspbian-jessie.zip | sudo dd of=/dev/sdX bs=4096
 
 - To see the progress of the copy operation, you can run the dd command with the status option.
    ```
-    dd bs=4M if=2017-07-05-raspbian-jessie.img of=/dev/sdX status=progress
+    dd bs=4M if=2017-07-05-raspbian-jessie.img of=/dev/sdX status=progress; sync
    ```
 - If you are using an older version of `dd`, the status option may not be available. You may be able to use the `dcfldd` command instead, which will give a progress report showing how much has been written.
 


### PR DESCRIPTION
The forum user 'jojopi' has observed that some files are placed at the very end of the partition on the latest image.
https://www.raspberrypi.org/forums/viewtopic.php?f=63&t=187936#p1185337

Some users are taking out the card as soon as `dd` finishes and are finding that those files are corrupted.
https://www.raspberrypi.org/forums/viewtopic.php?f=91&t=187880#p1185702

The `conv=fdatasync` parameter could also be used, but `; sync` is shorter and arguably more intuitive.