### PR TITLE
installing-images: dd - use conv=fsync and conv=sync for Linux and Mac

### DIFF
--- a/installation/installing-images/linux.md
+++ b/installation/installing-images/linux.md
@@ -24,7 +24,7 @@
 - In a terminal window, write the image to the card with the command below, making sure you replace the input file `if=` argument with the path to your `.img` file, and the `/dev/sdX` in the output file `of=` argument with the correct device name. This is very important, as you will lose all the data on the hard drive if you provide the wrong device name. Make sure the device name is the name of the whole SD card as described above, not just a partition. For example: `sdd`, not `sdds1` or `sddp1`, and `mmcblk0`, not `mmcblk0p1`.
 
     ```bash
-    dd bs=4M if=2017-07-05-raspbian-jessie.img of=/dev/sdX; sync
+    dd bs=4M if=2017-07-05-raspbian-jessie.img of=/dev/sdX conv=fsync
     ```
 
 - Please note that block size set to `4M` will work most of the time. If not,  try `1M`, although this will take considerably longer.
@@ -37,7 +37,7 @@ In Linux it is possible to combine the unzip and SD copying process into one com
 
 The following command unzips the zip file (replace 2017-07-05-raspbian-jessie.zip with the appropriate zip filename), and pipes the output directly to the dd command. This in turn copies it to the SD card, as described in the previous section.
 ```
-unzip -p 2017-07-05-raspbian-jessie.zip | sudo dd of=/dev/sdX bs=4M; sync
+unzip -p 2017-07-05-raspbian-jessie.zip | sudo dd of=/dev/sdX bs=4M conv=fsync
 ```
 
 ### Checking the image copy progress
@@ -46,7 +46,7 @@ unzip -p 2017-07-05-raspbian-jessie.zip | sudo dd of=/dev/sdX bs=4M; sync
 
 - To see the progress of the copy operation, you can run the dd command with the status option.
    ```
-    dd bs=4M if=2017-07-05-raspbian-jessie.img of=/dev/sdX status=progress; sync
+    dd bs=4M if=2017-07-05-raspbian-jessie.img of=/dev/sdX status=progress conv=fsync
    ```
 - If you are using an older version of `dd`, the status option may not be available. You may be able to use the `dcfldd` command instead, which will give a progress report showing how much has been written.
 

--- a/installation/installing-images/mac.md
+++ b/installation/installing-images/mac.md
@@ -13,7 +13,7 @@
 - From the terminal, run the following command:
 
     ```
-    sudo dd bs=1m if=path_of_your_image.img of=/dev/rdiskn
+    sudo dd bs=1m if=path_of_your_image.img of=/dev/rdiskn conv=sync
     ```
 
     Remember to replace `n` with the number that you noted before!
@@ -24,7 +24,7 @@
     - If this command fails, try using `disk` instead of `rdisk`:
     
        ```
-       sudo dd bs=1m if=path_of_your_image.img of=/dev/diskn
+       sudo dd bs=1m if=path_of_your_image.img of=/dev/diskn conv=sync
        ```
 This will take a few minutes, depending on the size of the image file. To check the progress, open Activity Monitor, click the Disk tab and find the process with the name `dd`. If `dd` is not in the list, you may need to select 'All Processes' from the View menu. The Bytes Read column will display the amount of data that has been read from the image. Compare that to the file size of the image to determine progress.
 
@@ -44,25 +44,25 @@ This will take a few minutes, depending on the size of the image file. To check 
     
 - Copy the data to your SD card:
 
-    `sudo dd bs=1m if=image.img of=/dev/rdisk<disk# from diskutil>`
+    `sudo dd bs=1m if=image.img of=/dev/rdisk<disk# from diskutil> conv=sync`
 
-    where `disk` is your BSD name e.g. `sudo dd bs=1m if=2017-07-05-raspbian-jessie.img of=/dev/rdisk4`
+    where `disk` is your BSD name e.g. `sudo dd bs=1m if=2017-07-05-raspbian-jessie.img of=/dev/rdisk4 conv=sync`
 
     - This may result in a ``dd: invalid number '1m'`` error if you have GNU
     coreutils installed. In that case, you need to use a block size of `1M` in the `bs=` section, as follows:
 
-       `sudo dd bs=1M if=image.img of=/dev/rdisk<disk# from diskutil>`
+       `sudo dd bs=1M if=image.img of=/dev/rdisk<disk# from diskutil> conv=sync`
 
     This will take a few minutes, depending on the image file size. You can check the progress by sending a `SIGINFO` signal (press Ctrl+T).
     
     - If this command still fails, try using `disk` instead of `rdisk`, for example:
     
        ```
-       sudo dd bs=1m if=2017-07-05-raspbian-jessie.img of=/dev/disk4
+       sudo dd bs=1m if=2017-07-05-raspbian-jessie.img of=/dev/disk4 conv=sync
        ```
        or
        ```
-       sudo dd bs=1M if=2017-07-05-raspbian-jessie.img of=/dev/disk4
+       sudo dd bs=1M if=2017-07-05-raspbian-jessie.img of=/dev/disk4 conv=sync
        ```
 
 ## Alternative method
@@ -85,7 +85,7 @@ These commands and actions must be performed from an account that has administra
 - In the terminal, write the image to the card with this command, using the raw device name from above. Read the above step carefully to make sure that you use the correct `rdisk` number here:
     
     ```
-    sudo dd bs=1m if=2017-07-05-raspbian-jessie.img of=/dev/rdisk3
+    sudo dd bs=1m if=2017-07-05-raspbian-jessie.img of=/dev/rdisk3 conv=sync
     ```
 
     If the above command reports the error `dd: bs: illegal numeric value`, change the block size `bs=1m` to `bs=1M`.


### PR DESCRIPTION
See https://github.com/raspberrypi/documentation/issues/693 and https://github.com/raspberrypi/documentation/pull/692#issuecomment-315710731

Fixes #693