### PR TITLE
Update wpa_supplicant

### DIFF
--- a/configuration/wireless/wireless-cli.md
+++ b/configuration/wireless/wireless-cli.md
@@ -17,6 +17,16 @@ Open the `wpa-supplicant` configuration file in nano:
 
 `sudo nano /etc/wpa_supplicant/wpa_supplicant.conf`  
 
+Update the second line from
+```
+ctrl_interface=DIR=/var/run/wpa_supplicant GROUP=netdev
+```
+to
+```
+ctrl_interface=/var/run/wpa_supplicant
+ctrl_interface_group=netdev
+```
+
 Go to the bottom of the file and add the following:   
 ```
 network={


### PR DESCRIPTION
The default /etc/wpa_supplicant/wpa_supplicant.conf will cause error. Check the [post](https://www.raspberrypi.org/forums/viewtopic.php?p=326151) 
> Failed to connect to non-global ctrl_ifname: wlan0  error: No such file or directory.

