### PR TITLE
VNC password command-line config instructions

### DIFF
--- a/remote-access/vnc/README.md
+++ b/remote-access/vnc/README.md
@@ -92,7 +92,7 @@ If you're connecting from a non-RealVNC Viewer app, you'll first need to downgra
 * **Or** if you're configuring your Raspberry Pi remotely from the command line, then to make the changes for Service Mode (the default configuration for the Raspberry Pi):
   * Open the `/root/.vnc/config.d/vncserver-x11` config file.
   * Replace `Authentication=SystemAuth` with `Authentication=VncAuth` and save the file.
-  * At the command line, run `sudo vncpasswd -service`. This  will prompt you to set a password and insert it for you in the right config file for VNC Server running in Service Mode.
+  * In the command line, run `sudo vncpasswd -service`. This  will prompt you to set a password, and will insert it for you in the right config file for VNC Server running in Service Mode.
   * Restart VNC Server.
 
 ## Playing Minecraft and other directly rendered apps remotely

--- a/remote-access/vnc/README.md
+++ b/remote-access/vnc/README.md
@@ -87,7 +87,13 @@ To complete either a direct or cloud connection, you must authenticate to VNC Se
 
 If you're connecting from the [compatible VNC Viewer app](https://www.realvnc.com/download/viewer/) from RealVNC, enter the user name and password you normally use to log in to your user account on the Raspberry Pi. By default, these credentials are `pi` and `raspberry`.
 
-If you're connecting from a non-RealVNC Viewer app, you'll first need to downgrade VNC Server's authentication scheme, specify a password unique to VNC Server, and then enter that instead. To do this, open the VNC Server dialog on your Raspberry Pi, select **Menu > Options > Security**, and choose **VNC password** from the **Authentication** dropdown.
+If you're connecting from a non-RealVNC Viewer app, you'll first need to downgrade VNC Server's authentication scheme, specify a password unique to VNC Server, and then enter that instead.
+* If you are in front of your Raspberry Pi and can see its screen, open the VNC Server dialog on your Raspberry Pi, select **Menu > Options > Security**, and choose **VNC password** from the **Authentication** dropdown.
+* **Or** if you're configuring your Raspberry Pi remotely from the command line, then to make the changes for Service Mode (the default configuration for the Raspberry Pi):
+  * Open the `/root/.vnc/config.d/vncserver-x11` config file.
+  * Replace `Authentication=SystemAuth` with `Authentication=VncAuth` and save the file.
+  * At the command line, run `sudo vncpasswd -service`. This  will prompt you to set a password and insert it for you in the right config file for VNC Server running in Service Mode.
+  * Restart VNC Server.
 
 ## Playing Minecraft and other directly rendered apps remotely
 


### PR DESCRIPTION
Added command-line instructions for configuring a VNC password for
authentication.

Fixes #674