### PR TITLE
Update building.md

### DIFF
--- a/linux/kernel/building.md
+++ b/linux/kernel/building.md
@@ -63,7 +63,7 @@ You can either do this using VirtualBox (or VMWare) on Windows, or install it di
 Use the following command to download the toolchain to the home folder:
 
 ```bash
-git clone https://github.com/raspberrypi/tools ~/
+git clone https://github.com/raspberrypi/tools ~/tools
 ```
 
 Updating the $PATH environment variable makes the system aware of file locations needed for cross-compilation. On a 32-bit host system you can update and reload it using:


### PR DESCRIPTION
'git clone' command for installing the tools for cross-compiling produces error 'fatal: destination path '/home/xxx' already exists and is not an empty directory' (for git version 1.7.10.4). Changes to explicitly define 'tools' as the directory.