### PR TITLE
Add link to elinux BCM2835_datasheet_errata

### DIFF
--- a/hardware/raspberrypi/bcm2835/README.md
+++ b/hardware/raspberrypi/bcm2835/README.md
@@ -5,7 +5,7 @@ This is the Broadcom chip used in the Raspberry Pi Model A, B, B+, the Compute M
 Please refer to:
 
 - [Peripheral specification](BCM2835-ARM-Peripherals.pdf)
-   - **Note:** This document contains some wrong information. An attempt to list all errors in the document and some additional information can be found [here](https://elinux.org/BCM2835_datasheet_errata).
+   - **Note:** This document contains a number of errors. A list of currently known errata and some additional information can be found [here](https://elinux.org/BCM2835_datasheet_errata).
 - [GPU documentation](https://docs.broadcom.com/docs/12358545) and [open-source driver](https://docs.broadcom.com/docs/12358546)
 - [ARM1176 processor](https://www.arm.com/products/processors/classic/arm11/arm1176.php)
 - [ARM1176JZF-S](http://infocenter.arm.com/help/index.jsp?topic=/com.arm.doc.ddi0301h/index.html)

--- a/hardware/raspberrypi/bcm2835/README.md
+++ b/hardware/raspberrypi/bcm2835/README.md
@@ -5,6 +5,7 @@ This is the Broadcom chip used in the Raspberry Pi Model A, B, B+, the Compute M
 Please refer to:
 
 - [Peripheral specification](BCM2835-ARM-Peripherals.pdf)
+   - **Note:** This document contains some wrong information. An attempt to list all errors in the document and some additional information can be found [here](https://elinux.org/BCM2835_datasheet_errata).
 - [GPU documentation](https://docs.broadcom.com/docs/12358545) and [open-source driver](https://docs.broadcom.com/docs/12358546)
 - [ARM1176 processor](https://www.arm.com/products/processors/classic/arm11/arm1176.php)
 - [ARM1176JZF-S](http://infocenter.arm.com/help/index.jsp?topic=/com.arm.doc.ddi0301h/index.html)


### PR DESCRIPTION
It just took me a few days and lending a frequency counter from a friend to figure out, that the [fractional divider for a clock needs to be specified with base 4096 instead of 1024](https://elinux.org/BCM2835_datasheet_errata#p105_table), how it says in the PDF file.

Only to then find out that this has been already documented somewhere.

I think there should at least be a link to that page.
It would be even better if it would be possible to add information like this as PDF-Annotations to the file that is hosted on the website.