### PR TITLE
Fix markdown formatting for raspberrypi.org systemd documentation

### DIFF
--- a/linux/usage/systemd.md
+++ b/linux/usage/systemd.md
@@ -8,7 +8,8 @@ On your Pi, create a .service file for your service, for example:
 
 myscript.service
 
-```[Unit]
+```
+[Unit]
 Description=My service
 After=network.target
 


### PR DESCRIPTION
The documentation on https://www.raspberrypi.org/documentation/linux/usage/systemd.md seems to be messed and not rendering the markdown properly because there isn't a new line after the first codeblock opening tag (\`\`\`) symbols.  This tweak should fix it