### PR TITLE
Improvements on the passwordless ssh tutorial

### DIFF
--- a/remote-access/ssh/passwordless.md
+++ b/remote-access/ssh/passwordless.md
@@ -67,7 +67,7 @@ To copy your public key to your Raspberry Pi, use the following command to appen
 cat ~/.ssh/id_rsa.pub | ssh <USERNAME>@<IP-ADDRESS> 'cat >> .ssh/authorized_keys'
 ```
 
-Now you'll have to edit /etc/ssh/sshd_config for it to accept connections via this method. Open the file and find the following parameter:
+Now you'll have to edit /etc/ssh/sshd_config on your Pi for it to accept connections via this method. Open the file and find the following parameter:
 ```
 #PasswordAuthentication yes
 ```
@@ -77,7 +77,7 @@ Replace it with
 PasswordAuthentication no
 ```
 
-Now restart the SSH service
+Then restart the SSH service
 ```
 sudo /etc/init.d/ssh restart
 ```

--- a/remote-access/ssh/passwordless.md
+++ b/remote-access/ssh/passwordless.md
@@ -67,7 +67,20 @@ To copy your public key to your Raspberry Pi, use the following command to appen
 cat ~/.ssh/id_rsa.pub | ssh <USERNAME>@<IP-ADDRESS> 'cat >> .ssh/authorized_keys'
 ```
 
-Note that this time you will have to authenticate with your password.
+Now you'll have to edit /etc/ssh/sshd_config for it to accept connections via this method. Open the file and find the following parameter:
+```
+#PasswordAuthentication yes
+```
+
+Replace it with
+```
+PasswordAuthentication no
+```
+
+Now restart the SSH service
+```
+sudo /etc/init.d/ssh restart
+```
 
 Now try `ssh <USER>@<IP-ADDRESS>` and you should connect without a password prompt.
 


### PR DESCRIPTION
I've never been able to setup passwordless ssh with the provided instructions on several Raspbian installs. It's always missing the step I added. Today, upon setting up a new machine, I remembered this tutorial and decided to try and correct it.