### PR TITLE
The Raspi-Config doc page doesn't match

### DIFF
--- a/configuration/raspi-config.md
+++ b/configuration/raspi-config.md
@@ -20,20 +20,23 @@ You should see a blue screen with options in a grey box in the centre, like so:
 It has the following options available:
 
 ```
-                        Raspberry Pi Software Configuration Tool (raspi-config)
-
-Setup Options
-
-    1 Expand Filesystem              Ensures that all of the SD card storage is available to the OS
-    2 Change User Password           Change password for the default user (pi)
-    3 Enable Boot to Desktop/Scratch Choose whether to boot into a desktop environment, Scratch, or the command line
-    4 Internationalisation Options   Set up language and regional settings to match your location
-    5 Enable Camera                  Enable this Pi to work with the Raspberry Pi camera
-    6 Overclock                      Configure overclocking for your Pi
-    7 Advanced Options               Configure advanced settings
-    8 About `raspi-config`           Information about this configuration tool
-
-                                   <Select>                                  <Finish>
+┌───────────────────┤ Raspberry Pi Software Configuration Tool (raspi-config) ├────────────────────┐
+│                                                                                                  │
+│        1 Change User Password Change password for the current user                               │
+│        2 Network Options      Configure network settings                                         │
+│        3 Boot Options         Configure options for start-up                                     │
+│        4 Localisation Options Set up language and regional settings to match your location       │
+│        5 Interfacing Options  Configure connections to peripherals                               │
+│        6 Overclock            Configure overclocking for your Pi                                 │
+│        7 Advanced Options     Configure advanced settings                                        │
+│        8 Update               Update this tool to the latest version                             │
+│        9 About raspi-config   Information about this configuration tool                          │
+│                                                                                                  │
+│                                                                                                  │
+│                                                                                                  │
+│                           <Select>                           <Finish>                            │
+│                                                                                                  │
+└──────────────────────────────────────────────────────────────────────────────────────────────────┘
 ```
 
 <a name="moving-around-the-menu"></a>
@@ -51,88 +54,64 @@ Generally speaking, `raspi-config` aims to provide the functionality to make the
 <a name="menu-options"></a>
 ## Menu options
 
-<a name="expand-filesystem"></a>
-### Expand filesystem
-
-If you have installed Raspbian using NOOBS, the filesystem will have been expanded automatically. There may be a rare occasion where this is not the case, e.g. if you have copied a smaller SD card onto a larger one. In this case, you should use this option to expand your installation to fill the whole SD card, giving you more space to use for files. You will need to reboot the Raspberry Pi to make this available. Note that there is no confirmation: selecting the option begins the partition expansion immediately.
-
 <a name="change-user-password"></a>
-### Change user password
+### Change User Password
 
-The default user on Raspbian is `pi` with the password `raspberry`. You can change that here. Read about other [users](../linux/usage/users.md).
+The default user on Raspbian is ```pi``` with the password ```raspberry```. You can change that here. Read about other [users](/linux/usage/users.md).
+ 
+<a name="network-options"></a>
+### Network Options
 
-<a name="change-boot-to-desktop"></a>
-### Enable boot to desktop or Scratch
-
-You can change what happens when your Pi boots. Use this option to change your boot preference to command line, desktop, or straight to Scratch.
-
-<a name="internationalisation-options"></a>
-### Internationalisation options
-
-Select `Internationalisation Options` and press `Enter` to be taken to a sub-menu containing the following options:
-
-<a name="change-locale"></a>
-#### Change locale
-
-Select a locale, for example `en_GB.UTF-8 UTF-8`.
-
-<a name="change-timezone"></a>
-#### Change timezone
-
-Select your local timezone, starting with the region such as `Europe`, then selecting a city, for example `London`. Type a letter to skip down the list to that point in the alphabet.
-
-<a name="change-keyboard-layout"></a>
-#### Change keyboard layout
-
-This option opens another menu which allows you to select your keyboard layout. It will take a long time to display while it reads all the keyboard types. Changes usually take effect immediately, but may require a reboot.
-
-<a name="enable-camera"></a>
-### Enable camera
-
-In order to use the Raspberry Pi Camera Module, you must enable it here. Select the option and proceed to `Enable`. This will make sure at least 128MB of RAM is dedicated to the GPU.
-
-<a name="overclock"></a>
-### Overclock
-
-It is possible to overclock your Raspberry Pi's CPU. The default is 700MHz but it can be set up to 1000MHz. The overclocking you can achieve will vary; overclocking too high may result in instability. Selecting this option shows the following warning:
-
-```
-Be aware that overclocking may reduce the lifetime of your Raspberry Pi. If overclocking at a certain level causes system instability, try a more modest overclock. Hold down `shift` during boot to temporarily disable overclock.
-```
-
-<a name="advanced-options"></a>
-### Advanced options
-
-<a name="overscan"></a>
-#### Overscan
-
-Old TV sets had a significant variation in the size of the picture they produced; some had cabinets that overlapped the screen. TV pictures were therefore given a black border so that none of the picture was lost; this is called overscan. Modern TVs and monitors don't need the border, and the signal doesn't allow for it. If the initial text shown on the screen disappears off the edge, you need to enable overscan to bring the border back.
-
-Any changes will take effect after a reboot. You can have greater control over the settings by editing [config.txt](config-txt/README.md).
-
-On some displays, particularly monitors, disabling overscan will make the picture fill the whole screen and correct the resolution. For other displays, it may be necessary to leave overscan enabled and adjust its values.
+From this sub-menu you can set the hostname, your WiFi SSID and pre-shared key or enable/disable predictable network interface names.
 
 <a name="hostname"></a>
 #### Hostname
 
 Set the visible name for this Pi on a network.
 
-<a name="memory-split"></a>
-#### Memory split
+<a name="boot-options"></a>
+### Boot Options
 
-Change the amount of memory made available to the GPU.
+From here you can change what happens when your Pi boots. Use this option to change your boot preference to command line, desktop. You can choose whether boot-up waits for the network to be available. You can choose whether the plymouth splash screen is displayed at boot-up
+
+<a name="localisation-options"></a>
+### Localisation Options
+
+The localisation sub-menu gives you options to choose: keyboard layout, timezone, locale and WiFi country code. All options on these menus default to British or GB until you change them.
+
+#### Change locale
+Select a locale, for example en_GB.UTF-8 UTF-8.
+
+#### Change timezone
+Select your local timezone, starting with the region such as Europe, then selecting a city, for example London. Type a letter to skip down the list to that point in the alphabet.
+
+#### Change keyboard layout
+This option opens another menu which allows you to select your keyboard layout. It will take a long time to display while it reads all the keyboard types. Changes usually take effect immediately, but may require a reboot.
+
+#### Change Wi-Fi Country
+This option sets the country code for your WiFi network.
+
+<a name="interfacing-options"></a>
+### Interfacing Options
+
+From this sub-menu there are options to enable/disable: Camera, SSH, VNC, SPI, I2C, Serial, 1-wire and Remote GPIO.
+
+<a name="camera"></a>
+#### Camera
+
+Enable/Disable the CSI camera interface
 
 <a name="ssh"></a>
 #### SSH
 
-Enable/disable remote command line access to your Pi using SSH.
+Enable/Disable remote command line access to your Pi using SSH.
 
 SSH allows you to remotely access the command line of the Raspberry Pi from another computer. SSH is disabled by default. Read more about using SSH on the [SSH documentation page](../remote-access/ssh/README.md). If connecting your Pi directly to a public network, you should not enable SSH unless you have set up secure passwords for all users.
 
-<a name="device-tree"></a>
-#### Device Tree
+<a name="VNC"></a>
+#### VNC
 
-Enable/Disable the use of Device Tree. Read more about Device Trees config on the [Device Trees documentation page](device-tree.md).
+Enable/Disable the RealVNC virtual network computing server.
 
 <a name="spi"></a>
 #### SPI
@@ -149,10 +128,77 @@ Enable/Disable I2C interfaces and automatic loading of the I2C kernel module.
 
 Enable/Disable shell and kernel messages on the serial connection.
 
+<a name="1-wire"></a>
+#### 1-wire
+
+Enable/Disable the Dallas 1-wire interface. This is usually used for DS18B20 temperature sensors.
+
+<a name="overclock"></a> 
+### Overclock
+
+It is possible to overclock your Raspberry Pi's CPU. The default is 700MHz but it can be set up to 1000MHz. The overclocking you can achieve will vary; overclocking too high may result in instability. Selecting this option shows the following warning:
+
+```
+Be aware that overclocking may reduce the lifetime of your Raspberry Pi. If overclocking at a certain level causes system instability, try a more modest overclock. Hold down shift during boot to temporarily disable overclock.
+```
+See http://elinux.org/RPi_Overclocking for more information.
+
+<a name="advanced-options"></a>
+### Advanced Options
+
+<a name="expand-filesystem"></a>
+#### Expand Filesystem
+
+If you have installed Raspbian using NOOBS, the filesystem will have been expanded automatically. There may be a rare occasion where this is not the case, e.g. if you have copied a smaller SD card onto a larger one. In this case, you should use this option to expand your installation to fill the whole SD card, giving you more space to use for files. You will need to reboot the Raspberry Pi to make this available. Note that there is no confirmation: selecting the option begins the partition expansion immediately.
+
+<a name="overscan"></a>
+#### Overscan
+
+Old TV sets had a significant variation in the size of the picture they produced; some had cabinets that overlapped the screen. TV pictures were therefore given a black border so that none of the picture was lost; this is called overscan. Modern TVs and monitors don't need the border, and the signal doesn't allow for it. If the initial text shown on the screen disappears off the edge, you need to enable overscan to bring the border back.
+
+Any changes will take effect after a reboot. You can have greater control over the settings by editing [config.txt](config-txt/README.md).
+
+On some displays, particularly monitors, disabling overscan will make the picture fill the whole screen and correct the resolution. For other displays, it may be necessary to leave overscan enabled and adjust its values.
+
+<a name="memory-split"></a>
+#### Memory split
+
+Change the amount of memory made available to the GPU.
+
 <a name="audio"></a>
 #### Audio
 
 Force audio out through HDMI or a 3.5mm jack. Read more on the [audio configuration documentation page](audio-config.md).
+
+<a name="resolution"></a>
+#### Resolution
+
+Define the default HDMI/DVI video resolution to use when the system boots without a TV or monitor being connected. This can have an effect on RealVNC if the VNC option is enabled.
+
+<a name="pixel-doubling"></a>
+#### Pixel Doubling
+
+Enable/Disable 2x2 pixel mapping.
+
+<a name="GL-driver"></a>
+#### GL Driver
+
+Enable/Disable the experimental GL desktop graphics drivers.
+
+<a name="GL-full-KMS"></a>
+##### GL (Full KMS) 
+
+Enable/Disable the experimental OpenGL Full KMS (kernel mode setting) desktop graphics driver.
+
+<a name="GL-fake-KMS"></a>
+##### GL (Fake KMS)
+
+Enable/Disable the experimental OpenGL Fake KMS desktop graphics driver.
+
+<a name="legacy"></a>
+##### Legacy
+
+Enable/Disable the original legacy non-GL videocore desktop graphics driver.
 
 <a name="update"></a>
 #### Update

--- a/configuration/raspi-config.md
+++ b/configuration/raspi-config.md
@@ -62,7 +62,7 @@ The default user on Raspbian is ```pi``` with the password ```raspberry```. You 
 <a name="network-options"></a>
 ### Network Options
 
-From this sub-menu you can set the hostname, your WiFi SSID and pre-shared key or enable/disable predictable network interface names.
+From this submenu you can set the host name, your WiFi SSID, and pre-shared key, or enable/disable predictable network interface names.
 
 <a name="hostname"></a>
 #### Hostname
@@ -72,75 +72,74 @@ Set the visible name for this Pi on a network.
 <a name="boot-options"></a>
 ### Boot Options
 
-From here you can change what happens when your Pi boots. Use this option to change your boot preference to command line, desktop. You can choose whether boot-up waits for the network to be available. You can choose whether the plymouth splash screen is displayed at boot-up
+From here you can change what happens when your Pi boots. Use this option to change your boot preference to command line or desktop. You can choose whether boot-up waits for the network to be available, and whether the Plymouth splash screen is displayed at boot-up.
 
 <a name="localisation-options"></a>
 ### Localisation Options
 
-The localisation sub-menu gives you options to choose: keyboard layout, timezone, locale and WiFi country code. All options on these menus default to British or GB until you change them.
+The localisation submenu gives you these options to choose from: keyboard layout, time zone, locale, and WiFi country code. All options on these menus default to British or GB until you change them.
 
 #### Change locale
-Select a locale, for example en_GB.UTF-8 UTF-8.
+Select a locale, for example `en_GB.UTF-8 UTF-8`.
 
-#### Change timezone
-Select your local timezone, starting with the region such as Europe, then selecting a city, for example London. Type a letter to skip down the list to that point in the alphabet.
+#### Change time zone
+Select your local time zone, starting with the region, e.g. Europe, then selecting a city, e.g. London. Type a letter to skip down the list to that point in the alphabet.
 
 #### Change keyboard layout
 This option opens another menu which allows you to select your keyboard layout. It will take a long time to display while it reads all the keyboard types. Changes usually take effect immediately, but may require a reboot.
 
-#### Change Wi-Fi Country
+#### Change WiFi Country
 This option sets the country code for your WiFi network.
 
 <a name="interfacing-options"></a>
 ### Interfacing Options
 
-From this sub-menu there are options to enable/disable: Camera, SSH, VNC, SPI, I2C, Serial, 1-wire and Remote GPIO.
+In this submenu there are the following options to enable/disable: Camera, SSH, VNC, SPI, I2C, Serial, 1-wire, and Remote GPIO.
 
 <a name="camera"></a>
 #### Camera
 
-Enable/Disable the CSI camera interface
+Enable/disable the CSI camera interface.
 
 <a name="ssh"></a>
 #### SSH
 
-Enable/Disable remote command line access to your Pi using SSH.
+Enable/disable remote command line access to your Pi using SSH.
 
 SSH allows you to remotely access the command line of the Raspberry Pi from another computer. SSH is disabled by default. Read more about using SSH on the [SSH documentation page](../remote-access/ssh/README.md). If connecting your Pi directly to a public network, you should not enable SSH unless you have set up secure passwords for all users.
 
 <a name="VNC"></a>
 #### VNC
 
-Enable/Disable the RealVNC virtual network computing server.
+Enable/disable the RealVNC virtual network computing server.
 
 <a name="spi"></a>
 #### SPI
 
-Enable/Disable SPI interfaces and automatic loading of the SPI kernel module, needed for products such as PiFace.
+Enable/disable SPI interfaces and automatic loading of the SPI kernel module, needed for products such as PiFace.
 
 <a name="i2c"></a>
 #### I2C
 
-Enable/Disable I2C interfaces and automatic loading of the I2C kernel module.
+Enable/disable I2C interfaces and automatic loading of the I2C kernel module.
 
 <a name="serial"></a>
 #### Serial
 
-Enable/Disable shell and kernel messages on the serial connection.
+Enable/disable shell and kernel messages on the serial connection.
 
 <a name="1-wire"></a>
 #### 1-wire
 
-Enable/Disable the Dallas 1-wire interface. This is usually used for DS18B20 temperature sensors.
+Enable/disable the Dallas 1-wire interface. This is usually used for DS18B20 temperature sensors.
 
 <a name="overclock"></a> 
 ### Overclock
 
 It is possible to overclock your Raspberry Pi's CPU. The default is 700MHz but it can be set up to 1000MHz. The overclocking you can achieve will vary; overclocking too high may result in instability. Selecting this option shows the following warning:
 
-```
-Be aware that overclocking may reduce the lifetime of your Raspberry Pi. If overclocking at a certain level causes system instability, try a more modest overclock. Hold down shift during boot to temporarily disable overclock.
-```
+**Be aware that overclocking may reduce the lifetime of your Raspberry Pi.** If overclocking at a certain level causes system instability, try a more modest overclock. Hold down the Shift key during boot to temporarily disable overclocking.
+
 See http://elinux.org/RPi_Overclocking for more information.
 
 <a name="advanced-options"></a>
@@ -178,27 +177,27 @@ Define the default HDMI/DVI video resolution to use when the system boots withou
 <a name="pixel-doubling"></a>
 #### Pixel Doubling
 
-Enable/Disable 2x2 pixel mapping.
+Enable/disable 2x2 pixel mapping.
 
 <a name="GL-driver"></a>
 #### GL Driver
 
-Enable/Disable the experimental GL desktop graphics drivers.
+Enable/disable the experimental GL desktop graphics drivers.
 
 <a name="GL-full-KMS"></a>
 ##### GL (Full KMS) 
 
-Enable/Disable the experimental OpenGL Full KMS (kernel mode setting) desktop graphics driver.
+Enable/disable the experimental OpenGL Full KMS (kernel mode setting) desktop graphics driver.
 
 <a name="GL-fake-KMS"></a>
 ##### GL (Fake KMS)
 
-Enable/Disable the experimental OpenGL Fake KMS desktop graphics driver.
+Enable/disable the experimental OpenGL Fake KMS desktop graphics driver.
 
 <a name="legacy"></a>
 ##### Legacy
 
-Enable/Disable the original legacy non-GL videocore desktop graphics driver.
+Enable/disable the original legacy non-GL videocore desktop graphics driver.
 
 <a name="update"></a>
 #### Update


### PR DESCRIPTION
The documentation page no longer matches the menu structure for the current version of the raspi-config tool.