### PR TITLE
mDNS method for discovering IP address

### DIFF
--- a/remote-access/ip-address.md
+++ b/remote-access/ip-address.md
@@ -36,22 +36,22 @@ PING raspberrypi.local (192.168.1.131): 56 data bytes
 64 bytes from 192.168.1.131: icmp_seq=0 ttl=255 time=2.618 ms
 ```
 
-If you change the system hostname fo the Raspberry Pi (e.g., by editing `/etc/hostname`), Avahi will also change the `.local` mDNS address.
+If you change the system hostname of the Raspberry Pi (e.g., by editing `/etc/hostname`), Avahi will also change the `.local` mDNS address.
 
 If you don't remember the hostname of the Raspberry Pi, but have a system with Avahi installed, you can browse all the hosts and services on the LAN with the [`avahi-browse`](https://linux.die.net/man/1/avahi-browse) command.
 
 ### nmap command
 
-The `nmap` command (Network Mapper) is a free and open-source tool for network discovery, available for Linux, Mac OS, and Windows.
+The `nmap` command (Network Mapper) is a free and open-source tool for network discovery, available for Linux, macOS, and Windows.
 
 - To install on **Linux**, install the `nmap` package e.g. `apt-get install nmap`.
 
-- To install on **Mac OS** or **Windows**, see the [nmap.org download page](http://nmap.org/download.html).
+- To install on **macOS** or **Windows**, see the [nmap.org download page](http://nmap.org/download.html).
 
 To use `nmap` to scan the devices on your network, you need to know the subnet you are connected to. First find your own IP address, in other words the one of the computer you're using to find your Pi's IP address:
 
 - On **Linux**, type `hostname -I` into a terminal window
-- On **Mac OS**, go to `System Preferences` then `Network` and select your active network connection to view the IP address
+- On **macOS**, go to `System Preferences` then `Network` and select your active network connection to view the IP address
 - On **Windows**, go to the Control Panel, then under `Network and Sharing Center`, click `View network connections`, select your active network connection and click `View status of this connection` to view the IP address
 
 Now you have the IP address of your computer, you will scan the whole subnet for other devices. For example, if your IP address is `192.168.1.5`, other devices will be at addresses like `192.168.1.2`, `192.168.1.3`, `192.168.1.4`, etc. The notation of this subnet range is `192.168.1.0/24` (this covers `192.168.1.0` to `192.168.1.255`).

--- a/remote-access/ip-address.md
+++ b/remote-access/ip-address.md
@@ -18,6 +18,25 @@ It is possible to find the IP address of your Pi without connecting to a screen 
 
 In a web browser navigate to your router's IP address e.g. `http://192.168.1.1`, which is usually printed on a label on your router; this will take you to a control panel. Then log in using your credentials, which is usually also printed on the router or sent to you in the accompanying paperwork. Browse to the list of connected devices or similar (all routers are different), and you should see some devices you recognise. Some devices are detected as PCs, tablets, phones, printers, etc. so you should recognise some and rule them out to figure out which is your Raspberry Pi. Also note the connection type; if your Pi is connected with a wire there should be fewer devices to choose from.
 
+### Resolving `raspberrypi.local` with mDNS
+
+On Raspbian, [multicast DNS](https://en.wikipedia.org/wiki/Multicast_DNS) is supported out-of-the-box by the [Avahi](https://en.wikipedia.org/wiki/Avahi_(software)) service.
+
+If your device supports mDNS, you can reach your Raspberry Pi by using its hostname and the `.local` suffix (the default hostname is `raspberrypi`):
+
+```bash
+ping raspberrypi.local
+```
+
+If the Raspberry Pi is reachable, `ping` will show its IP address:
+
+```
+PING raspberrypi.local (192.168.1.131): 56 data bytes
+64 bytes from 192.168.1.131: icmp_seq=0 ttl=255 time=2.618 ms
+```
+
+If you don't remember the hostname of the Raspberry Pi, but have a system with Avahi installed, you can browse all the hosts and services on the LAN with the [`avahi-browse`](https://linux.die.net/man/1/avahi-browse) command.
+
 ### nmap command
 
 The `nmap` command (Network Mapper) is a free and open-source tool for network discovery, available for Linux, Mac OS, and Windows.

--- a/remote-access/ip-address.md
+++ b/remote-access/ip-address.md
@@ -22,7 +22,8 @@ In a web browser navigate to your router's IP address e.g. `http://192.168.1.1`,
 
 On Raspbian, [multicast DNS](https://en.wikipedia.org/wiki/Multicast_DNS) is supported out-of-the-box by the [Avahi](https://en.wikipedia.org/wiki/Avahi_(software)) service.
 
-If your device supports mDNS, you can reach your Raspberry Pi by using its hostname and the `.local` suffix (the default hostname is `raspberrypi`):
+If your device supports mDNS, you can reach your Raspberry Pi by using its hostname and the `.local` suffix.
+The default hostname on a fresh Raspbian install is `raspberrypi`, so by default any Raspberry Pi running Raspbian responds to:
 
 ```bash
 ping raspberrypi.local
@@ -34,6 +35,8 @@ If the Raspberry Pi is reachable, `ping` will show its IP address:
 PING raspberrypi.local (192.168.1.131): 56 data bytes
 64 bytes from 192.168.1.131: icmp_seq=0 ttl=255 time=2.618 ms
 ```
+
+If you change the system hostname fo the Raspberry Pi (e.g., by editing `/etc/hostname`), Avahi will also change the `.local` mDNS address.
 
 If you don't remember the hostname of the Raspberry Pi, but have a system with Avahi installed, you can browse all the hosts and services on the LAN with the [`avahi-browse`](https://linux.die.net/man/1/avahi-browse) command.
 


### PR DESCRIPTION
One of the easiest ways to determine the IP address of a Raspberry Pi on the LAN is by pinging the `raspberrypi.local` hostname.
This method does not require to install additional software and is very simple, so I thought it was worth mentioning.