### PR TITLE
Update wireless-cli.md

### DIFF
--- a/configuration/wireless/wireless-cli.md
+++ b/configuration/wireless/wireless-cli.md
@@ -17,7 +17,16 @@ Open the `wpa-supplicant` configuration file in nano:
 
 `sudo nano /etc/wpa_supplicant/wpa_supplicant.conf`  
 
-Go to the bottom of the file and add the following:   
+For RASPBIAN STRETCH only Go to the top of the file and add the following:   
+```
+country=US
+ctrl_interface=DIR=/var/run/wpa_supplicant GROUP=netdev
+update_config=1
+```
+
+Where country is the code the RPi is being used in.
+
+Then below add the following:
 ```
 network={
     ssid="testing"


### PR DESCRIPTION
The instruction to create a wpa_supplicant need to be updated to reflect changes in Stretch. 

The following need to be added to the start of the file;

```
country=US
ctrl_interface=DIR=/var/run/wpa_supplicant GROUP=netdev
update_config=1
```

Where country code relates to the country you use the RPi in. 