### PR TITLE
Fix typos in sshd option names

### DIFF
--- a/configuration/security.md
+++ b/configuration/security.md
@@ -155,8 +155,8 @@ sudo nano /etc/ssh/sshd_config
 There are three lines that need to be changed to `no`, if they are not set that way already:
 
 ```
-ChallengeResponseAuthentification no
-PasswordAuthentification no
+ChallengeResponseAuthentication no
+PasswordAuthentication no
 UsePAM no
 ```
 


### PR DESCRIPTION
The two options  
`ChallengeResponseAuthentication` and `PasswordAuthentication`  
were incorrectly written as  
`ChallengeResponseAuthentification` and `PasswordAuthentification`  
(notice the extra "fi" in "Authentication").

Reference:
https://www.ssh.com/ssh/sshd_config/
https://linux.die.net/man/5/sshd_config