### PR TITLE
Corrections to markdown formatting and IP address

### DIFF
--- a/configuration/wireless/access-point.md
+++ b/configuration/wireless/access-point.md
@@ -25,7 +25,7 @@ sudo systemctl stop hostapd
 
 ## Configuring a static IP
 
-We are configuring a standalone network to act as a server, so the Raspberry Pi needs to have a static IP address assigned to the wireless port. This documentation assumes that we are using the standard 192.168.x.x IP addresses for our wireless network, so we will assign the server the IP address 192.168.0.1. It is also assumed that the wireless device being used is `wlan0`.
+We are configuring a standalone network to act as a server, so the Raspberry Pi needs to have a static IP address assigned to the wireless port. This documentation assumes that we are using the standard 192.168.x.x IP addresses for our wireless network, so we will assign the server the IP address 192.168.4.1. It is also assumed that the wireless device being used is `wlan0`.
 
 To configure the static IP address, edit the dhcpcd configuration file with: 
 ```
@@ -35,12 +35,12 @@ Go to the end of the file and edit it so that it looks like the following:
 ```
 interface wlan0
     static ip_address=192.168.4.1/24
-
+```
 Now restart the dhcpcd daemon and set up the new `wlan0` configuration:
 
 ```
 sudo service dhcpcd restart
-``
+```
 
 ## Configuring the DHCP server (dnsmasq)
 


### PR DESCRIPTION
In [Setting up a Raspberry Pi as an access point in a standalone network](https://www.raspberrypi.org/documentation/configuration/wireless/access-point.md): in section 'Configuring a static IP' there is an inconsistency in the static IP address (specified as `192.168.0.1` in the text, but set to `192.168.4.1` in the configuration snippets). Also markdown errors rendering text as code and vice-versa.

Not sure if I should have raised an issue first, but this seemed trivial enough to go straight to a PR.