### PR TITLE
Convert absolute link to relative link

### DIFF
--- a/hardware/raspberrypi/bootmodes/bootflow.md
+++ b/hardware/raspberrypi/bootmodes/bootflow.md
@@ -40,7 +40,7 @@ Next the boot ROM checks each of the boot sources for a file called bootcode.bin
 NOTES: 
 
 * If there is no SD card inserted, the SD boot mode takes five seconds to fail. To reduce this and fall back to USB more quickly, you can either insert an SD card with nothing on it or use the GPIO bootmode OTP setting described above to only enable USB.
-* The default pull for the GPIOs is defined on page 102 of the [ARM Peripherals datasheet](https://www.raspberrypi.org/documentation/hardware/raspberrypi/bcm2835/BCM2835-ARM-Peripherals.pdf). If the value at boot time does not equal the default pull, then that boot mode is enabled.
+* The default pull for the GPIOs is defined on page 102 of the [ARM Peripherals datasheet](../bcm2835/BCM2835-ARM-Peripherals.pdf). If the value at boot time does not equal the default pull, then that boot mode is enabled.
 * USB enumeration is a means of enabling power to the downstream devices on a hub, then waiting for the device to pull the D+ and D- lines to indicate if it is either USB 1 or USB 2. This can take time: on some devices it can take up to three seconds for a hard disk drive to spin up and start the enumeration process. Because this is the only way of detecting that the hardware is attached, we have to wait for a minimum amount of time (two seconds). If the device fails to respond after this maximum timeout, it is possible to increase the timeout to five seconds using `program_usb_timeout=1` in `config.txt`.
 * MSD takes precedence over Ethernet boot.
 * It is no longer necessary for the first partition to be the FAT partition, as the MSD boot will continue to search for a FAT partition beyond the first one.


### PR DESCRIPTION
This helps keep the documentation more "self-contained" (IMHO).