### PR TITLE
Update access-point.md

### DIFF
--- a/configuration/wireless/access-point.md
+++ b/configuration/wireless/access-point.md
@@ -23,6 +23,11 @@ sudo systemctl stop dnsmasq
 sudo systemctl stop hostapd
 ```
 
+Disable RFKILL to allow hostapd to control the wlan0 interface after reboot:
+```
+sudo systemctl disable systemd-rfkill
+```
+
 ## Configuring a static IP
 
 We are configuring a standalone network to act as a server, so the Raspberry Pi needs to have a static IP address assigned to the wireless port. This documentation assumes that we are using the standard 192.168.x.x IP addresses for our wireless network, so we will assign the server the IP address 192.168.4.1. It is also assumed that the wireless device being used is `wlan0`.


### PR DESCRIPTION
This setup tutorial requires RFKILL to be disabled in order to allow hostapd to bring up and control the wlan0 interface. I've added the line following the installation and stop of hostapd and dnsmasq to reflect this.