### PR TITLE
Add notes about distro upgrades

### DIFF
--- a/raspbian/updating.md
+++ b/raspbian/updating.md
@@ -13,7 +13,7 @@ sudo apt-get update
 Next, **upgrade** all your installed packages to their latest versions with the command:
 
 ```bash
-sudo apt-get dist-upgrade
+sudo apt-get upgrade
 ```
 
 Generally speaking, doing this regularly will keep your installation up to date, in that it will be equivalent to the latest released image available from [raspberrypi.org/downloads](https://www.raspberrypi.org/downloads/).
@@ -27,3 +27,7 @@ The kernel and firmware are installed as a Debian package, and so will also get 
 ## Running out of space
 
 When running `sudo apt-get dist-upgrade`, it will show how much data will be downloaded and how much space it will take up on the SD card. It's worth checking with `df -h` that you have enough free disk space, as unfortunately `apt` will not do this for you. Also be aware that downloaded package files (`.deb` files) are kept in `/var/cache/apt/archives`. You can remove these in order to free up space with `sudo apt-get clean`.
+
+## Upgrading to a newer version of Raspbian
+
+For an example of how to upgrade from one version of Raspbian to another (e.g. jessie to stretch), see https://www.raspberrypi.org/blog/raspbian-stretch/


### PR DESCRIPTION
I found this page while looking for instructions on upgrading to stretch.  This fixes the "dist-upgrade" command to simply "upgrade" so as not to mislead the reader into thinking it's a distro upgrade.  This also adds new heading with a link to an example of how to upgrade to a new version of Raspbian.