### PR TITLE
dt-blob.bin file does not take effect until after peripherals are initialised

### DIFF
--- a/configuration/pin-configuration.md
+++ b/configuration/pin-configuration.md
@@ -20,6 +20,9 @@ Similarly, a `.dtb` file can be converted back to a `.dts` file, if required.
 dtc -I dtb -O dts -o dt-blob.dts /boot/dt-blob.bin
 ```
 
+**NOTE:** The dt-blob.bin file generated does not reconfigure peripheral defaults before they are initialised, but afterwards. For example, take the scenario where GPIO 35 is configured to terminate low in the dt-blob.bin file, from its default high. In this case GPIO 35 will still default high on bootup for a few seconds, before it is terminated low as configured in the dt-blob.bin file.
+
+
 ## Sections of the dt-blob
 
 The `dt-blob.bin` is used to configure the binary blob (VideoCore) at boot time. It is not currently used by the Linux kernel, but a kernel section will be added at a later stage, when we reconfigure the Raspberry Pi kernel to use a dt-blob for configuration.  The dt-blob can configure all versions of the Raspberry Pi, including the Compute Module, to use the alternative settings. The following sections are valid in the dt-blob:


### PR DESCRIPTION
Initially i wrongly assumed that the dt-blob would "re-configure" GPIO defaults before the peripherals were initialised. PhilE on the [forum](https://www.raspberrypi.org/forums/viewtopic.php?f=98&t=213204) told me that this is incorrect.

Hence I've added a note to the pin-configuration.md file stating that the dt-blob.bin file does not take effect until after the peripherals are initialised. 

This is important for people to understand especially if they are designing hardware. As there will always be a transition from the "default" state, to the dt-blob settings.