### PR TITLE
Added Embest 1.2 RPi Zero

### DIFF
--- a/hardware/raspberrypi/revision-codes/README.md
+++ b/hardware/raspberrypi/revision-codes/README.md
@@ -86,6 +86,7 @@ New-style revision codes in use:
 | 900021 | A+                | 1.1      | 512 MB | Sony UK      |
 | 900032 | B+                | 1.2      | 512 MB | Sony UK      |
 | 900092 | Zero              | 1.2      | 512 MB | Sony UK      |
+| 920092 | Zero              | 1.2      | 512 MB | Embest       |
 | 900093 | Zero              | 1.3      | 512 MB | Sony UK      |
 | 9000c1 | Zero W            | 1.1      | 512 MB | Sony UK      |
 | 920093 | Zero              | 1.3      | 512 MB | Embest       |


### PR DESCRIPTION
I noticed a missing board revision in the list, so I added it here. 

For context, I maintain Raspberry Pi support for the [Johnny-Five](http://johnny-five.io/) robotics library, and one of my users with one of these boards opened https://github.com/nebrius/raspi-board/issues/4.