### PR TITLE
Make the contents of the Linux section consistent

### DIFF
--- a/linux/README.md
+++ b/linux/README.md
@@ -26,6 +26,8 @@ Explanation of some fundamental Linux usage, and commands for getting around the
         - Setting up scheduled tasks
     - [.bashrc and .bash_aliases](usage/bashrc.md)
         - Your shell configuration and aliases
+    - [systemd](usage/systemd.md)
+        - Configuration of systemd services to start scripts at booting
     - [rc.local](usage/rc-local.md)
         - Configuration of initialisation
 - [Software](software/README.md)

--- a/linux/usage/README.md
+++ b/linux/usage/README.md
@@ -12,6 +12,8 @@ Some general help with Linux usage.
     - Setting up multiple Linux users on your Pi system
 - [Root](root.md)
     - The `root` user and the `sudo` prefix
+- [Scripting](scripting.md)
+    - Combining commands to produce more complex actions
 - [Cron / Crontab](cron.md)
     - Setting up scheduled tasks
 - [.bashrc and .bash_aliases](bashrc.md)


### PR DESCRIPTION
Currently systemd is missing from the Linux section, but is present in Linux/Usage, while Scripting is present in Linux/Usage but missing from Linux.