### PR TITLE
Fix documentation about access point mode

### DIFF
--- a/configuration/wireless/access-point.md
+++ b/configuration/wireless/access-point.md
@@ -35,6 +35,7 @@ Go to the end of the file and edit it so that it looks like the following:
 ```
 interface wlan0
     static ip_address=192.168.4.1/24
+    nohook wpa_supplicant
 
 ```
 Now restart the dhcpcd daemon and set up the new `wlan0` configuration:


### PR DESCRIPTION
I tried following the original documentation, and most of the time the wifi interface would go up, then down after some seconds.
I spent some time debugging this, and I finally discoverer that just putting a static IP address in `dhcpcd.conf` is not sufficient, as `wpa_supplicant` is still launched on that interface, putting it in managed (client) mode.

The simplest and most effective solution I found is to disable the `wpa_supplicant` hook in dhcpcd.