### PR TITLE
Update updating.md

### DIFF
--- a/raspbian/updating.md
+++ b/raspbian/updating.md
@@ -13,7 +13,7 @@ sudo apt-get update
 Next, **upgrade** all your installed packages to their latest versions with the command:
 
 ```bash
-sudo apt-get dist-upgrade
+sudo apt-get upgrade
 ```
 
 Generally speaking, doing this regularly will keep your installation up to date, in that it will be equivalent to the latest released image available from [raspberrypi.org/downloads](https://www.raspberrypi.org/downloads/).


### PR DESCRIPTION
Reversing a change made by XECDesign two years ago
sudo apt-get update / upgrade should be run regularly, as stated, to upgrade packages but dist-upgrade is more aggressive and will upgrade the kernel.
see https://askubuntu.com/questions/81585/what-is-dist-upgrade-and-why-does-it-upgrade-more-than-upgrade
for full details