### PR TITLE
Explicitly mention 3+ in kernel configuration guide

### DIFF
--- a/linux/kernel/configuring.md
+++ b/linux/kernel/configuring.md
@@ -27,7 +27,7 @@ If you're cross-compiling, the second line should be:
 make ARCH=arm CROSS_COMPILE=arm-linux-gnueabihf- bcmrpi_defconfig
 ```
 
-For all models of Raspberry Pi 2/3:
+For all models of Raspberry Pi 2/3 (includes Pi 3+ and Compute Module 3):
 
 ```
 $ KERNEL=kernel7


### PR DESCRIPTION
To avoid confusion, explicitly mention 3+ and CM3 in kernel configuration guide.