### PR TITLE
Prefixed iptables-restore with sudo

### DIFF
--- a/configuration/wireless/access-point.md
+++ b/configuration/wireless/access-point.md
@@ -129,7 +129,7 @@ sudo sh -c "iptables-save > /etc/iptables.ipv4.nat"
 
 Edit /etc/rc.local and add this just above "exit 0" to install these rules on boot.
 ```
-iptables-restore < /etc/iptables.ipv4.nat
+sudo iptables-restore < /etc/iptables.ipv4.nat
 ```
 Reboot
 


### PR DESCRIPTION
When running this on a new Pi Zero the above line would not step through with error:
iptables-restore v1.6.0: iptables-restore: unable to initialize table 'nat'
Error occurred at line: 2