### PR TITLE
Mention `ctrl_interface` parameter in wireless-cli.md

### DIFF
--- a/configuration/wireless/wireless-cli.md
+++ b/configuration/wireless/wireless-cli.md
@@ -64,6 +64,12 @@ On the Raspberry Pi 3 Model B+, you will also need to set the country code, so t
 country=GB
 ```
 
+If your Raspberry Pi is having issues connecting to the network at boot, try adding these 2 lines at the top of your `wpa_supplicant.conf` file:
+```
+ctrl_interface=DIR=/var/run/wpa_supplicant GROUP=netdev
+update_config=1
+```
+
 ## Unsecured networks
 
 If the network you are connecting to does not use a password, the `wpa_supplicant` entry for the network will need to include the correct `key_mgmt` entry.


### PR DESCRIPTION
I am attempting for a headless setup of my Raspberry Pi by following the official documentation. Right from the get go, I had some problems connecting the Raspberry Pi to my wifi network at boot.

After adding these 2 lines at the top of my `wpa_supplicant.conf` file, the Raspberry Pi connected successfully at boot
```
ctrl_interface=DIR=/var/run/wpa_supplicant GROUP=netdev
update_config=1
```

Currently there is no mention of this parameters in the official documentation https://www.raspberrypi.org/documentation/configuration/wireless/wireless-cli.md

I found the solution [here](https://raspberrypi.stackexchange.com/a/82923) 