### PR TITLE
Correct disable_l2cache defaults in memory.md

### DIFF
--- a/configuration/config-txt/memory.md
+++ b/configuration/config-txt/memory.md
@@ -22,6 +22,7 @@ The `gpu_mem_1024` command sets the GPU memory in megabytes for the 1024MB Raspb
 
 ## disable_l2cache
 
-Setting this to `1` disables the CPU's access to the GPU's L2 cache, and requires a corresponding L2 disabled kernel. Default value is `0`.
+Setting this to `1` disables the CPU's access to the GPU's L2 cache, and requires a corresponding L2 disabled kernel. Default value on BCM2835 is `0`. On BCM2836 and BCM2837 the ARMs have their own L2 cache and therefore the default is `1`.
+The standard Pi kernel.img and kernel7.img builds reflect this difference in cache setting.
 
 *This article uses content from the eLinux wiki page [RPiconfig](http://elinux.org/RPiconfig), which is shared under the [Creative Commons Attribution-ShareAlike 3.0 Unported license](http://creativecommons.org/licenses/by-sa/3.0/)*


### PR DESCRIPTION
2835 and 2836/7 have different defaults, therefore need describing.