### PR TITLE
Fix typo (“Performancef” to “Performance“)

### DIFF
--- a/faqs/README.md
+++ b/faqs/README.md
@@ -221,7 +221,7 @@ The Raspberry Pi Model B versions measure 85.60mm x 56mm x 21mm (or roughly 3.37
 
 <a name="pi-performance"></a>
 
-## Performancef
+## Performance
 
 ### How powerful is it?
 


### PR DESCRIPTION
Originally introduced in https://github.com/raspberrypi/documentation/commit/ff298498b0ca7e56a300a98cc3f9f395d7eae1aa