### PR TITLE
Add a first draft of a NFS guide to the Pi repository

### DIFF
--- a/configuration/README.md
+++ b/configuration/README.md
@@ -38,4 +38,5 @@ Some basic guides to configuring your Raspberry Pi.
     - How to configure screen blanking/screen saver
 - [The boot folder](boot_folder.md)
     - What it's for and what's in it
-
+- [Network File System](nfs.md)
+    - How to setup a NFS and connect clients to it

--- a/configuration/README.md
+++ b/configuration/README.md
@@ -38,5 +38,5 @@ Some basic guides to configuring your Raspberry Pi.
     - How to configure screen blanking/screen saver
 - [The boot folder](boot_folder.md)
     - What it's for and what's in it
-- [Network File System](nfs.md)
+- [Network File System (NFS)](nfs.md)
     - How to set up a NFS and connect clients to it

--- a/configuration/README.md
+++ b/configuration/README.md
@@ -39,4 +39,4 @@ Some basic guides to configuring your Raspberry Pi.
 - [The boot folder](boot_folder.md)
     - What it's for and what's in it
 - [Network File System](nfs.md)
-    - How to setup a NFS and connect clients to it
+    - How to set up a NFS and connect clients to it

--- a/configuration/nfs.md
+++ b/configuration/nfs.md
@@ -17,7 +17,7 @@ Ubuntu Before deploying NFS you should be familiar with:
 
 Install the below packages:
 
-```
+```bash
 sudo apt install nfs-kernel-server
 ```
 
@@ -25,13 +25,13 @@ For easier maintenance we will isolate all NFS exports in single directory, wher
 
 Suppose we want to export our users' home directories in /home/users. First we create the export filesystem:
 
-```
+```bash
 sudo mkdir -p /export/users
 ```
 
 Note that /export and /export/users will need 777 permissions as we will be accessing the NFS share from the client without LDAP/NIS authentication. This will not apply if using authentication (see below). Now mount the real users directory with:
 
-```
+```bash
 sudo mount --bind /home/users /export/users
 ```
 
@@ -60,7 +60,7 @@ Nobody-Group = nogroup
 
 Please note that the client may have different requirements for the Nobody-User and Nobody-Group. On RedHat variants, it is nfsnobody for both. So to ensure that these are actually present, check via the following commands to see if `nobody` is there:
 
-```
+```bash
 cat /etc/passwd
 cat /etc/group
 ```
@@ -104,7 +104,7 @@ Please ensure that the list of authorised IP addresses includes the localhost ad
 
 Afterwards, go ahead and restart the service:
 
-```
+```bash
 sudo systemctl restart nfs-kernel-server
 ```
 
@@ -112,13 +112,13 @@ sudo systemctl restart nfs-kernel-server
 
 Install the required packages:
 
-```
+```bash
 sudo apt install nfs-common
 ```
 
 On the client we can mount the complete export tree with one command:
 
-```
+```bash
 mount -t nfs -o proto=tcp,port=2049 <nfs-server-IP>:/ /mnt
 ```
 
@@ -128,7 +128,7 @@ Note that `<nfs-server-IP>:/export` is not necessary in NFSv4, as it was in NFSv
 
 We can also mount an exported subtree with:
 
-```
+```bash
 mount -t nfs -o proto=tcp,port=2049 <nfs-server-IP>:/users /home/users
 ```
 
@@ -194,7 +194,7 @@ Where `myclients` is the netgroup name
 
 Run this command to rebuild the YP database:
 
-```
+```bash
 sudo make -C /var/yp
 ```
 
@@ -218,7 +218,7 @@ Where the "list of IPs" is a list of IP addresses that consists of the server an
 
 Install the necessary packages:
 
-```
+```bash
 sudo apt install rpcbind nfs-kernel-server
 ```
 
@@ -247,7 +247,7 @@ Where `rw` makes the share read/write, and `sync` requires the server to only re
 
 After setting up `/etc/exports`, export the shares:
 
-```
+```bash
 sudo exportfs -ra
 ```
 
@@ -259,7 +259,7 @@ By default, rpcbind only binds to the loopback interface. To enable access to rp
 
 If any changes were made, rpcbind and NFS will need to be restarted:
 
-```
+```bash
 sudo systemctl restart rpcbind
 sudo systemctl restart nfs-kernel-server
 ```
@@ -278,7 +278,7 @@ Mounting an NFS share inside an encrypted home directory will only work after yo
 
 1. Create an alternative directory to mount the NFS shares in:
 
-```
+```bash
 sudo mkdir /nfs
 sudo mkdir /nfs/music
 ```
@@ -291,7 +291,7 @@ nfsServer:music    /nfs/music    nfs    auto    0 0
 
 Create a symbolic link inside your home, pointing to the actual mount location. For example, in our case delete the 'Music' directory already existing there first:
 
-```
+```bash
 rmdir /home/user/Music
 ln -s /nfs/music/ /home/user/Music
 ```

--- a/configuration/nfs.md
+++ b/configuration/nfs.md
@@ -1,5 +1,7 @@
 # NFS - Network File System
 
+Note: this guide is a *work-in-pending*, feel free to correct any mistakes or add additional information if it is missing or needed.
+
 The "Network File System" allows you to share a directory located on one networked computer with other computers/devices on that network. The computer where directory located is called the server and computers or devices connecting to that server are called clients. Clients usually 'mount' the shared directory to make it a part of their own directory structure.
 
 For smaller networks it is perfect for creating a simple NAS (Networked Attached Storage) in a Linux/Unix environment.

--- a/configuration/nfs.md
+++ b/configuration/nfs.md
@@ -1,19 +1,19 @@
 # NFS - Network File System
 
-NFS (Network File System) allows you to 'share' a directory located on one networked computer with other computers/devices on that network. The computer where directory located is called the server and computers or devices connecting to that server are called clients. Clients usually 'mount' the shared directory to make it a part of their own directory structure.
+The "Network File System" allows you to share a directory located on one networked computer with other computers/devices on that network. The computer where directory located is called the server and computers or devices connecting to that server are called clients. Clients usually 'mount' the shared directory to make it a part of their own directory structure.
 
-NFS is perfect for creating NAS (Networked Attached Storage) in Linux/Unix environment. It is a native Linux/Unix protocol as opposed to Samba which uses the SMB protocol developed by Microsoft. Note that both Windows and Apple OS have good support for NFS.
+For smaller networks it is perfect for creating a simple NAS (Networked Attached Storage) in a Linux/Unix environment.
 
-NFS is perhaps best for more permanent network mounted directories such as /home directories or regularly accessed shared resources. If you want a network share that guest users can easily connect to, Samba is more suited. This is because tools exist more readily across old and proprietary operating systems to temporarily mount and detach from Samba shares.
+It is perhaps suited for more permanent network mounted directories such as `/home` directories or regularly accessed shared resources. If you want a network share that guest users can easily connect to, Samba is more suited. This is because tools exist more readily across old and proprietary operating systems to temporarily mount and detach from Samba shares.
 
 Ubuntu Before deploying NFS you should be familiar with:
 
 1. Linux file and directory permissions
-1. Mounting and detaching (unmounting) filesystems 
+1. Mounting and unmounting filesystems
 
 ### Setup a basic NFS server
 
-Install the required packages...
+Install the below packages:
 
 ```
 sudo apt install nfs-kernel-server
@@ -24,7 +24,7 @@ For easier maintenance we will isolate all NFS exports in single directory, wher
 Suppose we want to export our users' home directories in /home/users. First we create the export filesystem:
 
 ```
-sudo mkdir -p /export/users 
+sudo mkdir -p /export/users
 ```
 
 Note that /export and /export/users will need 777 permissions as we will be accessing the NFS share from the client without LDAP/NIS authentication. This will not apply if using authentication (see below). Now mount the real users directory with:
@@ -41,9 +41,9 @@ To save us from retyping this after every reboot we add the following line to `/
 
 There are three configuration files that relate to an NFS server:
 
-1. /etc/default/nfs-kernel-server
-1. /etc/default/nfs-common
-1. /etc/exports
+1. `/etc/default/nfs-kernel-server`
+1. `/etc/default/nfs-common`
+1. `/etc/exports`
 
 The only important option in `/etc/default/nfs-kernel-server` for now is `NEED_SVCGSSD`. It is set to "no" by default, which is fine, because we are not activating NFSv4 security this time.
 
@@ -80,7 +80,7 @@ To export our directories to a local network 192.168.1.0/24 we add the following
 /export/users 192.168.1.0/24(rw,nohide,insecure,no_subtree_check,async)
 ```
 
-### Portmap Lockdown - optional
+#### Portmap lockdown - optional
 
 Add the following line to `/etc/hosts.deny`:
 
@@ -98,9 +98,9 @@ rpcbind mountd nfsd statd lockd rquotad : <list of IPv4s>
 
 Where "list of IPv4" is a list of IP addresses that consists of the server and all clients. These have to be IP addresses because of a limitation in rpcbind, which it doesn't like hostnames. Note that if you have NIS set up, just add these to the same line.
 
-Note: Ensure that the list of authorised IP addresses includes the localhost address (127.0.0.1) as the startup scripts in recent versions of Ubuntu use the rpcinfo command to discover NFSv3 support, and this will be disabled if localhost is unable to connect.
+Please ensure that the list of authorised IP addresses includes the localhost address (127.0.0.1) as the startup scripts in recent versions of Ubuntu use the rpcinfo command to discover NFSv3 support, and this will be disabled if localhost is unable to connect.
 
-Go ahead and restart the service:
+Afterwards, go ahead and restart the service:
 
 ```
 sudo systemctl restart nfs-kernel-server
@@ -111,7 +111,7 @@ sudo systemctl restart nfs-kernel-server
 Install the required packages:
 
 ```
-sudo apt install nfs-common 
+sudo apt install nfs-common
 ```
 
 On the client we can mount the complete export tree with one command:
@@ -138,7 +138,7 @@ To ensure this is mounted on every reboot, add the following line to `/etc/fstab
 
 If after mounting, the entry in `/proc/mounts appears` as `<nfs-server-IP>://` (with two slashes), then you might need to specify two slashes in `/etc/fstab`, or else umount might complain that it cannot find the mount.
 
-### Portmap Lockdown - optional
+#### Portmap lockdown - optional
 
 Add the following line to `/etc/hosts.deny`:
 
@@ -166,7 +166,7 @@ NFS user permissions are based on user ID (UID). UIDs of any users on the client
 
 1. Use of DNS
 
-1. Use of NIS 
+1. Use of NIS
 
 Note that you have to be careful on systems where the main user has root access - that user can change UID's on the system to allow themselves access to anyone's files. This page assumes that the administrative team is the only group with root access and that they are all trusted. Anything else represents a more advanced configuration, and will not be addressed here.
 
@@ -253,9 +253,9 @@ You'll want to do this command whenever `/etc/exports` is modified.
 
 #### Restart Services
 
-By default, rpcbind only binds to the loopback interface. To enable access to rpcbind from remote machines, you need to change `/etc/default/rpcbind` to get rid of either `-l` or `-i 127.0.0.1`.
+By default, rpcbind only binds to the loopback interface. To enable access to rpcbind from remote machines, you need to change `/etc/conf.d/rpcbind` to get rid of either `-l` or `-i 127.0.0.1`.
 
-If `/etc/default/rpcbind` was changed, rpcbind and NFS will need to be restarted:
+If any changes were made, rpcbind and NFS will need to be restarted:
 
 ```
 sudo systemctl restart rpcbind
@@ -274,20 +274,20 @@ An alternative to IPSec is physically separate networks. This requires a separat
 
 Mounting an NFS share inside an encrypted home directory will only work after you are successfully logged in and your home is decrypted. This means that using /etc/fstab to mount NFS shares on boot will not work - because your home has not been decrypted at the time of mounting. There is a simple way around this using Symbolic links:
 
-1. Create an alternative directory to mount the NFS shares in: 
+1. Create an alternative directory to mount the NFS shares in:
 
 ```
-$ sudo mkdir /nfs
-$ sudo mkdir /nfs/music
+sudo mkdir /nfs
+sudo mkdir /nfs/music
 ```
 
-1. Edit /etc/fstab to mount the NFS share into that directory instead: 
+1. Edit /etc/fstab to mount the NFS share into that directory instead:
 
 ```
 nfsServer:music    /nfs/music    nfs    auto    0 0
 ```
 
-Create a symbolic link inside your home, pointing to the actual mount location. For example, in our case delete the 'Music' directory already existing there first: 
+Create a symbolic link inside your home, pointing to the actual mount location. For example, in our case delete the 'Music' directory already existing there first:
 
 ```
 rmdir /home/user/Music
@@ -296,6 +296,7 @@ ln -s /nfs/music/ /home/user/Music
 
 ### Author Information
 
-This guide is based on a write-up located on the official Ubuntu wiki:
+This guide is based on a documents located on the official Ubuntu wiki:
 
-https://help.ubuntu.com/community/SettingUpNFSHowTo
+1. https://help.ubuntu.com/community/SettingUpNFSHowTo
+1. https://help.ubuntu.com/stable/serverguide/network-file-system.html

--- a/configuration/nfs.md
+++ b/configuration/nfs.md
@@ -1,15 +1,15 @@
 # NFS - Network File System
 
-The "Network File System" allows you to share a directory located on one networked computer with other computers/devices on that network. The computer where directory located is called the server and computers or devices connecting to that server are called clients. Clients usually 'mount' the shared directory to make it a part of their own directory structure.
+A "Network File System" allows you to share a directory located on one networked computer with other computers or devices on that network. The computer where the directory is located is called the server, and computers or devices connecting to that server are called clients. Clients usually mount the shared directory to make it a part of their own directory structure.
 
-For smaller networks it is perfect for creating a simple NAS (Networked Attached Storage) in a Linux/Unix environment.
+For smaller networks, a NFS is perfect for creating a simple NAS (Network-attached Storage) in a Linux/Unix environment.
 
-It is perhaps suited for more permanent network mounted directories such as `/home` directories or regularly accessed shared resources. If you want a network share that guest users can easily connect to, Samba is more suited. This is because tools exist more readily across old and proprietary operating systems to temporarily mount and detach from Samba shares.
+It is perhaps best suited to more permanent network-mounted directories, such as `/home` directories or regularly accessed shared resources. If you want a network share that guest users can easily connect to, Samba is better suited. This is because tools to temporarily mount and detach from Samba shares are more readily across old and proprietary operating systems.
 
-Ubuntu Before deploying NFS you should be familiar with:
+Ubuntu Before deploying a NFS you should be familiar with:
 
 1. Linux file and directory permissions
-1. Mounting and unmounting filesystems
+2. Mounting and unmounting filesystems
 
 ### Setup a basic NFS server
 

--- a/configuration/nfs.md
+++ b/configuration/nfs.md
@@ -266,7 +266,7 @@ sudo systemctl restart nfs-kernel-server
 
 ### Security items to consider
 
-Aside from the UID issues discussed above, it should be noted that an attacker could potentially masquerade as a machine that is allowed to map the share, which allows them to create arbitrary UIDs to access your files. One potential solution to this is IPSec; see also the NFS and IPSec section below. You can set up all your domain members to talk to each other only over IPSec, which will effectively authenticate that your client is who it says it is.
+Aside from the UID issues discussed above, it should be noted that an attacker could potentially masquerade as a machine that is allowed to map the share, which allows them to create arbitrary UIDs to access your files. One potential solution to this is IPSec. You can set up all your domain members to talk to each other only over IPSec, which will effectively authenticate that your client is who it says it is.
 
 IPSec works by encrypting traffic to the server with the server's public key, and the server sends back all replies encrypted with the client's public key. The traffic is decrypted with the respective private keys. If the client doesn't have the keys that it is supposed to have, it can't send or receive data.
 

--- a/configuration/nfs.md
+++ b/configuration/nfs.md
@@ -2,7 +2,7 @@
 
 A **Network File System** (NFS) allows you to share a directory located on one networked computer with other computers or devices on the same network. The computer where the directory is located is called the **server**, and computers or devices connecting to that server are called **clients**. Clients usually `mount` the shared directory to make it a part of their own directory structure. The shared directory is an example of a shared resource or network share.
 
-For smaller networks, an NFS is perfect for creating a simple NAS (Network-attached Storage) in a Linux/Unix environment.
+For smaller networks, an NFS is perfect for creating a simple NAS (Network-attached storage) in a Linux/Unix environment.
 
 An NFS is perhaps best suited to more permanent network-mounted directories, such as `/home` directories or regularly-accessed shared resources. If you want a network share that guest users can easily connect to, Samba is better suited to the task. This is because tools to temporarily mount and detach from Samba shares are more readily available across old and proprietary operating systems.
 
@@ -47,7 +47,7 @@ There are three configuration files that relate to an NFS server:
 
 The only important option in `/etc/default/nfs-kernel-server` for now is `NEED_SVCGSSD`. It is set to `"no"` by default, which is fine, because we are not activating NFSv4 security this time.
 
-In order for the ID names to be automatically mapped, the file `/etc/idmapd.conf` must exist on both the client and the server with the same contents and with the correct domain names. Furthermore, this file should have the following lines in the Mapping section:
+In order for the ID names to be automatically mapped, the file `/etc/idmapd.conf` must exist on both the client and the server with the same contents and with the correct domain names. Furthermore, this file should have the following lines in the `Mapping` section:
 
 ```
 [Mapping]
@@ -97,7 +97,7 @@ Now add the following line to `/etc/hosts.allow`:
 rpcbind mountd nfsd statd lockd rquotad : <list of IPv4s>
 ```
 
-Where `<list of IPv4s>` is a list of IP addresses that consists of the server and all clients. (These have to be IP addresses because of a limitation in `rpcbind`, which it doesn't like hostnames.) Note that if you have NIS set up, you can just add these to the same line.
+where `<list of IPv4s>` is a list of the IP addresses of the server and all clients. (These have to be IP addresses because of a limitation in `rpcbind`, which doesn't like hostnames.) Note that if you have NIS set up, you can just add these to the same line.
 
 Please ensure that the list of authorised IP addresses includes the `localhost` address (`127.0.0.1`), as the startup scripts in recent versions of Ubuntu use the `rpcinfo` command to discover NFSv3 support, and this will be disabled if `localhost` is unable to connect.
 
@@ -107,7 +107,7 @@ Finally, to make your changes take effect, restart the service:
 sudo systemctl restart nfs-kernel-server
 ```
 
-## Setup a NFSv4 client
+## Set up an NFSv4 client
 
 Now that your server is running, you need to set up any clients to be able to access it. To start, install the required packages:
 
@@ -137,7 +137,7 @@ To ensure this is mounted on every reboot, add the following line to `/etc/fstab
 <nfs-server-IP>:/   /mnt   nfs    auto  0  0
 ```
 
-If after mounting, the entry in `/proc/mounts appears` as `<nfs-server-IP>://` (with two slashes), then you might need to specify two slashes in `/etc/fstab`, or else `umount` might complain that it cannot find the mount.
+If, after mounting, the entry in `/proc/mounts appears` as `<nfs-server-IP>://` (with two slashes), then you might need to specify two slashes in `/etc/fstab`, or else `umount` might complain that it cannot find the mount.
 
 ### Portmap lockdown (optional)
 
@@ -155,9 +155,9 @@ Now add the following line to `/etc/hosts.allow`:
 rpcbind : <NFS server IP address>
 ```
 
-Where `<NFS server IP address>` is the IP address of the server.
+where `<NFS server IP address>` is the IP address of the server.
 
-## NFS Server with complex user permissions
+## NFS server with complex user permissions
 
 NFS user permissions are based on user ID (UID). UIDs of any users on the client must match those on the server in order for the users to have access. The typical ways of doing this are:
 
@@ -174,7 +174,7 @@ A user's file access is determined by their membership of groups on the client, 
 
 ### DNS (optional, only if using DNS)
 
-Add any client name and IP addresses to `/etc/hosts`. (The IP address of the server should already be there.) This ensures that NFS will still work even if DNS goes down. You can rely on DNS if you want; it's up to you.
+Add any client name and IP addresses to `/etc/hosts`. (The IP address of the server should already be there.) This ensures that NFS will still work even if DNS goes down. Alternatively you can rely on DNS if you want - it's up to you.
 
 ### NIS (optional, only if using NIS)
 
@@ -194,7 +194,7 @@ Next run this command to rebuild the NIS database:
 sudo make -C /var/yp
 ```
 
-The name YP refers to Yellow Pages, the former name of NIS.
+The filename `yp` refers to Yellow Pages, the former name of NIS.
 
 ### Portmap lockdown (optional)
 
@@ -257,10 +257,10 @@ You'll want to run this command whenever `/etc/exports` is modified.
 
 By default, `rpcbind` only binds to the loopback interface. To enable access to `rpcbind` from remote machines, you need to change `/etc/conf.d/rpcbind` to get rid of either `-l` or `-i 127.0.0.1`.
 
-If any changes were made, rpcbind and NFS will need to be restarted:
+If any changes are made, rpcbind and NFS will need to be restarted:
 
 ```bash
-sudo systemctl restart `rpcbind`
+sudo systemctl restart rpcbind
 sudo systemctl restart nfs-kernel-server
 ```
 
@@ -283,20 +283,20 @@ sudo mkdir /nfs
 sudo mkdir /nfs/music
 ```
 
-1. Edit /etc/fstab to mount the NFS share into that directory instead:
+2. Edit `/etc/fstab` to mount the NFS share into that directory instead:
 
 ```
 nfsServer:music    /nfs/music    nfs    auto    0 0
 ```
 
-1. Create a symbolic link inside your home, pointing to the actual mount location. For example, and in this case deleting the `Music` directory already existing there first:
+3. Create a symbolic link inside your home, pointing to the actual mount location. For example, and in this case deleting the `Music` directory already existing there first:
 
 ```bash
 rmdir /home/user/Music
 ln -s /nfs/music/ /home/user/Music
 ```
 
-## Author Information
+## Author information
 
 This guide is based on documents on the official Ubuntu wiki:
 

--- a/configuration/nfs.md
+++ b/configuration/nfs.md
@@ -1,39 +1,39 @@
 # NFS - Network File System
 
-A "Network File System" allows you to share a directory located on one networked computer with other computers or devices on that network. The computer where the directory is located is called the server, and computers or devices connecting to that server are called clients. Clients usually mount the shared directory to make it a part of their own directory structure.
+A **Network File System** (NFS) allows you to share a directory located on one networked computer with other computers or devices on the same network. The computer where the directory is located is called the **server**, and computers or devices connecting to that server are called **clients**. Clients usually `mount` the shared directory to make it a part of their own directory structure. The shared directory is an example of a shared resource or network share.
 
-For smaller networks, a NFS is perfect for creating a simple NAS (Network-attached Storage) in a Linux/Unix environment.
+For smaller networks, an NFS is perfect for creating a simple NAS (Network-attached Storage) in a Linux/Unix environment.
 
-It is perhaps best suited to more permanent network-mounted directories, such as `/home` directories or regularly accessed shared resources. If you want a network share that guest users can easily connect to, Samba is better suited. This is because tools to temporarily mount and detach from Samba shares are more readily across old and proprietary operating systems.
+An NFS is perhaps best suited to more permanent network-mounted directories, such as `/home` directories or regularly-accessed shared resources. If you want a network share that guest users can easily connect to, Samba is better suited to the task. This is because tools to temporarily mount and detach from Samba shares are more readily available across old and proprietary operating systems.
 
-Ubuntu Before deploying a NFS you should be familiar with:
+Before deploying an NFS, you should be familiar with:
 
-1. Linux file and directory permissions
-2. Mounting and unmounting filesystems
+* Linux file and directory permissions
+* mounting and unmounting filesystems
 
-### Setup a basic NFS server
+## Set up a basic NFS server
 
-Install the below packages:
+Install the packages required using the command below:
 
 ```bash
 sudo apt install nfs-kernel-server
 ```
 
-For easier maintenance we will isolate all NFS exports in single directory, where the real directories will be mounted with the --bind option.
+For easier maintenance, we will isolate all NFS exports in single directory, into which the real directories will be mounted with the `--bind` option.
 
-Suppose we want to export our users' home directories in /home/users. First we create the export filesystem:
+Suppose we want to export our users' home directories, which are in `/home/users`. First we create the export filesystem:
 
 ```bash
 sudo mkdir -p /export/users
 ```
 
-Note that /export and /export/users will need 777 permissions as we will be accessing the NFS share from the client without LDAP/NIS authentication. This will not apply if using authentication (see below). Now mount the real users directory with:
+Note that `/export` and `/export/users` will need 777 permissions, as we will be accessing the NFS share from the client without LDAP/NIS authentication. This will not apply if using authentication (see below). Now mount the real `users` directory with:
 
 ```bash
 sudo mount --bind /home/users /export/users
 ```
 
-To save us from retyping this after every reboot we add the following line to `/etc/fstab` like so:
+To save us from retyping this after every reboot, we add the following line to `/etc/fstab`:
 
 ```
 /home/users    /export/users   none    bind  0  0
@@ -45,9 +45,9 @@ There are three configuration files that relate to an NFS server:
 1. `/etc/default/nfs-common`
 1. `/etc/exports`
 
-The only important option in `/etc/default/nfs-kernel-server` for now is `NEED_SVCGSSD`. It is set to "no" by default, which is fine, because we are not activating NFSv4 security this time.
+The only important option in `/etc/default/nfs-kernel-server` for now is `NEED_SVCGSSD`. It is set to `"no"` by default, which is fine, because we are not activating NFSv4 security this time.
 
-In order for the ID names to be automatically mapped, both the client and server require the `/etc/idmapd.conf` file to have the same contents with the correct domain names. Furthermore, this file should have the following lines in the Mapping section:
+In order for the ID names to be automatically mapped, the file `/etc/idmapd.conf` must exist on both the client and the server with the same contents and with the correct domain names. Furthermore, this file should have the following lines in the Mapping section:
 
 ```
 [Mapping]
@@ -56,14 +56,14 @@ Nobody-User = nobody
 Nobody-Group = nogroup
 ```
 
-Please note that the client may have different requirements for the Nobody-User and Nobody-Group. On RedHat variants, it is nfsnobody for both. So to ensure that these are actually present, check via the following commands to see if `nobody` is there:
+However, note that the client may have different requirements for the Nobody-User and Nobody-Group. For example, on RedHat variants, it is `nfsnobody` for both. If you're not sure, check via the following commands to see if `nobody` and `nogroup` are there:
 
 ```bash
 cat /etc/passwd
 cat /etc/group
 ```
 
-This way, server and client do not need the users to share same UID/GUID. For those who use LDAP-based authentication, add the following lines to the idmapd.conf of your clients:
+This way, server and client do not need the users to share same UID/GUID. For those who use LDAP-based authentication, add the following lines to the `idmapd.conf` of your clients:
 
 ```
 [Translation]
@@ -71,16 +71,17 @@ This way, server and client do not need the users to share same UID/GUID. For th
 Method = nsswitch
 ```
 
-This will cause idmapd to know to look at nsswitch.conf to determine where it should look for credential information. If you have LDAP authentication already working, nsswitch shouldn't require further explanation.
+This will cause `idmapd` to know to look at `nsswitch.conf` to determine where it should look for credential information. If you have LDAP authentication already working, `nsswitch` shouldn't require further explanation.
 
-To export our directories to a local network 192.168.1.0/24 we add the following two lines to `/etc/exports`:
+To export our directories to a local network `192.168.1.0/24`, we add the following two lines to `/etc/exports`:
 
 ```
 /export       192.168.1.0/24(rw,fsid=0,insecure,no_subtree_check,async)
 /export/users 192.168.1.0/24(rw,nohide,insecure,no_subtree_check,async)
 ```
 
-#### Portmap lockdown - optional
+### Portmap lockdown (optional)
+The files on your NFS are open to anyone on the network. As a security measure, you can restrict access to specified clients.
 
 Add the following line to `/etc/hosts.deny`:
 
@@ -88,7 +89,7 @@ Add the following line to `/etc/hosts.deny`:
 rpcbind mountd nfsd statd lockd rquotad : ALL
 ```
 
-By blocking all clients first, only clients in `/etc/hosts.allow` below will be allowed to access the server.
+By blocking all clients first, only clients in `/etc/hosts.allow` (added below) will be allowed to access the server. 
 
 Now add the following line to `/etc/hosts.allow`:
 
@@ -96,33 +97,33 @@ Now add the following line to `/etc/hosts.allow`:
 rpcbind mountd nfsd statd lockd rquotad : <list of IPv4s>
 ```
 
-Where "list of IPv4" is a list of IP addresses that consists of the server and all clients. These have to be IP addresses because of a limitation in rpcbind, which it doesn't like hostnames. Note that if you have NIS set up, just add these to the same line.
+Where `<list of IPv4s>` is a list of IP addresses that consists of the server and all clients. (These have to be IP addresses because of a limitation in `rpcbind`, which it doesn't like hostnames.) Note that if you have NIS set up, you can just add these to the same line.
 
-Please ensure that the list of authorised IP addresses includes the localhost address (127.0.0.1) as the startup scripts in recent versions of Ubuntu use the rpcinfo command to discover NFSv3 support, and this will be disabled if localhost is unable to connect.
+Please ensure that the list of authorised IP addresses includes the `localhost` address (`127.0.0.1`), as the startup scripts in recent versions of Ubuntu use the `rpcinfo` command to discover NFSv3 support, and this will be disabled if `localhost` is unable to connect.
 
-Afterwards, go ahead and restart the service:
+Finally, to make your changes take effect, restart the service:
 
 ```bash
 sudo systemctl restart nfs-kernel-server
 ```
 
-### Setup a NFSv4 client
+## Setup a NFSv4 client
 
-Install the required packages:
+Now that your server is running, you need to set up any clients to be able to access it. To start, install the required packages:
 
 ```bash
 sudo apt install nfs-common
 ```
 
-On the client we can mount the complete export tree with one command:
+On the client, we can mount the complete export tree with one command:
 
 ```bash
 mount -t nfs -o proto=tcp,port=2049 <nfs-server-IP>:/ /mnt
 ```
 
-You can also specify the NFS server hostname instead of its IP, but in this case you need to assure the hostname can be resolved to an IP on the client side. A robust way of ensuring this will always resolve is to use `/etc/hosts` file.
+You can also specify the NFS server hostname instead of its IP address, but in this case you need to ensure that the hostname can be resolved to an IP on the client side. A robust way of ensuring that this will always resolve is to use the `/etc/hosts` file.
 
-Note that `<nfs-server-IP>:/export` is not necessary in NFSv4, as it was in NFSv3. The root export :/ defaults to export with fsid=0.
+Note that `<nfs-server-IP>:/export` is not necessary in NFSv4, as it was in NFSv3. The root export `:/` defaults to export with `fsid=0`.
 
 We can also mount an exported subtree with:
 
@@ -136,9 +137,9 @@ To ensure this is mounted on every reboot, add the following line to `/etc/fstab
 <nfs-server-IP>:/   /mnt   nfs    auto  0  0
 ```
 
-If after mounting, the entry in `/proc/mounts appears` as `<nfs-server-IP>://` (with two slashes), then you might need to specify two slashes in `/etc/fstab`, or else umount might complain that it cannot find the mount.
+If after mounting, the entry in `/proc/mounts appears` as `<nfs-server-IP>://` (with two slashes), then you might need to specify two slashes in `/etc/fstab`, or else `umount` might complain that it cannot find the mount.
 
-#### Portmap lockdown - optional
+### Portmap lockdown (optional)
 
 Add the following line to `/etc/hosts.deny`:
 
@@ -154,9 +155,9 @@ Now add the following line to `/etc/hosts.allow`:
 rpcbind : <NFS server IP address>
 ```
 
-Where "NFS server IP address" is the IP address of the server.
+Where `<NFS server IP address>` is the IP address of the server.
 
-### NFS Server with complex user permissions
+## NFS Server with complex user permissions
 
 NFS user permissions are based on user ID (UID). UIDs of any users on the client must match those on the server in order for the users to have access. The typical ways of doing this are:
 
@@ -170,15 +171,15 @@ NFS user permissions are based on user ID (UID). UIDs of any users on the client
 
 Note that you have to be careful on systems where the main user has root access - that user can change UID's on the system to allow themselves access to anyone's files. This page assumes that the administrative team is the only group with root access and that they are all trusted. Anything else represents a more advanced configuration, and will not be addressed here.
 
-#### Group permissions
+### Group permissions
 
 File access is determined by his/her membership of groups on the client, not on the server. However, there is an important limitation: a maximum of 16 groups are passed from the client to the server, and, if a user is member of more than 16 groups on the client, some files or directories might be unexpectedly inaccessible.
 
-#### DNS - optional, only if using DNS
+### DNS - optional, only if using DNS
 
 Add any client name and IP addresses to `/etc/hosts`. The IP address of the server should already be here. This ensures that NFS will still work even if DNS goes down. You could rely on DNS if you wanted, it's up to you.
 
-#### NIS - optional, only if using NIS
+### NIS - optional, only if using NIS
 
 This applies to clients utilizing NIS. Otherwise you can't use netgroups and should specify individual IPs or hostnames in `/etc/exports`. Read the BUGS section in man netgroup.
 
@@ -196,7 +197,7 @@ Run this command to rebuild the YP database:
 sudo make -C /var/yp
 ```
 
-#### Portmap Lockdown - optional
+### Portmap Lockdown - optional
 
 Add the following line to `/etc/hosts.deny`:
 
@@ -212,7 +213,7 @@ rpcbind mountd nfsd statd lockd rquotad : <list of IPs>
 
 Where the "list of IPs" is a list of IP addresses that consists of the server and all clients. These have to be IP addresses because of a limitation in rpcbind. Note that if you have NIS set up, just add these to the same line.
 
-#### Package installation and configuration
+### Package installation and configuration
 
 Install the necessary packages:
 
@@ -251,7 +252,7 @@ sudo exportfs -ra
 
 You'll want to do this command whenever `/etc/exports` is modified.
 
-#### Restart Services
+### Restart Services
 
 By default, rpcbind only binds to the loopback interface. To enable access to rpcbind from remote machines, you need to change `/etc/conf.d/rpcbind` to get rid of either `-l` or `-i 127.0.0.1`.
 
@@ -262,7 +263,7 @@ sudo systemctl restart rpcbind
 sudo systemctl restart nfs-kernel-server
 ```
 
-#### Security items to consider
+### Security items to consider
 
 Aside from the UID issues discussed above, it should be noted that an attacker could potentially masquerade as a machine that is allowed to map the share, which allows them to create arbitrary UIDs to access your files. One potential solution to this is IPSec, see also the NFS and IPSec section below. You can set up all your domain members to talk only to each other over IPSec, which will effectively authenticate that your client is who it says it is.
 
@@ -270,7 +271,7 @@ IPSec works by encrypting traffic to the server with the server's key, and the s
 
 An alternative to IPSec is physically separate networks. This requires a separate network switch and separate ethernet cards, and physical security of that network.
 
-### Troubleshooting
+## Troubleshooting
 
 Mounting an NFS share inside an encrypted home directory will only work after you are successfully logged in and your home is decrypted. This means that using /etc/fstab to mount NFS shares on boot will not work - because your home has not been decrypted at the time of mounting. There is a simple way around this using Symbolic links:
 
@@ -294,9 +295,9 @@ rmdir /home/user/Music
 ln -s /nfs/music/ /home/user/Music
 ```
 
-### Author Information
+## Author Information
 
-This guide is based on a documents located on the official Ubuntu wiki:
+This guide is based on a document located on the official Ubuntu wiki:
 
 1. https://help.ubuntu.com/community/SettingUpNFSHowTo
 1. https://help.ubuntu.com/stable/serverguide/network-file-system.html

--- a/configuration/nfs.md
+++ b/configuration/nfs.md
@@ -1,7 +1,5 @@
 # NFS - Network File System
 
-Note: this guide is a *work-in-pending*, feel free to correct any mistakes or add additional information if it is missing or needed.
-
 The "Network File System" allows you to share a directory located on one networked computer with other computers/devices on that network. The computer where directory located is called the server and computers or devices connecting to that server are called clients. Clients usually 'mount' the shared directory to make it a part of their own directory structure.
 
 For smaller networks it is perfect for creating a simple NAS (Networked Attached Storage) in a Linux/Unix environment.

--- a/configuration/nfs.md
+++ b/configuration/nfs.md
@@ -1,0 +1,301 @@
+# NFS - Network File System
+
+NFS (Network File System) allows you to 'share' a directory located on one networked computer with other computers/devices on that network. The computer where directory located is called the server and computers or devices connecting to that server are called clients. Clients usually 'mount' the shared directory to make it a part of their own directory structure.
+
+NFS is perfect for creating NAS (Networked Attached Storage) in Linux/Unix environment. It is a native Linux/Unix protocol as opposed to Samba which uses the SMB protocol developed by Microsoft. Note that both Windows and Apple OS have good support for NFS.
+
+NFS is perhaps best for more permanent network mounted directories such as /home directories or regularly accessed shared resources. If you want a network share that guest users can easily connect to, Samba is more suited. This is because tools exist more readily across old and proprietary operating systems to temporarily mount and detach from Samba shares.
+
+Ubuntu Before deploying NFS you should be familiar with:
+
+1. Linux file and directory permissions
+1. Mounting and detaching (unmounting) filesystems 
+
+### Setup a basic NFS server
+
+Install the required packages...
+
+```
+sudo apt install nfs-kernel-server
+```
+
+For easier maintenance we will isolate all NFS exports in single directory, where the real directories will be mounted with the --bind option.
+
+Suppose we want to export our users' home directories in /home/users. First we create the export filesystem:
+
+```
+sudo mkdir -p /export/users 
+```
+
+Note that /export and /export/users will need 777 permissions as we will be accessing the NFS share from the client without LDAP/NIS authentication. This will not apply if using authentication (see below). Now mount the real users directory with:
+
+```
+sudo mount --bind /home/users /export/users
+```
+
+To save us from retyping this after every reboot we add the following line to `/etc/fstab` like so:
+
+```
+/home/users    /export/users   none    bind  0  0
+```
+
+There are three configuration files that relate to an NFS server:
+
+1. /etc/default/nfs-kernel-server
+1. /etc/default/nfs-common
+1. /etc/exports
+
+The only important option in `/etc/default/nfs-kernel-server` for now is `NEED_SVCGSSD`. It is set to "no" by default, which is fine, because we are not activating NFSv4 security this time.
+
+In order for the ID names to be automatically mapped, both the client and server require the `/etc/idmapd.conf` file to have the same contents with the correct domain names. Furthermore, this file should have the following lines in the Mapping section:
+
+```
+[Mapping]
+
+Nobody-User = nobody
+Nobody-Group = nogroup
+```
+
+Please note that the client may have different requirements for the Nobody-User and Nobody-Group. On RedHat variants, it is nfsnobody for both. So to ensure that these are actually present, check via the following commands to see if `nobody` is there:
+
+```
+cat /etc/passwd
+cat /etc/group
+```
+
+This way, server and client do not need the users to share same UID/GUID. For those who use LDAP-based authentication, add the following lines to the idmapd.conf of your clients:
+
+```
+[Translation]
+
+Method = nsswitch
+```
+
+This will cause idmapd to know to look at nsswitch.conf to determine where it should look for credential information. If you have LDAP authentication already working, nsswitch shouldn't require further explanation.
+
+To export our directories to a local network 192.168.1.0/24 we add the following two lines to `/etc/exports`:
+
+```
+/export       192.168.1.0/24(rw,fsid=0,insecure,no_subtree_check,async)
+/export/users 192.168.1.0/24(rw,nohide,insecure,no_subtree_check,async)
+```
+
+### Portmap Lockdown - optional
+
+Add the following line to `/etc/hosts.deny`:
+
+```
+rpcbind mountd nfsd statd lockd rquotad : ALL
+```
+
+By blocking all clients first, only clients in `/etc/hosts.allow` below will be allowed to access the server.
+
+Now add the following line to `/etc/hosts.allow`:
+
+```
+rpcbind mountd nfsd statd lockd rquotad : <list of IPv4s>
+```
+
+Where "list of IPv4" is a list of IP addresses that consists of the server and all clients. These have to be IP addresses because of a limitation in rpcbind, which it doesn't like hostnames. Note that if you have NIS set up, just add these to the same line.
+
+Note: Ensure that the list of authorised IP addresses includes the localhost address (127.0.0.1) as the startup scripts in recent versions of Ubuntu use the rpcinfo command to discover NFSv3 support, and this will be disabled if localhost is unable to connect.
+
+Go ahead and restart the service:
+
+```
+sudo systemctl restart nfs-kernel-server
+```
+
+### Setup a NFSv4 client
+
+Install the required packages:
+
+```
+sudo apt install nfs-common 
+```
+
+On the client we can mount the complete export tree with one command:
+
+```
+mount -t nfs -o proto=tcp,port=2049 <nfs-server-IP>:/ /mnt
+```
+
+You can also specify the NFS server hostname instead of its IP, but in this case you need to assure the hostname can be resolved to an IP on the client side. A robust way of ensuring this will always resolve is to use `/etc/hosts` file.
+
+Note that `<nfs-server-IP>:/export` is not necessary in NFSv4, as it was in NFSv3. The root export :/ defaults to export with fsid=0.
+
+We can also mount an exported subtree with:
+
+```
+mount -t nfs -o proto=tcp,port=2049 <nfs-server-IP>:/users /home/users
+```
+
+To ensure this is mounted on every reboot, add the following line to `/etc/fstab`:
+
+```
+<nfs-server-IP>:/   /mnt   nfs    auto  0  0
+```
+
+If after mounting, the entry in `/proc/mounts appears` as `<nfs-server-IP>://` (with two slashes), then you might need to specify two slashes in `/etc/fstab`, or else umount might complain that it cannot find the mount.
+
+### Portmap Lockdown - optional
+
+Add the following line to `/etc/hosts.deny`:
+
+```
+rpcbind : ALL
+```
+
+By blocking all clients first, only clients in `/etc/hosts.allow` below will be allowed to access the server.
+
+Now add the following line to `/etc/hosts.allow`:
+
+```
+rpcbind : <NFS server IP address>
+```
+
+Where "NFS server IP address" is the IP address of the server.
+
+### NFS Server with complex user permissions
+
+NFS user permissions are based on user ID (UID). UIDs of any users on the client must match those on the server in order for the users to have access. The typical ways of doing this are:
+
+1. Manual password file synchronization
+
+1. Use of LDAP
+
+1. Use of DNS
+
+1. Use of NIS 
+
+Note that you have to be careful on systems where the main user has root access - that user can change UID's on the system to allow themselves access to anyone's files. This page assumes that the administrative team is the only group with root access and that they are all trusted. Anything else represents a more advanced configuration, and will not be addressed here.
+
+#### Group permissions
+
+File access is determined by his/her membership of groups on the client, not on the server. However, there is an important limitation: a maximum of 16 groups are passed from the client to the server, and, if a user is member of more than 16 groups on the client, some files or directories might be unexpectedly inaccessible.
+
+#### DNS - optional, only if using DNS
+
+Add any client name and IP addresses to `/etc/hosts`. The IP address of the server should already be here. This ensures that NFS will still work even if DNS goes down. You could rely on DNS if you wanted, it's up to you.
+
+#### NIS - optional, only if using NIS
+
+This applies to clients utilizing NIS. Otherwise you can't use netgroups and should specify individual IPs or hostnames in `/etc/exports`. Read the BUGS section in man netgroup.
+
+Edit `/etc/netgroup` and add a line to classify your clients. (This step is not necessary, but is for convenience).
+
+```
+myclients (client1,,) (client2,,)
+```
+
+Where `myclients` is the netgroup name
+
+Run this command to rebuild the YP database:
+
+```
+sudo make -C /var/yp
+```
+
+#### Portmap Lockdown - optional
+
+Add the following line to `/etc/hosts.deny`:
+
+```
+rpcbind mountd nfsd statd lockd rquotad : ALL
+```
+
+By blocking all clients first, only clients in `/etc/hosts.allow` below will be allowed to access the server. Consider adding the following line:
+
+```
+rpcbind mountd nfsd statd lockd rquotad : <list of IPs>
+```
+
+Where the "list of IPs" is a list of IP addresses that consists of the server and all clients. These have to be IP addresses because of a limitation in rpcbind. Note that if you have NIS set up, just add these to the same line.
+
+#### Package installation and configuration
+
+Install the necessary packages:
+
+```
+sudo apt install rpcbind nfs-kernel-server
+```
+
+Edit `/etc/exports` and add the shares:
+
+```
+/home @myclients(rw,sync,no_subtree_check)
+/usr/local @myclients(rw,sync,no_subtree_check)
+```
+
+The above shares `/home` and `/usr/local` to all clients in the `myclients` netgroup.
+
+```
+/home 192.168.0.10(rw,sync,no_subtree_check) 192.168.0.11(rw,sync,no_subtree_check)
+/usr/local 192.168.0.10(rw,sync,no_subtree_check) 192.168.0.11(rw,sync,no_subtree_check)
+```
+
+Where the above shares `/home` and `/usr/local` are on two clients with static IP addresses. If you wanted instead allow to all clients in the private network falling within the designated ip address range, consider the following:
+
+```
+/home 192.168.0.0/255.255.255.0(rw,sync,no_subtree_check)
+/usr/local 192.168.0.0/255.255.255.0(rw,sync,no_subtree_check)
+```
+
+Where `rw` makes the share read/write, and `sync` requires the server to only reply to requests once any changes have been flushed to disk. This is the safest option; async is faster, but dangerous. It is strongly recommended that you read man exports if you are considering other options.
+
+After setting up `/etc/exports`, export the shares:
+
+```
+sudo exportfs -ra
+```
+
+You'll want to do this command whenever `/etc/exports` is modified.
+
+#### Restart Services
+
+By default, rpcbind only binds to the loopback interface. To enable access to rpcbind from remote machines, you need to change `/etc/default/rpcbind` to get rid of either `-l` or `-i 127.0.0.1`.
+
+If `/etc/default/rpcbind` was changed, rpcbind and NFS will need to be restarted:
+
+```
+sudo systemctl restart rpcbind
+sudo systemctl restart nfs-kernel-server
+```
+
+#### Security items to consider
+
+Aside from the UID issues discussed above, it should be noted that an attacker could potentially masquerade as a machine that is allowed to map the share, which allows them to create arbitrary UIDs to access your files. One potential solution to this is IPSec, see also the NFS and IPSec section below. You can set up all your domain members to talk only to each other over IPSec, which will effectively authenticate that your client is who it says it is.
+
+IPSec works by encrypting traffic to the server with the server's key, and the server sends back all replies encrypted with the client's key. The traffic is decrypted with the respective keys. If the client doesn't have the keys that the client is supposed to have, it can't send or receive data.
+
+An alternative to IPSec is physically separate networks. This requires a separate network switch and separate ethernet cards, and physical security of that network.
+
+### Troubleshooting
+
+Mounting an NFS share inside an encrypted home directory will only work after you are successfully logged in and your home is decrypted. This means that using /etc/fstab to mount NFS shares on boot will not work - because your home has not been decrypted at the time of mounting. There is a simple way around this using Symbolic links:
+
+1. Create an alternative directory to mount the NFS shares in: 
+
+```
+$ sudo mkdir /nfs
+$ sudo mkdir /nfs/music
+```
+
+1. Edit /etc/fstab to mount the NFS share into that directory instead: 
+
+```
+nfsServer:music    /nfs/music    nfs    auto    0 0
+```
+
+Create a symbolic link inside your home, pointing to the actual mount location. For example, in our case delete the 'Music' directory already existing there first: 
+
+```
+rmdir /home/user/Music
+ln -s /nfs/music/ /home/user/Music
+```
+
+### Author Information
+
+This guide is based on a write-up located on the official Ubuntu wiki:
+
+https://help.ubuntu.com/community/SettingUpNFSHowTo

--- a/configuration/nfs.md
+++ b/configuration/nfs.md
@@ -1,4 +1,4 @@
-# NFS - Network File System
+# Network File System (NFS)
 
 A **Network File System** (NFS) allows you to share a directory located on one networked computer with other computers or devices on the same network. The computer where the directory is located is called the **server**, and computers or devices connecting to that server are called **clients**. Clients usually `mount` the shared directory to make it a part of their own directory structure. The shared directory is an example of a shared resource or network share.
 


### PR DESCRIPTION
As per issue #986, there is currently no official NFS setup guide for the Raspberry Pi documentation repository. This branch attempts to borrow content from the official Ubuntu wiki and adapt it slightly for newer versions of Raspian and rpcbind and systemd.

Not the most elegantly written, however, I believe this could serve as a "first draft" for a future guide.