### PR TITLE
Adding some technical details regarding the Broadcom BCM2837B0 chip

### DIFF
--- a/hardware/raspberrypi/README.md
+++ b/hardware/raspberrypi/README.md
@@ -10,6 +10,8 @@ The hardware in the Raspberry Pi
     - The Broadcom processor used in Raspberry Pi 2
 - [BCM2837](bcm2837/README.md)
     - The Broadcom processor used in Raspberry Pi 3 (and later Raspberry Pi 2)
+- [BCM2837B0](bcm2837b0/README.md)
+    - The Broadcom processor used in Raspberry Pi 3B+
 - [Bootmodes](bootmodes/README.md)
     - A description of the BCM2835/6/7 bootmodes available 
 - [Mechanical drawings](mechanical/README.md)

--- a/hardware/raspberrypi/README.md
+++ b/hardware/raspberrypi/README.md
@@ -11,9 +11,9 @@ The hardware in the Raspberry Pi
 - [BCM2837](bcm2837/README.md)
     - The Broadcom processor used in Raspberry Pi 3 (and later Raspberry Pi 2)
 - [BCM2837B0](bcm2837b0/README.md)
-    - The Broadcom processor used in Raspberry Pi 3B+
+    - The Broadcom processor used in Raspberry Pi 3B+ and 3A+
 - [Bootmodes](bootmodes/README.md)
-    - A description of the BCM2835/6/7 bootmodes available 
+    - A description of the available BCM2835/6/7 bootmodes
 - [Mechanical drawings](mechanical/README.md)
     - Mechanical drawings of the Raspberry Pi
 - [Power](power/README.md)

--- a/hardware/raspberrypi/bcm2837b0/README.md
+++ b/hardware/raspberrypi/bcm2837b0/README.md
@@ -1,12 +1,12 @@
 # BCM2837B0
 
-This is the Broadcom chip used in the Raspberry Pi 3B+. The underlying architecture of the BCM2837B0 is identical to the BCM2837A0 chip used in other versions of the Pi. The ARM core hardware is the same, only the frequency is rated higher.
+This is the Broadcom chip used in the Raspberry Pi 3B+ and 3A+. The underlying architecture of the BCM2837B0 is identical to the BCM2837A0 chip used in other versions of the Pi. The ARM core hardware is the same, only the frequency is rated higher.
 
- The ARM cores are capable of running up to 1.4GHz, making the device about 17% faster than the original Raspberry Pi 3. The VideoCore IV runs at 400MHz. The ARM core is 64-bit while the VideoCore IV is 32-bit.
+The ARM cores are capable of running at up to 1.4GHz, making the 3B+/3A+ about 17% faster than the original Raspberry Pi 3. The VideoCore IV runs at 400MHz. The ARM core is 64-bit, while the VideoCore IV is 32-bit.
 
-Regarding the BCM2837B0 chip itself, it is packaged slightly differently than the BCM2837A0 and most notably includes a heat spreader for better thermals. These allow higher clock frequencies (or to run at lower voltages to reduce power consumption), and to more accurately monitor and control the temperature of the chip.
+The BCM2837B0 chip is packaged slightly differently to the BCM2837A0, and most notably includes a heat spreader for better thermals. These allow higher clock frequencies (or running at lower voltages to reduce power consumption), and more accurate monitoring and control of the chip's temperature.
 
-This [blog post](https://www.raspberrypi.org/blog/raspberry-pi-3-model-bplus-sale-now-35/) on the official Raspberry Pi foundation website goes into further detail about the BCM2837B0 chip.
+[This post on the Raspberry Pi blog](https://www.raspberrypi.org/blog/raspberry-pi-3-model-bplus-sale-now-35/) goes into further detail about the BCM2837B0 chip.
 
 Also see the following documents for information about the previous Raspberry Pi chips:
 

--- a/hardware/raspberrypi/bcm2837b0/README.md
+++ b/hardware/raspberrypi/bcm2837b0/README.md
@@ -1,0 +1,16 @@
+# BCM2837B0
+
+This is the Broadcom chip used in the Raspberry Pi 3B+. The underlying architecture of the BCM2837B0 is identical to the BCM2836 and BCM2837. The only significant difference is the replacement of the ARMv7 quad core cluster with a quad-core ARM Cortex A53 (ARMv8) cluster.
+
+The ARM cores run at 1.4GHz, making the device about 17% faster than the original Raspberry Pi 3. The VideoCore IV runs at 400MHz.
+
+Regarding the BCM2837B0 chip itself, it is an updated version of the 64-bit Broadcom application processor used in Raspberry Pi 3B, which incorporates power integrity optimisations, and a heat spreader. These allow higher clock frequencies (or to run at lower voltages to reduce power consumption), and to more accurately monitor and control the temperature of
+the chip.
+
+This [blog post](https://www.raspberrypi.org/blog/raspberry-pi-3-model-bplus-sale-now-35/) on the official Raspberry Pi foundation website goes into further detail about the BCM2837B0 chip.
+
+Also see the following documents for information about the previous Raspberry Pi chips:
+
+* Raspberry Pi 3 chip [BCM2837](../bcm2837/README.md)
+* Raspberry Pi 2 chip [BCM2836](../bcm2836/README.md)
+* Raspberry Pi 1 chip [BCM2835](../bcm2835/README.md)

--- a/hardware/raspberrypi/bcm2837b0/README.md
+++ b/hardware/raspberrypi/bcm2837b0/README.md
@@ -2,7 +2,7 @@
 
 This is the Broadcom chip used in the Raspberry Pi 3B+. The underlying architecture of the BCM2837B0 is identical to the BCM2837A0 chip used in other versions of the Pi. The ARM core hardware is the same, only the frequency is rated higher.
 
-The ARM cores run at 1.4GHz, making the device about 17% faster than the original Raspberry Pi 3. The VideoCore IV runs at 400MHz. The ARM core is 64-bit while the VideoCore IV is 32-bit.
+ The ARM cores are capable of running up to 1.4GHz, making the device about 17% faster than the original Raspberry Pi 3. The VideoCore IV runs at 400MHz. The ARM core is 64-bit while the VideoCore IV is 32-bit.
 
 Regarding the BCM2837B0 chip itself, it is packaged slightly differently than the BCM2837A0 and most notably includes a heat spreader for better thermals. These allow higher clock frequencies (or to run at lower voltages to reduce power consumption), and to more accurately monitor and control the temperature of the chip.
 

--- a/hardware/raspberrypi/bcm2837b0/README.md
+++ b/hardware/raspberrypi/bcm2837b0/README.md
@@ -1,11 +1,10 @@
 # BCM2837B0
 
-This is the Broadcom chip used in the Raspberry Pi 3B+. The underlying architecture of the BCM2837B0 is identical to the BCM2836 and BCM2837. The only significant difference is the replacement of the ARMv7 quad core cluster with a quad-core ARM Cortex A53 (ARMv8) cluster.
+This is the Broadcom chip used in the Raspberry Pi 3B+. The underlying architecture of the BCM2837B0 is identical to the BCM2837A0 chip used in other versions of the Pi. The ARM core hardware is the same, only the frequency is rated higher.
 
-The ARM cores run at 1.4GHz, making the device about 17% faster than the original Raspberry Pi 3. The VideoCore IV runs at 400MHz.
+The ARM cores run at 1.4GHz, making the device about 17% faster than the original Raspberry Pi 3. The VideoCore IV runs at 400MHz. The ARM core is 64-bit while the VideoCore IV is 32-bit.
 
-Regarding the BCM2837B0 chip itself, it is an updated version of the 64-bit Broadcom application processor used in Raspberry Pi 3B, which incorporates power integrity optimisations, and a heat spreader. These allow higher clock frequencies (or to run at lower voltages to reduce power consumption), and to more accurately monitor and control the temperature of
-the chip.
+Regarding the BCM2837B0 chip itself, it is packaged slightly differently than the BCM2837A0 and most notably includes a heat spreader for better thermals. These allow higher clock frequencies (or to run at lower voltages to reduce power consumption), and to more accurately monitor and control the temperature of the chip.
 
 This [blog post](https://www.raspberrypi.org/blog/raspberry-pi-3-model-bplus-sale-now-35/) on the official Raspberry Pi foundation website goes into further detail about the BCM2837B0 chip.
 


### PR DESCRIPTION
As the title mentions, this adds a page for the newer chip used in the latest Pi 3B+ models.