### PR TITLE
Add missing step for bridge access point setup

### DIFF
--- a/configuration/wireless/access-point.md
+++ b/configuration/wireless/access-point.md
@@ -229,6 +229,18 @@ wpa_pairwise=TKIP
 rsn_pairwise=CCMP
 ```
 
+We now need to tell the system where to find this configuration file.
+
+```
+sudo nano /etc/default/hostapd
+```
+
+Find the line with #DAEMON_CONF, and replace it with this:
+
+```
+DAEMON_CONF="/etc/hostapd/hostapd.conf"
+```
+
 Now reboot the Raspberry Pi.
 ```
 sudo reboot


### PR DESCRIPTION
This PR add a missing step, which is mentioned in `Setting up a Raspberry Pi as an access point in a standalone network`, but not in `Using the Raspberry Pi as an access point to share an internet connection (bridge)`.

https://www.raspberrypi.org/documentation/configuration/wireless/access-point.md