### PR TITLE
Clarify options for USB host MSD and ethernet booting

### DIFF
--- a/hardware/raspberrypi/bootmodes/README.md
+++ b/hardware/raspberrypi/bootmodes/README.md
@@ -4,7 +4,7 @@
 
 The Raspberry Pi has a number of different stages of booting. This document is meant to help explain how the boot modes work, and which ones are supported for Linux booting.
 
-[Description of Boot Sequence](bootflow.md)
+[Boot Sequence](bootflow.md)
 
 [SD card boot](sdcard.md)
 

--- a/hardware/raspberrypi/bootmodes/README.md
+++ b/hardware/raspberrypi/bootmodes/README.md
@@ -2,7 +2,7 @@
 
 ## Introduction
 
-The Raspberry Pi has a number of different stages of booting. This document is explains how the boot modes work, and which ones are supported for Linux booting.
+The Raspberry Pi has a number of different stages of booting. This document explains how the boot modes work, and which ones are supported for Linux booting.
 
 [Boot Sequence](bootflow.md)
 

--- a/hardware/raspberrypi/bootmodes/README.md
+++ b/hardware/raspberrypi/bootmodes/README.md
@@ -16,11 +16,11 @@ The Raspberry Pi has a number of different stages of booting. This document is m
   
 ## Special bootcode.bin-only boot mode
 
-For the original Raspberry Pi and the Raspberry Pi 2 (based on the BCM2835 and BCM2836 devices), and in situations where the Pi 3 fails to boot, there is a new method of booting from one of the new boot modes (MSD or ethernet).
+In addition to the ability to do USB host and ethernet boot on the BCM2837-based Raspberry Pi's, all Raspberry Pi's can use a new bootcode.bin only method to enable USB host and ethernet booting.
 
 Just format an SD card as FAT32 and copy on the latest [bootcode.bin](https://github.com/raspberrypi/firmware/raw/master/boot/bootcode.bin). 
 
-This will then enable the new bootmodes with some bug fixes for the failing Pi 3 cases.
+This is useful for the Raspberry Pi and the Raspberry Pi 2 (based on the BCM2835 and BCM2836 devices), and in situations where a Pi 3 fails to boot since there are additional bugfixes included for the Pi 3, compared to the boot code burned into the BCM2837.
 
 If you have a problem with a mass storage device still not working even with this bootcode.bin, then please add a new file 'timeout' to the SD card. This should extend the time it waits for the mass storage device to initialise to six seconds.
 

--- a/hardware/raspberrypi/bootmodes/README.md
+++ b/hardware/raspberrypi/bootmodes/README.md
@@ -8,7 +8,7 @@ The Raspberry Pi has a number of different stages of booting. This document expl
 
 [SD card boot](sdcard.md)
 
-[USB boot ](usb.md) comprising the following 2 modes:
+[USB boot](usb.md) comprising the following 2 modes:
 * [Device boot](device.md): Booting as a mass storage device
 * [Host boot](host.md): Booting as a USB host using the following:
   * [Mass storage boot](msd.md): Boot from mass Storage Device

--- a/hardware/raspberrypi/bootmodes/README.md
+++ b/hardware/raspberrypi/bootmodes/README.md
@@ -2,7 +2,7 @@
 
 ## Introduction
 
-The Raspberry Pi has a number of different stages of booting. This document is meant to help explain how the boot modes work, and which ones are supported for Linux booting.
+The Raspberry Pi has a number of different stages of booting. This document is explains how the boot modes work, and which ones are supported for Linux booting.
 
 [Boot Sequence](bootflow.md)
 

--- a/hardware/raspberrypi/bootmodes/README.md
+++ b/hardware/raspberrypi/bootmodes/README.md
@@ -12,7 +12,7 @@ The Raspberry Pi has a number of different stages of booting. This document expl
 * [Device boot](device.md): booting as a mass storage device
 * [Host boot](host.md): booting as a USB host using one of the following:
   * [Mass storage boot](msd.md): boot from mass storage device
-  * [Network boot](net.md): Boot via Ethernet
+  * [Network boot](net.md): boot via Ethernet
   
 ## Special bootcode.bin-only boot mode
 USB host and Ethernet boot can be performed by BCM2837-based Raspberry Pis (these are all Pi 3 models, and some Pi 2Bs). In addition, all Raspberry Pi models can use a new bootcode.bin-only method to enable USB host and Ethernet booting.

--- a/hardware/raspberrypi/bootmodes/README.md
+++ b/hardware/raspberrypi/bootmodes/README.md
@@ -4,14 +4,16 @@
 
 The Raspberry Pi has a number of different stages of booting. This document is meant to help explain how the boot modes work, and which ones are supported for Linux booting.
 
-* [Bootflow](bootflow.md): Boot sequence description
-* [SD card](sdcard.md): SD card boot description
-* [USB](usb.md): USB boot description
-  * [Device boot](device.md): Booting as a mass storage device
-  * [Host boot](host.md): Booting as a USB host
-    * [Mass storage boot](msd.md): Boot from Mass Storage Device (MSD)
-    * [Network boot](net.md): Boot from ethernet
+[Description of Boot Sequence](bootflow.md)
 
+[SD card boot](sdcard.md)
+
+[USB boot ](usb.md) comprising the following 2 modes:
+* [Device boot](device.md): Booting as a mass storage device
+* [Host boot](host.md): Booting as a USB host using the following:
+  * [Mass storage boot](msd.md): Boot from mass Storage Device
+  * [Network boot](net.md): Boot from ethernet
+  
 ## Special bootcode.bin-only boot mode
 
 For the original Raspberry Pi and the Raspberry Pi 2 (based on the BCM2835 and BCM2836 devices), and in situations where the Pi 3 fails to boot, there is a new method of booting from one of the new boot modes (MSD or ethernet).

--- a/hardware/raspberrypi/bootmodes/README.md
+++ b/hardware/raspberrypi/bootmodes/README.md
@@ -8,19 +8,18 @@ The Raspberry Pi has a number of different stages of booting. This document expl
 
 [SD card boot](sdcard.md)
 
-[USB boot](usb.md) comprising the following 2 modes:
-* [Device boot](device.md): Booting as a mass storage device
-* [Host boot](host.md): Booting as a USB host using the following:
-  * [Mass storage boot](msd.md): Boot from mass Storage Device
-  * [Network boot](net.md): Boot from ethernet
+[USB boot](usb.md) comprises the following two modes:
+* [Device boot](device.md): booting as a mass storage device
+* [Host boot](host.md): booting as a USB host using one of the following:
+  * [Mass storage boot](msd.md): boot from mass storage device
+  * [Network boot](net.md): Boot via Ethernet
   
 ## Special bootcode.bin-only boot mode
-
-In addition to the ability to do USB host and ethernet boot on the BCM2837-based Raspberry Pi's, all Raspberry Pi's can use a new bootcode.bin only method to enable USB host and ethernet booting.
+USB host and Ethernet boot can be performed by BCM2837-based Raspberry Pis (these are all Pi 3 models, and some Pi 2Bs). In addition, all Raspberry Pi models can use a new bootcode.bin-only method to enable USB host and Ethernet booting.
 
 Just format an SD card as FAT32 and copy on the latest [bootcode.bin](https://github.com/raspberrypi/firmware/raw/master/boot/bootcode.bin). 
 
-This is useful for the Raspberry Pi and the Raspberry Pi 2 (based on the BCM2835 and BCM2836 devices), and in situations where a Pi 3 fails to boot since there are additional bugfixes included for the Pi 3, compared to the boot code burned into the BCM2837.
+This is useful for the Raspberry Pi 1, 2, and Zero models, which are based on the BCM2835 and BCM2836 devices, and in situations where a Pi 3 fails to boot (the latest bootcode.bin includes additional bugfixes for the Pi 3, compared to the boot code burned into the BCM2837).
 
 If you have a problem with a mass storage device still not working even with this bootcode.bin, then please add a new file 'timeout' to the SD card. This should extend the time it waits for the mass storage device to initialise to six seconds.
 

--- a/hardware/raspberrypi/bootmodes/usb.md
+++ b/hardware/raspberrypi/bootmodes/usb.md
@@ -4,11 +4,11 @@ There are two separate boot modes for USB:
 
 * [USB device boot](device.md)
 * [USB host boot](host.md) with boot options:
-  * [USB Mass storage boot](msd.md)
+  * [USB mass storage boot](msd.md)
   * [Network boot](net.md)
 
-Note that network boot is only possible from the wired ethernet interfaces built into certain models of Raspberry Pi.
+Note that network boot is only possible on Raspberry Pi models that have a built-in wired Ethernet interface.
 
-The choice between the two boot modes is made at boot time by the firmware by reading the OTP bits. There are two bits to control USB boot: the first enables device boot and is enabled by default on all Raspberry Pi devices. The second bit enables USB host boot; if this bit is also set then the processor reads the OTGID pin to decide whether to boot as a host (driven to zero as on the Raspberry Pi Model B) or as a device (left floating). The Pi Zero has access to this pin through the OTGID pin on the USB connector, and the compute module has access to this pin on the edge connector.
+The choice between the two boot modes is made by the firmware at boot time when it reads the OTP bits. There are two bits to control USB boot: the first enables device boot and is enabled by default on all Raspberry Pi computers. The second bit enables USB host boot; if this bit is also set, then the processor reads the OTGID pin to decide whether to boot as a host (driven to zero as on the Raspberry Pi Model B) or as a device (left floating). The Pi Zero has access to this pin through the OTGID pin on the USB connector, and the Compute Module has access to this pin on the edge connector.
 
-There are also OTP bits to allow certain GPIO pins to be used to select which boot modes the Pi should attempt to use.
+There are also OTP bits that allow certain GPIO pins to be used for selecting which boot modes the Pi should attempt to use.

--- a/hardware/raspberrypi/bootmodes/usb.md
+++ b/hardware/raspberrypi/bootmodes/usb.md
@@ -7,7 +7,7 @@ There are two separate boot modes for USB:
   * [USB Mass storage boot](msd.md)
   * [Network boot](net.md)
 
-Note that network boot is only possible from the USB-attached network interfaces built into certain models of Raspberry Pi.
+Note that network boot is only possible from the wired ethernet interfaces built into certain models of Raspberry Pi.
 
 The choice between the two boot modes is made at boot time by the firmware by reading the OTP bits. There are two bits to control USB boot: the first enables device boot and is enabled by default on all Raspberry Pi devices. The second bit enables USB host boot; if this bit is also set then the processor reads the OTGID pin to decide whether to boot as a host (driven to zero as on the Raspberry Pi Model B) or as a device (left floating). The Pi Zero has access to this pin through the OTGID pin on the USB connector, and the compute module has access to this pin on the edge connector.
 

--- a/hardware/raspberrypi/bootmodes/usb.md
+++ b/hardware/raspberrypi/bootmodes/usb.md
@@ -1,14 +1,14 @@
 # USB boot modes
 
-There are four different boot modes for USB: 
+There are two separate boot modes for USB: 
 
-* [USB host boot](host.md)
 * [USB device boot](device.md)
-* [USB Mass storage boot](msd.md)
-* [Network boot](net.md)
+* [USB host boot](host.md) with boot options:
+  * [USB Mass storage boot](msd.md)
+  * [Network boot](net.md)
 
 Note that network boot is only possible from the USB-attached network interfaces built into certain models of Raspberry Pi.
 
-The choice between the four modes is made at boot time by reading the OTP bits. There are three bits to control USB boot: the first enables device boot and is enabled by default on all Raspberry Pi devices. The second bit enables USB host boot; if this bit is also set then the processor reads the OTGID pin to decide whether to boot as a host (driven to zero as on the Raspberry Pi Model B) or as a device (left floating). The Pi Zero has access to this pin through the OTGID pin on the USB connector, and the compute module has access to this pin on the edge connector. The third OTP bit enables both USB mass storage boot and network boot. There are also OTP bits to allow certain GPIO pins to be used to select which boot modes the Pi should attempt to use.
+The choice between the two boot modes is made at boot time by the firmware by reading the OTP bits. There are two bits to control USB boot: the first enables device boot and is enabled by default on all Raspberry Pi devices. The second bit enables USB host boot; if this bit is also set then the processor reads the OTGID pin to decide whether to boot as a host (driven to zero as on the Raspberry Pi Model B) or as a device (left floating). The Pi Zero has access to this pin through the OTGID pin on the USB connector, and the compute module has access to this pin on the edge connector.
 
-
+There are also OTP bits to allow certain GPIO pins to be used to select which boot modes the Pi should attempt to use.

--- a/hardware/raspberrypi/bootmodes/usb.md
+++ b/hardware/raspberrypi/bootmodes/usb.md
@@ -1,6 +1,14 @@
 # USB boot modes
 
-There are two separate boot modes for USB: the device and the host boot modes. The choice between the two modes is made at boot time by reading the OTP bits. There are two bits to control USB boot: the first enables device boot and is enabled by default on all Raspberry Pi devices. The second bit enables USB host boot; if this bit is also set then the processor reads the OTGID pin to decide whether to boot as a host (driven to zero as on the Raspberry Pi Model B) or as a device (left floating). The Pi Zero has access to this pin through the OTGID pin on the USB connector, and the compute module has access to this pin on the edge connector.
+There are four different boot modes for USB: 
 
 * [USB host boot](host.md)
 * [USB device boot](device.md)
+* [USB Mass storage boot](msd.md)
+* [Network boot](net.md)
+
+Note that network boot is only possible from the USB-attached network interfaces built into certain models of Raspberry Pi.
+
+The choice between the four modes is made at boot time by reading the OTP bits. There are three bits to control USB boot: the first enables device boot and is enabled by default on all Raspberry Pi devices. The second bit enables USB host boot; if this bit is also set then the processor reads the OTGID pin to decide whether to boot as a host (driven to zero as on the Raspberry Pi Model B) or as a device (left floating). The Pi Zero has access to this pin through the OTGID pin on the USB connector, and the compute module has access to this pin on the edge connector. The third OTP bit enables both USB mass storage boot and network boot. There are also OTP bits to allow certain GPIO pins to be used to select which boot modes the Pi should attempt to use.
+
+


### PR DESCRIPTION
I'm including the net boot mode here since it is listed under USB boot modes on documentation/hardware/raspberrypi/bootmodes/readme.md, and the network interfaces supported are all connected via USB.