### PR TITLE
Fix broken link to Avahi Wikipedia Page

### DIFF
--- a/remote-access/ip-address.md
+++ b/remote-access/ip-address.md
@@ -20,7 +20,7 @@ In a web browser navigate to your router's IP address e.g. `http://192.168.1.1`,
 
 ### Resolving `raspberrypi.local` with mDNS
 
-On Raspbian, [multicast DNS](https://en.wikipedia.org/wiki/Multicast_DNS) is supported out-of-the-box by the [Avahi](https://en.wikipedia.org/wiki/Avahi_(software)) service.
+On Raspbian, [multicast DNS](https://en.wikipedia.org/wiki/Multicast_DNS) is supported out-of-the-box by the [Avahi](https://en.wikipedia.org/wiki/Avahi_%28software%29) service.
 
 If your device supports mDNS, you can reach your Raspberry Pi by using its hostname and the `.local` suffix.
 The default hostname on a fresh Raspbian install is `raspberrypi`, so by default any Raspberry Pi running Raspbian responds to:


### PR DESCRIPTION
The markdown renderer at <https://www.raspberrypi.org/documentation/remote-access/ip-address.md> seems to have a bug in it, since it thinks the markdown:

```md
[Avahi](https://en.wikipedia.org/wiki/Avahi_(software))
```

is a link to <https://en.wikipedia.org/wiki/Avahi_(software>, missing the final `)` and placing it into the text, ie:

```html
<a href="https://en.wikipedia.org/wiki/Avahi_(software">Avahi</a>)
```

By percent encoding the parentheses with `%28` and `%29`, this will be avoided.

Other potential solutions are discussed here <https://meta.stackexchange.com/a/13509> but URL encoding is probably the most likely to work.