### PR TITLE
cmdline-txt.md: add documentation

### DIFF
--- a/configuration/cmdline-txt.md
+++ b/configuration/cmdline-txt.md
@@ -25,7 +25,7 @@ There are many kernel command line parameters, some of which are defined by the 
 
  - splash: tells the boot to use a splash screen via the Plymouth module.
  - plymouth.ignore_serial_console - tells Plymouth not to output a boot splash on any serial console which may be configured.
- - dwc_otg.lpm_enable: turns off Link Power Management (LPM) in the dwc_otg driver. The dwc_otg driver is the driver for the USB controller built into the Raspberry Pi
+ - dwc_otg.lpm_enable: turns off Link Power Management (LPM) in the dwc_otg driver. The dwc_otg driver is the driver for the USB controller built into the Raspberry Pi.
  - dwc_otg.speed: sets the speed of the USB controller. `dwc_otg.speed=1` will set it to full speed (USB 1.0).
  - smsc95xx.turbo_mode: enables/disables the wired networking driver turbo mode. `smsc95xx.turbo_mode=N` turns turbo mode off.
  - usbhid.mousepoll: specifies the mouse polling interval. If you have problems with a slow or erratic wireless mouse, setting this to 0 might help: `usbhid.mousepoll=0`.

--- a/configuration/cmdline-txt.md
+++ b/configuration/cmdline-txt.md
@@ -26,7 +26,7 @@ There are many kernel command line parameters, some of which are defined by the 
  - splash: tells the boot to use a splash screen via the Plymouth module.
  - plymouth.ignore_serial_console - tells Plymouth not to output a boot splash on any serial console which may be configured.
  - dwc_otg.lpm_enable: turns off Link Power Management (LPM) in the dwc_otg driver. The dwc_otg driver is the driver for the USB controller built into the Raspberry Pi.
- - dwc_otg.speed: sets the speed of the USB controller. `dwc_otg.speed=1` will set it to full speed (USB 1.0).
+ - dwc_otg.speed: sets the speed of the USB controller. `dwc_otg.speed=1` will set it to full speed (USB 1.0), which is slower than high speed (USB 2.0). This option should not be set except when troubleshooting problems with USB devices.
  - smsc95xx.turbo_mode: enables/disables the wired networking driver turbo mode. `smsc95xx.turbo_mode=N` turns turbo mode off.
  - usbhid.mousepoll: specifies the mouse polling interval. If you have problems with a slow or erratic wireless mouse, setting this to 0 might help: `usbhid.mousepoll=0`.
 

--- a/configuration/cmdline-txt.md
+++ b/configuration/cmdline-txt.md
@@ -24,9 +24,9 @@ There are many kernel command line parameters, some of which are defined by the 
 #### Other Entries (not exhaustive)
 
  - splash: tells the boot to use a splash screen via the Plymouth module.
- - plymouth.ignore_serial_console - tells Plymouth not to output a boot splash on any serial console which may be configured.
- - dwc_otg.lpm_enable: turns off Link Power Management (LPM) in the dwc_otg driver. The dwc_otg driver is the driver for the USB controller built into the Raspberry Pi.
- - dwc_otg.speed: sets the speed of the USB controller. `dwc_otg.speed=1` will set it to full speed (USB 1.0), which is slower than high speed (USB 2.0). This option should not be set except when troubleshooting problems with USB devices.
+ - plymouth.ignore_serial_console: tells Plymouth not to output a boot splash on any serial console which may be configured.
+ - dwc_otg.lpm_enable: turns off Link Power Management (LPM) in the dwc_otg driver; the dwc_otg driver is the driver for the USB controller built into the Raspberry Pi.
+ - dwc_otg.speed: sets the speed of the USB controller. `dwc_otg.speed=1` will set it to full speed (USB 1.0), which is slower than high speed (USB 2.0). This option should not be set except during troubleshooting of problems with USB devices.
  - smsc95xx.turbo_mode: enables/disables the wired networking driver turbo mode. `smsc95xx.turbo_mode=N` turns turbo mode off.
  - usbhid.mousepoll: specifies the mouse polling interval. If you have problems with a slow or erratic wireless mouse, setting this to 0 might help: `usbhid.mousepoll=0`.
 

--- a/configuration/cmdline-txt.md
+++ b/configuration/cmdline-txt.md
@@ -24,9 +24,9 @@ There are many kernel command line parameters, some of which are defined by the 
 #### Other Entries (not exhaustive)
 
  - splash: tells the boot to use a splash screen via the Plymouth module.
- - plymouth.ignore_serial_console
- - dwc_otg.lpm_enable: turns off LPM in the dwc_otg (On The Go) driver.
- - dwc_otg.speed: sets the speed of the USB property. `dwc_otg.speed=1` will set it to USBv1.0 speed.
+ - plymouth.ignore_serial_console - tells Plymouth not to output a boot splash on any serial console which may be configured.
+ - dwc_otg.lpm_enable: turns off Link Power Management (LPM) in the dwc_otg driver. The dwc_otg driver is the driver for the USB controller built into the Raspberry Pi
+ - dwc_otg.speed: sets the speed of the USB controller. `dwc_otg.speed=1` will set it to full speed (USB 1.0).
  - smsc95xx.turbo_mode: enables/disables the wired networking driver turbo mode. `smsc95xx.turbo_mode=N` turns turbo mode off.
  - usbhid.mousepoll: specifies the mouse polling interval. If you have problems with a slow or erratic wireless mouse, setting this to 0 might help: `usbhid.mousepoll=0`.
 


### PR DESCRIPTION
Improve documentation of:

- plymouth.ignore_serial_console (not currently explained)
- dwc_org.lpm_enable
- dwc_otg.speed