### PR TITLE
Adjusting networking boot tutorial in net_tutorial.md

### DIFF
--- a/hardware/raspberrypi/bootmodes/net_tutorial.md
+++ b/hardware/raspberrypi/bootmodes/net_tutorial.md
@@ -6,13 +6,13 @@ Due to the huge range of networking devices available, we can't guarantee that n
 
 ## Client configuration
 
-This section only applies to the *original* Raspberry Pi 3; if you are using the new 3+ then this can be ignored. Skip to the server section below then.
+This section only applies to the **original** Raspberry Pi 3B; if you are using the 3B+, then ignore this section and skip to the server section below then.
 
 Before a Raspberry Pi will network boot, it needs to be booted from an SD card with a config option to enable USB boot mode. This will set a bit in the OTP (One Time Programmable) memory in the Raspberry Pi SoC that enables network booting. Once this is done, the SD card is no longer required. 
 
 Install Raspbian Lite (or Raspbian with Raspberry Pi Desktop) on the SD card in the [usual way](../../../installation/installing-images/README.md). 
 
-Afterwards, setup program USB boot mode by preparing the `/boot` directory with the latest boot files:
+Afterwards, set up USB boot mode by preparing the `/boot` directory with the latest boot files:
 
 ```bash
 sudo apt update && sudo apt upgrade
@@ -37,9 +37,9 @@ The client configuration is almost done. The final thing to do is to remove the 
 
 ## Server configuration
 
-Plug the SD card into the server Raspberry Pi and then boot the server. Before you do anything else, make sure you have run `sudo raspi-config` and expanded the root filesystem to take up the entire SD card.
+Plug the SD card into the server Raspberry Pi, and then boot the server. Before you do anything else, make sure you have run `sudo raspi-config` and expanded the root file system to take up the entire SD card.
 
-The client Raspberry Pi will need a root filesystem to boot off, so before we do anything else on the server, make a full copy of its filesystem and put it in a directory called `/nfs/client1`:
+The client Raspberry Pi will need a root file system to boot off, so before you do anything else on the server, make a full copy of its file system and put it in a directory called `/nfs/client1`:
 
 ```bash
 sudo mkdir -p /nfs/client1
@@ -87,7 +87,7 @@ Finally, note down the address of your DNS server, which is the same address as 
 cat /etc/resolv.conf
 ```
 
-Configure a static network address on your server Raspberry Pi via the systemd-networking, which works as the network handler and DHCP server.
+Configure a static network address on your server Raspberry Pi via the `systemd` networking, which works as the network handler and DHCP server.
 
 To do that, you'll need to to create a `10-eth0.netdev` and a `11-eth0.network` like so:
 
@@ -125,7 +125,7 @@ DNS=10.42.0.1
 Gateway=10.42.0.1
 ```
 
-At this point, you won't have working DNS, so you'll need to add the server you noted down before to systemd resolv. In this example the gateway address is 10.42.0.1
+At this point, you won't have working DNS, so you'll need to add the server you noted down before to `systemd/resolved.conf`. In this example, the gateway address is 10.42.0.1.
 
 ```bash
 sudo nano /etc/systemd/resolved.conf
@@ -139,14 +139,14 @@ DNS=10.42.0.1
 #FallbackDNS=
 ```
 
-Enable systemd-networkd and then reboot for the changes to take effect:
+Enable `systemd-networkd` and then reboot for the changes to take effect:
 
 ```bash
 sudo systemctl enable systemd-networkd
 sudo reboot
 ```
 
-Now start tcpdump so you can search for DHCP packets from the client Raspberry Pi:
+Now start `tcpdump` so you can search for DHCP packets from the client Raspberry Pi:
 
 ```bash
 sudo apt install tcpdump dnsmasq
@@ -160,14 +160,14 @@ Connect the client Raspberry Pi to your network and power it on. Check that the 
 IP 0.0.0.0.bootpc > 255.255.255.255.bootps: BOOTP/DHCP, Request from b8:27:eb...
 ```
 
-Now we need to modify the dnsmasq configuration to enable DHCP to reply to the device. Press `CTRL+C` on the keyboard to exit the tcpdump program, then type the following:
+Now you need to modify the `dnsmasq` configuration to enable DHCP to reply to the device. Press <kbd>CTRL + C</kbd> to exit the `tcpdump` program, then type the following:
 
 ```bash
 echo | sudo tee /etc/dnsmasq.conf
 sudo nano /etc/dnsmasq.conf
 ```
 
-Then replace the contents of dnsmasq.conf with:
+Then replace the contents of `dnsmasq.conf` with:
 
 ```
 port=0
@@ -180,7 +180,7 @@ pxe-service=0,"Raspberry Pi Boot"
 
 Where the first address of the `dhcp-range` line is, use the broadcast address you noted down earlier.
 
-Now create a /tftpboot directory:
+Now create a `/tftpboot` directory:
 
 ```bash
 sudo mkdir /tftpboot
@@ -189,7 +189,7 @@ sudo systemctl enable dnsmasq.service
 sudo systemctl restart dnsmasq.service
 ```
 
-Now monitor the dnsmasq log:
+Now monitor the `dnsmasq` log:
 
 ```bash
 tail -F /var/log/daemon.log
@@ -201,15 +201,15 @@ You should see something like this:
 raspberrypi dnsmasq-tftp[1903]: file /tftpboot/bootcode.bin not found
 ```
 
-Next, you will need to copy the contents of the boot folder into the /tftpboot directory.
+Next, you will need to copy the contents of the boot folder into the `/tftpboot` directory.
 
-First, use `Ctrl + C` to exit the monitoring state. Then type the following: 
+First, press <kbd>CTRL + C</kbd> to exit the monitoring state. Then type the following: 
 
 ```bash
 cp -r /boot/* /tftpboot
 ```
 
-Since the tftp location has changed, restart dnsmasq:
+Since the tftp location has changed, restart `dnsmasq`:
 
 ```bash
 sudo systemctl restart dnsmasq
@@ -217,9 +217,9 @@ sudo systemctl restart dnsmasq
 
 ### Set up NFS root
 
-This should now allow your Raspberry Pi client to attempt to boot through until it tries to load a root filesystem (which it doesn't have).
+This should now allow your Raspberry Pi client to attempt to boot through until it tries to load a root file system (which it doesn't have).
 
-At this point export the `/nfs/client1` filesystem created earlier.
+At this point, export the `/nfs/client1` file system created earlier.
 
 ```bash
 sudo apt-get install nfs-kernel-server
@@ -235,7 +235,7 @@ sudo systemctl enable nfs-kernel-server
 sudo systemctl restart nfs-kernel-server
 ```
 
-Edit /tftpboot/cmdline.txt and from `root=` onwards, and replace it with:
+Edit `/tftpboot/cmdline.txt` and from `root=` onwards, and replace it with:
 
 ```
 root=/dev/nfs nfsroot=10.42.0.211:/nfs/client1,vers=3 rw ip=dhcp rootwait elevator=deadline

--- a/hardware/raspberrypi/bootmodes/net_tutorial.md
+++ b/hardware/raspberrypi/bootmodes/net_tutorial.md
@@ -4,19 +4,18 @@ This tutorial is written to explain how to set up a simple DHCP/TFTP server whic
 
 Due to the huge range of networking devices available, we can't guarantee that network booting will work with any device. We have had reports that, if you cannot get network booting to work, disabling STP frames on your network may help.
 
-**Note:** if you are using a Raspberry Pi 3B+, then USB boot mode is set by default, so you can ignore the instructions in the **Client configuration** and **Program USB boot mode** sections and go directly to **Server configuration**.
-
 ## Client configuration
+
+This section only applies to the *original* Raspberry Pi 3; if you are using the new 3+ then this can be ignored. Skip to the server section below then.
+
 Before a Raspberry Pi will network boot, it needs to be booted from an SD card with a config option to enable USB boot mode. This will set a bit in the OTP (One Time Programmable) memory in the Raspberry Pi SoC that enables network booting. Once this is done, the SD card is no longer required. 
 
 Install Raspbian Lite (or Raspbian with Raspberry Pi Desktop) on the SD card in the [usual way](../../../installation/installing-images/README.md). 
 
-### Program USB boot mode
-
-First, prepare the `/boot` directory with the latest boot files:
+Afterwards, setup program USB boot mode by preparing the `/boot` directory with the latest boot files:
 
 ```bash
-sudo apt-get update && sudo apt-get upgrade
+sudo apt update && sudo apt upgrade
 ```
 
 Now, enable USB boot mode with the following command:
@@ -37,13 +36,14 @@ Ensure the output `0x3020000a` is correct.
 The client configuration is almost done. The final thing to do is to remove the `program_usb_boot_mode` line from `config.txt` (make sure there is no blank line at the end). You can do this with `sudo nano /boot/config.txt`, for example. Finally, shut the client Raspberry Pi down with `sudo poweroff`.
 
 ## Server configuration
-Plug the SD card into the server Raspberry Pi. Boot the server. Before you do anything else, make sure you have run `sudo raspi-config` and expanded the root filesystem to take up the entire SD card.
 
-The client Raspberry Pi will need a root filesystem to boot off, so before we do anything else on the server, we're going to make a full copy of its filesystem and put it in a directory called `/nfs/client1`.
+Plug the SD card into the server Raspberry Pi and then boot the server. Before you do anything else, make sure you have run `sudo raspi-config` and expanded the root filesystem to take up the entire SD card.
+
+The client Raspberry Pi will need a root filesystem to boot off, so before we do anything else on the server, make a full copy of its filesystem and put it in a directory called `/nfs/client1`:
 
 ```bash
 sudo mkdir -p /nfs/client1
-sudo apt-get install rsync
+sudo apt install rsync
 sudo rsync -xa --progress --exclude /nfs / /nfs/client1
 ```
 
@@ -58,9 +58,7 @@ sudo chroot .
 rm /etc/ssh/ssh_host_*
 dpkg-reconfigure openssh-server
 exit
-sudo umount dev
-sudo umount sys
-sudo umount proc
+sudo umount dev sys proc
 ```
 
 Find the settings of your local network. You need to find the address of your router (or gateway), which can be done with:
@@ -89,57 +87,70 @@ Finally, note down the address of your DNS server, which is the same address as 
 cat /etc/resolv.conf
 ```
 
-Configure a static network address on your server Raspberry Pi by with `sudo nano /etc/network/interfaces` (where you replace nano with an editor of your choice). Change the line, `iface eth0 inet manual` so that the address is the first address from the command before last, the netmask address as `255.255.255.0` and the gateway address as the number received from the last command. 
+Configure a static network address on your server Raspberry Pi via the systemd-networking, which works as the network handler and DHCP server.
+
+To do that, you'll need to to create a `10-eth0.netdev` and a `11-eth0.network` like so:
 
 ```
-auto eth0
-iface eth0 inet static 
-        address 10.42.0.211
-        netmask 255.255.255.0
-        gateway 10.42.0.1
+sudo nano /etc/systemd/network/10-eth0.netdev
 ```
 
-Disable the DHCP client daemon and switch to standard Debian networking:
+Add the following lines:
+
+```
+[Match]
+Name=eth0
+
+[Network]
+DHCP=no
+```
+
+Then create a network file:
+
+```
+sudo nano /etc/systemd/network/11-eth0.network
+```
+
+Add the following contents:
+
+```
+[Match]
+Name=eth0
+
+[Network]
+Address=10.42.0.211/24
+DNS=10.42.0.1
+
+[Route]
+Gateway=10.42.0.1
+```
+
+At this point, you won't have working DNS, so you'll need to add the server you noted down before to systemd resolv. In this example the gateway address is 10.42.0.1
 
 ```bash
-sudo systemctl disable dhcpcd
-sudo systemctl enable networking
+sudo nano /etc/systemd/resolved.conf
 ```
 
-Reboot for the changes to take effect:
+Uncomment the DNS line and add the DNS IP address there. Additionally, if you have a fallback DNS server, add it there as well.
+
 ```bash
-sudo reboot
+[Resolve]
+DNS=10.42.0.1
+#FallbackDNS=
 ```
 
-At this point, you won't have working DNS, so you'll need to add the server you noted down before to `/etc/resolv.conf`. Do this by using the following command, where the IP address is that of the gateway address you found before.
+Enable systemd-networkd and then reboot for the changes to take effect:
 
 ```bash
-echo "nameserver 10.42.0.1" | sudo tee -a /etc/resolv.conf
-```
-
-Make the file immutable (because otherwise dnsmasq will interfere) with the following command:
-
-```bash
-sudo chattr +i /etc/resolv.conf
-```
-
-Install software we need:
-
-```bash
-sudo apt-get update
-sudo apt-get install dnsmasq tcpdump
-```
-
-Stop dnsmasq breaking DNS resolving:
-
-```bash
-sudo rm /etc/resolvconf/update.d/dnsmasq
+sudo systemctl enable systemd-networkd
 sudo reboot
 ```
 
 Now start tcpdump so you can search for DHCP packets from the client Raspberry Pi:
 
 ```bash
+sudo apt install tcpdump dnsmasq
+sudo systemctl enable dnsmasq
 sudo tcpdump -i eth0 port bootpc
 ```
 
@@ -198,7 +209,7 @@ First, use `Ctrl + C` to exit the monitoring state. Then type the following:
 cp -r /boot/* /tftpboot
 ```
 
-Restart dnsmasq for good measure:
+Since the tftp location has changed, restart dnsmasq:
 
 ```bash
 sudo systemctl restart dnsmasq
@@ -206,11 +217,18 @@ sudo systemctl restart dnsmasq
 
 ### Set up NFS root
 
-This should now allow your Raspberry Pi to boot through until it tries to load a root filesystem (which it doesn't have). All we have to do to get this working is to export the `/nfs/client1` filesystem we created earlier.
+This should now allow your Raspberry Pi client to attempt to boot through until it tries to load a root filesystem (which it doesn't have).
+
+At this point export the `/nfs/client1` filesystem created earlier.
 
 ```bash
 sudo apt-get install nfs-kernel-server
 echo "/nfs/client1 *(rw,sync,no_subtree_check,no_root_squash)" | sudo tee -a /etc/exports
+```
+
+Restart RPC-Bind and the NFS server in order to have them detect the new files.
+
+```bash
 sudo systemctl enable rpcbind
 sudo systemctl restart rpcbind
 sudo systemctl enable nfs-kernel-server


### PR DESCRIPTION
As per issue #1006 I have improved the tutorial to better reflect the fact that newer variants of Linux are more reliant on systemd to handle many of their basic networking functions.

For context, this only changes a single tutorial markdown file; hardware/raspberry_pi/bootmodes/net_tutorial.md.