### PR TITLE
Add some content to bootmodes/sdcard.md

### DIFF
--- a/hardware/raspberrypi/bootmodes/sdcard.md
+++ b/hardware/raspberrypi/bootmodes/sdcard.md
@@ -1,1 +1,3 @@
-# SD Card boot
+# SD card boot
+
+The default way of using a Raspberry Pi is to boot it using an SD card: this is the recommended method for new and inexperienced users. See the [installation section of the documentation](https://www.raspberrypi.org/documentation/installation/) for more information on how to install a suitable operating system on an SD card.

--- a/hardware/raspberrypi/bootmodes/sdcard.md
+++ b/hardware/raspberrypi/bootmodes/sdcard.md
@@ -1,3 +1,3 @@
 # SD card boot
 
-The default way of using a Raspberry Pi is to boot it using an SD card: this is the recommended method for new and inexperienced users. See the [installation section of the documentation](../../../installation/) for more information on how to install a suitable operating system on an SD card.
+The default way of using a Raspberry Pi is to boot it using an SD card: this is the recommended method for new and inexperienced users. See [the installation section of the documentation](../../../installation/) for more information on how to install a suitable operating system on an SD card.

--- a/hardware/raspberrypi/bootmodes/sdcard.md
+++ b/hardware/raspberrypi/bootmodes/sdcard.md
@@ -1,3 +1,3 @@
 # SD card boot
 
-The default way of using a Raspberry Pi is to boot it using an SD card: this is the recommended method for new and inexperienced users. See the [installation section of the documentation](https://www.raspberrypi.org/documentation/installation/) for more information on how to install a suitable operating system on an SD card.
+The default way of using a Raspberry Pi is to boot it using an SD card: this is the recommended method for new and inexperienced users. See the [installation section of the documentation](../../../installation/) for more information on how to install a suitable operating system on an SD card.


### PR DESCRIPTION
documentation/hardware/raspberrypi/bootmodes/sdcard.md is intended to document SD card booting as part of the 'boot modes' documentation - it is currently blank. Add a few sentences about SD card booting, along with a link to the 'installation' section of the docs for those looking for basic SD card installation info.