### PR TITLE
Renaming etcher to balenaEtcher

### DIFF
--- a/installation/installing-images/README.md
+++ b/installation/installing-images/README.md
@@ -22,9 +22,9 @@ If you're not using Etcher (see below), you'll need to unzip `.zip` downloads to
 
 You will need to use an image writing tool to install the image you have downloaded on your SD card.
 
-**Etcher** is a graphical SD card writing tool that works on Mac OS, Linux and Windows, and is the easiest option for most users. Etcher also supports writing images directly from the zip file, without any unzipping required. To write your image with Etcher:
+**balenaEtcher** is a graphical SD card writing tool that works on Mac OS, Linux and Windows, and is the easiest option for most users. Etcher also supports writing images directly from the zip file, without any unzipping required. To write your image with Etcher:
 
-- Download [Etcher](https://etcher.io/) and install it.
+- Download [balenaEtcher](https://www.balena.io/etcher/) and install it.
 - Connect an SD card reader with the SD card inside.
 - Open Etcher and select from your hard drive the Raspberry Pi `.img` or `.zip` file you wish to write to the SD card.
 - Select the SD card you wish to write your image to.


### PR DESCRIPTION
Etcher has been renamed to balenaEtcher and it's website changed to www.balena.io/etcher/