### PR TITLE
Add installing images instructions for Chrome OS

### DIFF
--- a/installation/installing-images/README.md
+++ b/installation/installing-images/README.md
@@ -35,4 +35,4 @@ For more advanced control of this process, see our system-specific guides:
 - [Linux](linux.md)
 - [Mac OS](mac.md)
 - [Windows](windows.md)
-- [ChromeOS](chromeos.md)
+- [Chrome OS](chromeos.md)

--- a/installation/installing-images/README.md
+++ b/installation/installing-images/README.md
@@ -35,3 +35,4 @@ For more advanced control of this process, see our system-specific guides:
 - [Linux](linux.md)
 - [Mac OS](mac.md)
 - [Windows](windows.md)
+- [ChromeOS](chromeos.md)

--- a/installation/installing-images/chromeos.md
+++ b/installation/installing-images/chromeos.md
@@ -1,16 +1,16 @@
-# Installing operating system images using ChomeOS
+# Installing operating system images using Chrome OS
 
-Easiest option to write images to an SD card and USB drives with ChromeOS is to use the official [Chromebook Recovery Utility](https://chrome.google.com/webstore/detail/chromebook-recovery-utili/jndclpdbaamdhonoechobihbbiimdgai). It can be used to create Chromebook Recovery media, but it will also accept .zip files containing images.
+Easiest option to write images to an SD card and USB drives with Chrome OS is to use the official [Chromebook Recovery Utility](https://chrome.google.com/webstore/detail/chromebook-recovery-utili/jndclpdbaamdhonoechobihbbiimdgai). It can be used to create Chromebook Recovery media, but it will also accept .zip files containing images.
  
 ## Recovery Utility
 
 - Download the [Chromebook Recovery Utility](https://chrome.google.com/webstore/detail/chromebook-recovery-utili/jndclpdbaamdhonoechobihbbiimdgai).
-- Download the [Raspbian .zip file](https://www.raspberrypi.org/downloads/raspbian/)
-- Launch the Recovery Utility
+- Download the Raspbian .zip file (https://www.raspberrypi.org/downloads/raspbian/).
+- Launch the **Recovery Utility**
 - Click the Settings Gears icon in the upper right next to the window close icon.
-- Select the Use Local Image option
-- Choose the Downloaded .zip file
-- Insert the SD card and click Continue
-- Read the warning and click the **Create now** button
+- Select the **Use Local Image** option.
+- Choose the Downloaded .zip file.
+- Insert the SD card and click **Continue**.
+- Read the warning and click the **Create now** button.
 - Wait for the progress bar to complete twice (unpacking and writing, might take a couple of minutes).
 - A big green checkmark will be shown once done. You can close the utility and eject the card.

--- a/installation/installing-images/chromeos.md
+++ b/installation/installing-images/chromeos.md
@@ -1,16 +1,16 @@
 # Installing operating system images using Chrome OS
 
-Easiest option to write images to an SD card and USB drives with Chrome OS is to use the official [Chromebook Recovery Utility](https://chrome.google.com/webstore/detail/chromebook-recovery-utili/jndclpdbaamdhonoechobihbbiimdgai). It can be used to create Chromebook Recovery media, but it will also accept .zip files containing images.
+The easiest way to write images to an SD card and USB drives with Chrome OS is to use the official [Chromebook Recovery Utility](https://chrome.google.com/webstore/detail/chromebook-recovery-utili/jndclpdbaamdhonoechobihbbiimdgai). It can be used to create Chromebook Recovery media, and it will also accept .zip files containing images.
  
-## Recovery Utility
+## Using the Recovery Utility
 
 - Download the [Chromebook Recovery Utility](https://chrome.google.com/webstore/detail/chromebook-recovery-utili/jndclpdbaamdhonoechobihbbiimdgai).
-- Download the Raspbian .zip file (https://www.raspberrypi.org/downloads/raspbian/).
+- Download the [Raspbian .zip file](https://www.raspberrypi.org/downloads/raspbian/).
 - Launch the **Recovery Utility**
-- Click the Settings Gears icon in the upper right next to the window close icon.
+- Click on the **Settings Gears** icon in the upper right-hand corner, next to the window close icon.
 - Select the **Use Local Image** option.
-- Choose the Downloaded .zip file.
+- Choose the .zip file you downloaded.
 - Insert the SD card and click **Continue**.
 - Read the warning and click the **Create now** button.
-- Wait for the progress bar to complete twice (unpacking and writing, might take a couple of minutes).
-- A big green checkmark will be shown once done. You can close the utility and eject the card.
+- Wait for the progress bar to complete twice (for unpacking and writing). This might take a few minutes. Once the process is complete, a big green checkmark will be shown.
+- Close the program and eject the card.

--- a/installation/installing-images/chromeos.md
+++ b/installation/installing-images/chromeos.md
@@ -1,0 +1,16 @@
+# Installing operating system images using ChomeOS
+
+Easiest option to write images to an SD card and USB drives with ChromeOS is to use the official [Chromebook Recovery Utility](https://chrome.google.com/webstore/detail/chromebook-recovery-utili/jndclpdbaamdhonoechobihbbiimdgai). It can be used to create Chromebook Recovery media, but it will also accept .zip files containing images.
+ 
+## Recovery Utility
+
+- Download the [Chromebook Recovery Utility](https://chrome.google.com/webstore/detail/chromebook-recovery-utili/jndclpdbaamdhonoechobihbbiimdgai).
+- Download the [Raspbian .zip file](https://www.raspberrypi.org/downloads/raspbian/)
+- Launch the Recovery Utility
+- Click the Settings Gears icon in the upper right next to the window close icon.
+- Select the Use Local Image option
+- Choose the Downloaded .zip file
+- Insert the SD card and click Continue
+- Read the warning and click the **Create now** button
+- Wait for the progress bar to complete twice (unpacking and writing, might take a couple of minutes).
+- A big green checkmark will be shown once done. You can close the utility and eject the card.


### PR DESCRIPTION
Chromebooks tend to be popular in education, add instructions on how to prepare a raspbian SD card (alongside windows/mac/linux).