### PR TITLE
Added missing modes (Closes #1091)

### DIFF
--- a/configuration/config-txt/video.md
+++ b/configuration/config-txt/video.md
@@ -12,6 +12,8 @@ The `sdtv_mode` command defines the TV standard used for composite video output 
 | 1 | Japanese version of NTSC – no pedestal |
 | 2 | Normal PAL |
 | 3 | Brazilian version of PAL – 525/60 rather than 625/50, different subcarrier |
+| 16 | Progressive scan NTSC |
+| 18 | Progressive scan PAL |
 
 ### sdtv_aspect
 


### PR DESCRIPTION
I added the missing progressive scan modes to the documentation. This modes are important for people who use console-emulators, for accurate emulation on a CRT TV.