### PR TITLE
--datestamp should be --datetime

### DIFF
--- a/raspbian/applications/camera.md
+++ b/raspbian/applications/camera.md
@@ -438,7 +438,7 @@ The specific value is the time between shots in milliseconds. Note that you shou
 Specifies the first frame number in the timelapse. Useful if you have already saved a number of frames, and want to start again at the next frame.
 
 ```
---datestamp,   -dt
+--datetime,   -dt
 ```
 
 Instead of a simple frame number, the timelapse file names will use a date/time value of the format `aabbccddee`, where `aa` is the month, `bb` is the day of the month, `cc` is the hour, `dd` is the minute, and  `ee` is the second.


### PR DESCRIPTION
--datestamp is not a valid option for raspistill. The correct option is --datetime.

There is a --timestamp option, so potentially it would be better (i.e. more consistent) to change the code for raspistill to --datestamp, but for now the correct (valid) option is --datetime and not --datestamp, so the documentation should be updated to match the code.