### PR TITLE
Add wired networking documentation

### DIFF
--- a/configuration/README.md
+++ b/configuration/README.md
@@ -8,6 +8,8 @@ Some basic guides to configuring your Raspberry Pi.
     - The Raspberry Pi configuration tool in Raspbian, allowing you to easily enable features such as the camera, and to change your specific settings such as keyboard layout
 - [config.txt](config-txt/README.md)
     - The Raspberry Pi configuration file
+- [Ethernet networking](ethernet/README.md)
+    - How to configure the wired network interface on the Pi
 - [Wireless networking](wireless/README.md)
     - Configuring your Pi to connect to a wireless network using the Raspberry Pi 3's or Pi Zero W's inbuilt wireless connectivity, or a USB wireless dongle
 - [Wireless access point](wireless/access-point.md)

--- a/configuration/ethernet/README.md
+++ b/configuration/ethernet/README.md
@@ -1,0 +1,3 @@
+#Ethernet configuration
+
+The Raspberry Pi uses dhcpcd to configure the wired network interface. Otherwise it is configured the same as on Debian Linux.


### PR DESCRIPTION
I've produced a page that tells folk that the Pi uses Debian networking, except dhcpcd in preference to NetworkManager for the ethernet interface. I intend to flesh this out a bit more in the coming days.