### PR TITLE
Document GPIO boot mode on its own page

### DIFF
--- a/hardware/raspberrypi/bootmodes/gpio.md
+++ b/hardware/raspberrypi/bootmodes/gpio.md
@@ -15,11 +15,11 @@ Once GPIO boot mode is enabled, the Raspberry Pi will no longer boot. You must p
 Once enabled, the GPIOs are allocated to boot modes as follows:
 
 |Bank 1|Bank 2|boot type|
-|:----:|:---:|:---- ---:|
+|:----:|:---:|:--------:|
 |22    |39   |SD0       |
 |23    |40   |SD1       |
-|24    |41   |NAND      |
-|25    |42   |SPI       |
+|24    |41   |NAND (no Linux support at present)    |
+|25    |42   |SPI (no Linux support at present)    |
 |26    |43   |USB       |
 
 The various boot modes are attempted in the numerical order of the GPIO pins, i.e. SD0, then SD1, then NAND and so on.

--- a/hardware/raspberrypi/bootmodes/gpio.md
+++ b/hardware/raspberrypi/bootmodes/gpio.md
@@ -1,1 +1,23 @@
 # GPIO boot mode
+
+The Raspberry Pi can be configured to allow the boot mode to be selected at run time using hardware attached to the GPIO connector: this is GPIO boot mode. This is done by setting a bit in the OTP memory of the SoC. Once the bit is set, it permanently allocates 5 GPIOs to allow this selected to be made. Once the OTP bit is set it cannot be undone, so you should think carefully about enabling this, since those 5 GPIO lines will then be permanently unavailable for any other use.
+
+To enable GPIO boot mode, add the following line to the config.txt file:
+
+```
+program_gpio_bootmode=n
+```
+
+And reboot the Pi once to program the OTP with this setting. Where n is the bank of GPIOs which you wish to use. Bank 1 is GPIOs 22-26, bank 2 is GPIOs 39-43. Unless you have a compute module, you must use bank 1: the GPIOs in bank 2 are only available on the compute module.
+
+Once enabled, the GPIOs are mapped as follows:
+
+|Bank 1|Bank2|boot type|
+|:----:|:---:|:-------:|
+|22    |39   |SD1      |
+|23    |40   |SD2      |
+|24    |41   |NAND     |
+|25    |42   |SPI      |
+|26    |43   |USB      |
+
+SD1 is the <xxx> SD card interface. SD2 is the <yyy> SD card interface. USB enables both USB device mode and USB host mode boot.

--- a/hardware/raspberrypi/bootmodes/gpio.md
+++ b/hardware/raspberrypi/bootmodes/gpio.md
@@ -2,7 +2,7 @@
 
 The Raspberry Pi can be configured to allow the boot mode to be selected at power on using hardware attached to the GPIO connector: this is GPIO boot mode. This is done by setting bits in the OTP memory of the SoC. Once the bits are set, they permanently allocate 5 GPIOs to allow this selection to be made. Once the OTP bits are set they cannot be unset so you should think carefully about enabling this, since those 5 GPIO lines will then be unavailable for any other use.
 
-To enable GPIO boot mode, add the following line to the [config.txt](configuration/config-txt/README.md) file:
+To enable GPIO boot mode, add the following line to the [config.txt](../../../configurationconfig-txt/README.md) file:
 
 ```
 program_gpio_bootmode=n
@@ -28,4 +28,4 @@ SD1 is the Broadcom SD card / MMC interface, which is used by default for the bu
 
 USB in the table selects USB device boot mode and USB host boot mode, which are only available on certain models of Raspberry Pi.
 
-The default pull resistance on the GPIO lines is 50K ohm, as documented on page 102 of the [BCM2835 ARM peripherals datasheet](hardware/raspberrypi/bcm2835/BCM2835-ARM-Peripherals.pdf). A pull resistance of 5K ohm is recommended to pull a GPIO line up: this will allow the GPIO to function but not consume too much power.
+The default pull resistance on the GPIO lines is 50K ohm, as documented on page 102 of the [BCM2835 ARM peripherals datasheet](../../hardware/raspberrypi/bcm2835/BCM2835-ARM-Peripherals.pdf). A pull resistance of 5K ohm is recommended to pull a GPIO line up: this will allow the GPIO to function but not consume too much power.

--- a/hardware/raspberrypi/bootmodes/gpio.md
+++ b/hardware/raspberrypi/bootmodes/gpio.md
@@ -26,7 +26,7 @@ The various boot modes are attempted in the numerical order of the GPIO pins, i.
 
 SD0 is the Broadcom SD card / MMC interface. When the boot ROM within the SoC runs, it always connects SD0 to the built-in SD card slot, or on the Compute Module, to the eMMC device. SD1 is the Arasan SD card / MMC interface which is also capable of SDIO. All Raspberry Pi models with built-in wifi use SD1 to connect to the wifi chip via SDIO.
 
-It is possible to reassign both SD0 and SD1 to different uses after the Pi has booted, but the boot ROM will always use the assignments noted above at boot time .
+It is possible to reassign both SD0 and SD1 to different uses after the Pi has booted, but the boot ROM will always use the assignments noted above at boot time.
 
 USB in the table selects USB device boot mode and USB host boot mode, which are only available on certain models of Raspberry Pi. In order to use a USB boot mode, it must by enabled in the OTP memory. For more information, see [USB device boot](device.md) and [USB host boot](host.md).
 

--- a/hardware/raspberrypi/bootmodes/gpio.md
+++ b/hardware/raspberrypi/bootmodes/gpio.md
@@ -1,6 +1,8 @@
 # GPIO boot mode
 
-The Raspberry Pi can be configured to allow the boot mode to be selected at power on using hardware attached to the GPIO connector: this is GPIO boot mode. This is done by setting bits in the OTP memory of the SoC. Once the bits are set, they permanently allocate 5 GPIOs to allow this selection to be made. Once the OTP bits are set they cannot be unset so you should think carefully about enabling this, since those 5 GPIO lines will then be unavailable for any other use.
+**GPIO boot mode is only available on the Raspberry Pi 3B and 3B+.**
+
+The Raspberry Pi can be configured to allow the boot mode to be selected at power on using hardware attached to the GPIO connector: this is GPIO boot mode. This is done by setting bits in the OTP memory of the SoC. Once the bits are set, they permanently allocate 5 GPIOs to allow this selection to be made. Once the OTP bits are set they cannot be unset so you should think carefully about enabling this, since those 5 GPIO lines will always control booting. Although you can use the GPIOs for some other function once the Pi has booted, you must set them up so that they enable the desired boot modes when the Pi boots.
 
 To enable GPIO boot mode, add the following line to the [config.txt](../../../configuration/config-txt/README.md) file:
 
@@ -12,7 +14,8 @@ Where n is the bank of GPIOs which you wish to use. Then reboot the Pi once to p
 
 Once GPIO boot mode is enabled, the Raspberry Pi will no longer boot. You must pull up at least one boot mode GPIO pin in order for the Pi to boot.
 
-Once enabled, the GPIOs are allocated to boot modes as follows:
+## GPIO boot mode pin assignments
+### Raspberry Pi 3B
 
 |Bank 1|Bank 2|boot type|
 |:----:|:---:|:--------:|
@@ -22,12 +25,28 @@ Once enabled, the GPIOs are allocated to boot modes as follows:
 |25    |42   |SPI (no Linux support at present)    |
 |26    |43   |USB       |
 
+USB in the table above selects both USB device boot mode and USB host boot mode. In order to use a USB boot mode, it must by enabled in the OTP memory. For more information, see [USB device boot](device.md) and [USB host boot](host.md).
+
+### Raspberry Pi 3B+
+
+|Bank 1|Bank 2|boot type|
+|:----:|:---:|:--------:|
+|20    |37   |SD0       |
+|21    |38   |SD1       |
+|22    |39   |NAND (no Linux support at present)    |
+|23    |40   |SPI (no Linux support at present)    |
+|24    |41   |USB device      |
+|25    |42   |USB host - mass storage device |
+|26    |43   |USB host - ethernet |
+
+## Boot order
+
 The various boot modes are attempted in the numerical order of the GPIO pins, i.e. SD0, then SD1, then NAND and so on.
+
+## Boot flow
 
 SD0 is the Broadcom SD card / MMC interface. When the boot ROM within the SoC runs, it always connects SD0 to the built-in microSD card slot. On Compute Modules with an eMMC device, SD0 is connected to that; on the Compute Module Lite SD0 is available on the edge connector and connects to the microSD card slot in the CMIO carrier board. SD1 is the Arasan SD card / MMC interface which is also capable of SDIO. All Raspberry Pi models with built-in wifi use SD1 to connect to the wifi chip via SDIO.
 
 It is possible to reassign both SD0 and SD1 to different uses after the Pi has booted, but the boot ROM will always use the assignments noted above at boot time.
-
-USB in the table selects USB device boot mode and USB host boot mode, which are only available on certain models of Raspberry Pi. In order to use a USB boot mode, it must by enabled in the OTP memory. For more information, see [USB device boot](device.md) and [USB host boot](host.md).
 
 The default pull resistance on the GPIO lines is 50K ohm, as documented on page 102 of the [BCM2835 ARM peripherals datasheet](../../hardware/raspberrypi/bcm2835/BCM2835-ARM-Peripherals.pdf). A pull resistance of 5K ohm is recommended to pull a GPIO line up: this will allow the GPIO to function but not consume too much power.

--- a/hardware/raspberrypi/bootmodes/gpio.md
+++ b/hardware/raspberrypi/bootmodes/gpio.md
@@ -28,6 +28,6 @@ SD0 is the Broadcom SD card / MMC interface. When the boot ROM within the SoC ru
 
 It is possible to reassign both SD0 and SD1 to different uses after the Pi has booted, but the boot ROM will always use the assignments noted above at boot time .
 
-USB in the table selects USB device boot mode and USB host boot mode, which are only available on certain models of Raspberry Pi. In order to use a USB boot mode, it must by enabled in the OTP memory. For more information, see [USB device boot](device.md) and [USB host boot](host.md)
+USB in the table selects USB device boot mode and USB host boot mode, which are only available on certain models of Raspberry Pi. In order to use a USB boot mode, it must by enabled in the OTP memory. For more information, see [USB device boot](device.md) and [USB host boot](host.md).
 
 The default pull resistance on the GPIO lines is 50K ohm, as documented on page 102 of the [BCM2835 ARM peripherals datasheet](../../hardware/raspberrypi/bcm2835/BCM2835-ARM-Peripherals.pdf). A pull resistance of 5K ohm is recommended to pull a GPIO line up: this will allow the GPIO to function but not consume too much power.

--- a/hardware/raspberrypi/bootmodes/gpio.md
+++ b/hardware/raspberrypi/bootmodes/gpio.md
@@ -24,7 +24,7 @@ Once enabled, the GPIOs are allocated to boot modes as follows:
 
 The various boot modes are attempted in the numerical order of the GPIO pins, i.e. SD0, then SD1, then NAND and so on.
 
-SD0 is the Broadcom SD card / MMC interface. When the boot ROM within the SoC runs, it always connects SD0 to the built-in SD card slot, or on the Compute Module, to the eMMC device. SD1 is the Arasan SD card / MMC interface which is also capable of SDIO. All Raspberry Pi models with built-in wifi use SD1 to connect to the wifi chip via SDI0.
+SD0 is the Broadcom SD card / MMC interface. When the boot ROM within the SoC runs, it always connects SD0 to the built-in SD card slot, or on the Compute Module, to the eMMC device. SD1 is the Arasan SD card / MMC interface which is also capable of SDIO. All Raspberry Pi models with built-in wifi use SD1 to connect to the wifi chip via SDIO.
 
 It is possible to reassign both SD0 and SD1 to different uses after the Pi has booted, but the boot ROM will always use the assignments noted above at boot time .
 

--- a/hardware/raspberrypi/bootmodes/gpio.md
+++ b/hardware/raspberrypi/bootmodes/gpio.md
@@ -24,7 +24,7 @@ Once enabled, the GPIOs are allocated to boot modes as follows:
 
 The various boot modes are attempted in the numerical order of the GPIO pins, i.e. SD0, then SD1, then NAND and so on.
 
-SD0 is the Broadcom SD card / MMC interface. When the boot ROM within the SoC runs, it always connects SD0 to the built-in SD card slot. On Compute Modules with an eMMC device, SD0 is connected to that; on the Compute Module Lite SD0 is available on the edge connector and connects to the SD card slot in the CMIO carrier board. SD1 is the Arasan SD card / MMC interface which is also capable of SDIO. All Raspberry Pi models with built-in wifi use SD1 to connect to the wifi chip via SDIO.
+SD0 is the Broadcom SD card / MMC interface. When the boot ROM within the SoC runs, it always connects SD0 to the built-in microSD card slot. On Compute Modules with an eMMC device, SD0 is connected to that; on the Compute Module Lite SD0 is available on the edge connector and connects to the microSD card slot in the CMIO carrier board. SD1 is the Arasan SD card / MMC interface which is also capable of SDIO. All Raspberry Pi models with built-in wifi use SD1 to connect to the wifi chip via SDIO.
 
 It is possible to reassign both SD0 and SD1 to different uses after the Pi has booted, but the boot ROM will always use the assignments noted above at boot time.
 

--- a/hardware/raspberrypi/bootmodes/gpio.md
+++ b/hardware/raspberrypi/bootmodes/gpio.md
@@ -8,7 +8,7 @@ To enable GPIO boot mode, add the following line to the [config.txt](../../../co
 program_gpio_bootmode=n
 ```
 
-Where n is the bank of GPIOs which you wish to use. Then reboot the Pi once to program the OTP with this setting. Bank 1 is GPIOs 22-26, bank 2 is GPIOs 39-43. Unless you have a Compute Module, you must use bank 1: the GPIOs in bank 1 are only available on the Compute Module. Because of the way the OTP bits are arranged, if you first program GPIO boot mode for bank 1, you then have the option of selecting bank 2 later. The reverse is not true: once bank 2 has been selected for GPIO boot mode, you cannot select bank 1.
+Where n is the bank of GPIOs which you wish to use. Then reboot the Pi once to program the OTP with this setting. Bank 1 is GPIOs 22-26, bank 2 is GPIOs 39-43. Unless you have a Compute Module, you must use bank 1: the GPIOs in bank 2 are only available on the Compute Module. Because of the way the OTP bits are arranged, if you first program GPIO boot mode for bank 1, you then have the option of selecting bank 2 later. The reverse is not true: once bank 2 has been selected for GPIO boot mode, you cannot select bank 1.
 
 Once GPIO boot mode is enabled, the Raspberry Pi will no longer boot. You must pull up at least one boot mode GPIO pin in order for the Pi to boot.
 

--- a/hardware/raspberrypi/bootmodes/gpio.md
+++ b/hardware/raspberrypi/bootmodes/gpio.md
@@ -8,24 +8,26 @@ To enable GPIO boot mode, add the following line to the [config.txt](../../../co
 program_gpio_bootmode=n
 ```
 
-Where n is the bank of GPIOs which you wish to use. Then reboot the Pi once to program the OTP with this setting. Bank 1 is GPIOs 22-26, bank 2 is GPIOs 39-43. Unless you have a Compute Module, you must use bank 1: the GPIOs in bank 2 are only available on the Compute Module. Because of the way the OTP bits are arranged, if you first program GPIO boot mode for bank 1, you then have the option of selecting bank 2 later. The reverse is not true: once bank 2 has been selected for GPIO boot mode, you cannot select bank 1.
+Where n is the bank of GPIOs which you wish to use. Then reboot the Pi once to program the OTP with this setting. Bank 0 is GPIOs 22-26, bank 1 is GPIOs 39-43. Unless you have a Compute Module, you must use bank 0: the GPIOs in bank 1 are only available on the Compute Module. Because of the way the OTP bits are arranged, if you first program GPIO boot mode for bank 0, you then have the option of selecting bank 1 later. The reverse is not true: once bank 1 has been selected for GPIO boot mode, you cannot select bank 0.
 
 Once GPIO boot mode is enabled, the Raspberry Pi will no longer boot. You must pull up at least one boot mode GPIO pin in order for the Pi to boot.
 
 Once enabled, the GPIOs are allocated to boot modes as follows:
 
 |Bank 1|Bank 2|boot type|
-|:----:|:---:|:-------:|
-|22    |39   |SD0      |
-|23    |40   |SD1      |
-|24    |41   |NAND     |
-|25    |42   |SPI      |
-|26    |43   |USB      |
+|:----:|:---:|:---- ---:|
+|22    |39   |SD0       |
+|23    |40   |SD1       |
+|24    |41   |NAND      |
+|25    |42   |SPI       |
+|26    |43   |USB       |
 
 The various boot modes are attempted in the numerical order of the GPIO pins, i.e. SD0, then SD1, then NAND and so on.
 
-SD1 is the Broadcom SD card / MMC interface, which is used by default for the built-in SD card slot, and on the Compute Module for the eMMC. SD1 is the Arasan SD card / MMC interface which is also capable of SDIO. All Raspberry Pi models with built-in wifi use SD1 to connect to the wifi chip via SDIO, although it can be reassigned to other uses.
+SD0 is the Broadcom SD card / MMC interface. When the boot ROM within the SoC runs, it always connects SD0 to the built-in SD card slot, or on the Compute Module, to the eMMC device. SD1 is the Arasan SD card / MMC interface which is also capable of SDIO. All Raspberry Pi models with built-in wifi use SD1 to connect to the wifi chip via SDI0.
 
-USB in the table selects USB device boot mode and USB host boot mode, which are only available on certain models of Raspberry Pi.
+It is possible to reassign both SD0 and SD1 to different uses after the Pi has booted, but the boot ROM will always use the assignments noted above at boot time .
+
+USB in the table selects USB device boot mode and USB host boot mode, which are only available on certain models of Raspberry Pi. In order to use a USB boot mode, it must by enabled in the OTP memory. For more information, see [USB device boot](device.md) and [USB host boot](host.md)
 
 The default pull resistance on the GPIO lines is 50K ohm, as documented on page 102 of the [BCM2835 ARM peripherals datasheet](../../hardware/raspberrypi/bcm2835/BCM2835-ARM-Peripherals.pdf). A pull resistance of 5K ohm is recommended to pull a GPIO line up: this will allow the GPIO to function but not consume too much power.

--- a/hardware/raspberrypi/bootmodes/gpio.md
+++ b/hardware/raspberrypi/bootmodes/gpio.md
@@ -18,8 +18,8 @@ Once enabled, the GPIOs are allocated to boot modes as follows:
 |:----:|:---:|:---- ---:|
 |22    |39   |SD0       |
 |23    |40   |SD1       |
-|24    |41   |NAND      |
-|25    |42   |SPI       |
+|24    |41   |NAND (no Linux support at present)      |
+|25    |42   |SPI (no Linux support at present)      |
 |26    |43   |USB       |
 
 The various boot modes are attempted in the numerical order of the GPIO pins, i.e. SD0, then SD1, then NAND and so on.

--- a/hardware/raspberrypi/bootmodes/gpio.md
+++ b/hardware/raspberrypi/bootmodes/gpio.md
@@ -24,7 +24,7 @@ Once enabled, the GPIOs are allocated to boot modes as follows:
 
 The various boot modes are attempted in the numerical order of the GPIO pins, i.e. SD0, then SD1, then NAND and so on.
 
-SD0 is the Broadcom SD card / MMC interface. When the boot ROM within the SoC runs, it always connects SD0 to the built-in SD card slot, or on the Compute Module, to the eMMC device. SD1 is the Arasan SD card / MMC interface which is also capable of SDIO. All Raspberry Pi models with built-in wifi use SD1 to connect to the wifi chip via SDIO.
+SD0 is the Broadcom SD card / MMC interface. When the boot ROM within the SoC runs, it always connects SD0 to the built-in SD card slot. On Compute Modules with an eMMC device, SD0 is connected to that; on the Compute Module Lite SD0 ????? SD1 is the Arasan SD card / MMC interface which is also capable of SDIO. All Raspberry Pi models with built-in wifi use SD1 to connect to the wifi chip via SDIO.
 
 It is possible to reassign both SD0 and SD1 to different uses after the Pi has booted, but the boot ROM will always use the assignments noted above at boot time.
 

--- a/hardware/raspberrypi/bootmodes/gpio.md
+++ b/hardware/raspberrypi/bootmodes/gpio.md
@@ -22,7 +22,7 @@ Once enabled, the GPIOs are polled in numerical order as follows:
 |25    |42   |SPI      |
 |26    |43   |USB      |
 
-SD1 is the Broadcom SD card / MMC interface, which is used by default for the built-in SD card slot, and on the Compute Module for the eMMC. SD1 is the Arasan SD card interface which is also capable on SDIO. All Raspberry Pi models with built-in wifi use SD1 to connect to the wifi chip via SDIO.
+SD1 is the Broadcom SD card / MMC interface, which is used by default for the built-in SD card slot, and on the Compute Module for the eMMC. SD1 is the Arasan SD card / MMC interface which is also capable of SDIO. All Raspberry Pi models with built-in wifi use SD1 to connect to the wifi chip via SDIO.
 
 USB in the table is USB device boot mode and USB host boot mode, which are only available on certain models of Raspberry Pi.
 

--- a/hardware/raspberrypi/bootmodes/gpio.md
+++ b/hardware/raspberrypi/bootmodes/gpio.md
@@ -16,12 +16,14 @@ Once enabled, the GPIOs are polled in numerical order as follows:
 
 |Bank 1|Bank2|boot type|
 |:----:|:---:|:-------:|
-|22    |39   |SD1      |
-|23    |40   |SD2      |
+|22    |39   |SD0      |
+|23    |40   |SD1      |
 |24    |41   |NAND     |
 |25    |42   |SPI      |
 |26    |43   |USB      |
 
-SD1 is the <xxx> SD card interface. SD2 is the <yyy> SD card interface. USB enables both USB device mode and USB host mode boot.
+SD1 is the Broadcom SD card interface, which is used by default for the built-in SD card slot, and on the Compute Module for the eMMC. SD1 is the Arasan SD card interface which is also capable on SDIO.
 
-The default pull resistance on the GPIO lines is 50K ohm, as documented on page 102 of the [BCM2835 ARM peripherals datasheet](hardware/raspberrypi/bcm2835/BCM2835-ARM-Peripherals.pdf). A pull resistance of 5K ohm is recommended to pull a GPIO line up or down: this will allow the GPIO to function but not consume too much power.
+USB in the able table is USB device boot mode and USB host boot mode, which are only available on certain models of Raspberry Pi.
+
+The default pull resistance on the GPIO lines is 50K ohm, as documented on page 102 of the [BCM2835 ARM peripherals datasheet](hardware/raspberrypi/bcm2835/BCM2835-ARM-Peripherals.pdf). A pull resistance of 5K ohm is recommended to pull a GPIO line up: this will allow the GPIO to function but not consume too much power.

--- a/hardware/raspberrypi/bootmodes/gpio.md
+++ b/hardware/raspberrypi/bootmodes/gpio.md
@@ -24,7 +24,7 @@ Once enabled, the GPIOs are allocated to boot modes as follows:
 
 The various boot modes are attempted in the numerical order of the GPIO pins, i.e. SD0, then SD1, then NAND and so on.
 
-SD1 is the Broadcom SD card / MMC interface, which is used by default for the built-in SD card slot, and on the Compute Module for the eMMC. SD1 is the Arasan SD card / MMC interface which is also capable of SDIO. All Raspberry Pi models with built-in wifi use SD1 to connect to the wifi chip via SDIO.
+SD1 is the Broadcom SD card / MMC interface, which is used by default for the built-in SD card slot, and on the Compute Module for the eMMC. SD1 is the Arasan SD card / MMC interface which is also capable of SDIO. All Raspberry Pi models with built-in wifi use SD1 to connect to the wifi chip via SDIO, although it can be reassigned to other uses.
 
 USB in the table is USB device boot mode and USB host boot mode, which are only available on certain models of Raspberry Pi.
 

--- a/hardware/raspberrypi/bootmodes/gpio.md
+++ b/hardware/raspberrypi/bootmodes/gpio.md
@@ -1,6 +1,6 @@
 # GPIO boot mode
 
-The Raspberry Pi can be configured to allow the boot mode to be selected at power on using hardware attached to the GPIO connector: this is GPIO boot mode. This is done by setting bits in the OTP memory of the SoC. Once the bits are set, they permanently allocate 5 GPIOs to allow this selection to be made. Once the OTP bits are set they cannot be unset so you should think carefully about enabling this, since those 5 GPIO lines will then be permanently unavailable for any other use.
+The Raspberry Pi can be configured to allow the boot mode to be selected at power on using hardware attached to the GPIO connector: this is GPIO boot mode. This is done by setting bits in the OTP memory of the SoC. Once the bits are set, they permanently allocate 5 GPIOs to allow this selection to be made. Once the OTP bits are set they cannot be unset so you should think carefully about enabling this, since those 5 GPIO lines will then be unavailable for any other use.
 
 To enable GPIO boot mode, add the following line to the config.txt file:
 
@@ -22,7 +22,7 @@ Once enabled, the GPIOs are polled in numerical order as follows:
 |25    |42   |SPI      |
 |26    |43   |USB      |
 
-SD1 is the Broadcom SD card interface, which is used by default for the built-in SD card slot, and on the Compute Module for the eMMC. SD1 is the Arasan SD card interface which is also capable on SDIO.
+SD1 is the Broadcom SD card / MMC interface, which is used by default for the built-in SD card slot, and on the Compute Module for the eMMC. SD1 is the Arasan SD card interface which is also capable on SDIO. All Raspberry Pi models with built-in wifi use SD1 to connect to the wifi chip via SDIO.
 
 USB in the table is USB device boot mode and USB host boot mode, which are only available on certain models of Raspberry Pi.
 

--- a/hardware/raspberrypi/bootmodes/gpio.md
+++ b/hardware/raspberrypi/bootmodes/gpio.md
@@ -1,6 +1,6 @@
 # GPIO boot mode
 
-The Raspberry Pi can be configured to allow the boot mode to be selected at run time using hardware attached to the GPIO connector: this is GPIO boot mode. This is done by setting a bit in the OTP memory of the SoC. Once the bit is set, it permanently allocates 5 GPIOs to allow this selected to be made. Once the OTP bit is set it cannot be undone, so you should think carefully about enabling this, since those 5 GPIO lines will then be permanently unavailable for any other use.
+The Raspberry Pi can be configured to allow the boot mode to be selected at power on using hardware attached to the GPIO connector: this is GPIO boot mode. This is done by setting bits in the OTP memory of the SoC. Once the bits are set, they permanently allocates 5 GPIOs to allow this selection to be made. Once the OTP bits are set they cannot be unset so you should think carefully about enabling this, since those 5 GPIO lines will then be permanently unavailable for any other use.
 
 To enable GPIO boot mode, add the following line to the config.txt file:
 
@@ -8,11 +8,11 @@ To enable GPIO boot mode, add the following line to the config.txt file:
 program_gpio_bootmode=n
 ```
 
-And reboot the Pi once to program the OTP with this setting. Where n is the bank of GPIOs which you wish to use. Bank 1 is GPIOs 22-26, bank 2 is GPIOs 39-43. Unless you have a compute module, you must use bank 1: the GPIOs in bank 2 are only available on the compute module.
+Where n is the bank of GPIOs which you wish to use. Then reboot the Pi once to program the OTP with this setting. Bank 1 is GPIOs 22-26, bank 2 is GPIOs 39-43. Unless you have a Compute Module, you must use bank 1: the GPIOs in bank 2 are only available on the Compute Module. Because of the way the OTP bits are arranged, if you first program GPIO boot mode for bank 1, you then have the option of selecting bank 2 later. The reverse is not true: once bank 2 has been selected for GPIO boot mode, you cannot select bank 1.
 
 Once GPIO boot mode is enabled, the Raspberry Pi will no longer boot. You must pull up at least one boot mode GPIO pin in order for the Pi to boot.
 
-Once enabled, the GPIOs are mapped as follows:
+Once enabled, the GPIOs are polled in numerical order as follows:
 
 |Bank 1|Bank2|boot type|
 |:----:|:---:|:-------:|

--- a/hardware/raspberrypi/bootmodes/gpio.md
+++ b/hardware/raspberrypi/bootmodes/gpio.md
@@ -26,6 +26,6 @@ The various boot modes are attempted in the numerical order of the GPIO pins, i.
 
 SD1 is the Broadcom SD card / MMC interface, which is used by default for the built-in SD card slot, and on the Compute Module for the eMMC. SD1 is the Arasan SD card / MMC interface which is also capable of SDIO. All Raspberry Pi models with built-in wifi use SD1 to connect to the wifi chip via SDIO, although it can be reassigned to other uses.
 
-USB in the table is USB device boot mode and USB host boot mode, which are only available on certain models of Raspberry Pi.
+USB in the table selects USB device boot mode and USB host boot mode, which are only available on certain models of Raspberry Pi.
 
 The default pull resistance on the GPIO lines is 50K ohm, as documented on page 102 of the [BCM2835 ARM peripherals datasheet](hardware/raspberrypi/bcm2835/BCM2835-ARM-Peripherals.pdf). A pull resistance of 5K ohm is recommended to pull a GPIO line up: this will allow the GPIO to function but not consume too much power.

--- a/hardware/raspberrypi/bootmodes/gpio.md
+++ b/hardware/raspberrypi/bootmodes/gpio.md
@@ -24,7 +24,7 @@ Once enabled, the GPIOs are allocated to boot modes as follows:
 
 The various boot modes are attempted in the numerical order of the GPIO pins, i.e. SD0, then SD1, then NAND and so on.
 
-SD0 is the Broadcom SD card / MMC interface. When the boot ROM within the SoC runs, it always connects SD0 to the built-in SD card slot. On Compute Modules with an eMMC device, SD0 is connected to that; on the Compute Module Lite SD0 ????? SD1 is the Arasan SD card / MMC interface which is also capable of SDIO. All Raspberry Pi models with built-in wifi use SD1 to connect to the wifi chip via SDIO.
+SD0 is the Broadcom SD card / MMC interface. When the boot ROM within the SoC runs, it always connects SD0 to the built-in SD card slot. On Compute Modules with an eMMC device, SD0 is connected to that; on the Compute Module Lite SD0 is available on the edge connector and connects to the SD card slot in the CMIO carrier board. SD1 is the Arasan SD card / MMC interface which is also capable of SDIO. All Raspberry Pi models with built-in wifi use SD1 to connect to the wifi chip via SDIO.
 
 It is possible to reassign both SD0 and SD1 to different uses after the Pi has booted, but the boot ROM will always use the assignments noted above at boot time.
 

--- a/hardware/raspberrypi/bootmodes/gpio.md
+++ b/hardware/raspberrypi/bootmodes/gpio.md
@@ -41,7 +41,7 @@ USB in the table above selects both USB device boot mode and USB host boot mode.
 
 ## Boot order
 
-The various boot modes are attempted in the numerical order of the GPIO pins, i.e. SD0, then SD1, then NAND and so on.
+The various boot modes are attempted in the numerical order of the GPIO lines, i.e. SD0, then SD1, then NAND and so on.
 
 ## Boot flow
 

--- a/hardware/raspberrypi/bootmodes/gpio.md
+++ b/hardware/raspberrypi/bootmodes/gpio.md
@@ -24,6 +24,6 @@ Once enabled, the GPIOs are polled in numerical order as follows:
 
 SD1 is the Broadcom SD card interface, which is used by default for the built-in SD card slot, and on the Compute Module for the eMMC. SD1 is the Arasan SD card interface which is also capable on SDIO.
 
-USB in the able table is USB device boot mode and USB host boot mode, which are only available on certain models of Raspberry Pi.
+USB in the table is USB device boot mode and USB host boot mode, which are only available on certain models of Raspberry Pi.
 
 The default pull resistance on the GPIO lines is 50K ohm, as documented on page 102 of the [BCM2835 ARM peripherals datasheet](hardware/raspberrypi/bcm2835/BCM2835-ARM-Peripherals.pdf). A pull resistance of 5K ohm is recommended to pull a GPIO line up: this will allow the GPIO to function but not consume too much power.

--- a/hardware/raspberrypi/bootmodes/gpio.md
+++ b/hardware/raspberrypi/bootmodes/gpio.md
@@ -1,6 +1,6 @@
 # GPIO boot mode
 
-**GPIO boot mode is only available on the Raspberry Pi 3B and 3B+.**
+**GPIO boot mode is only available on the Raspberry Pi 3A+, 3B, 3B+, Computer Module 3 and 3+**
 
 The Raspberry Pi can be configured to allow the boot mode to be selected at power on using hardware attached to the GPIO connector: this is GPIO boot mode. This is done by setting bits in the OTP memory of the SoC. Once the bits are set, they permanently allocate 5 GPIOs to allow this selection to be made. Once the OTP bits are set they cannot be unset so you should think carefully about enabling this, since those 5 GPIO lines will always control booting. Although you can use the GPIOs for some other function once the Pi has booted, you must set them up so that they enable the desired boot modes when the Pi boots.
 

--- a/hardware/raspberrypi/bootmodes/gpio.md
+++ b/hardware/raspberrypi/bootmodes/gpio.md
@@ -18,8 +18,8 @@ Once enabled, the GPIOs are allocated to boot modes as follows:
 |:----:|:---:|:---- ---:|
 |22    |39   |SD0       |
 |23    |40   |SD1       |
-|24    |41   |NAND (no Linux support at present)      |
-|25    |42   |SPI (no Linux support at present)      |
+|24    |41   |NAND      |
+|25    |42   |SPI       |
 |26    |43   |USB       |
 
 The various boot modes are attempted in the numerical order of the GPIO pins, i.e. SD0, then SD1, then NAND and so on.

--- a/hardware/raspberrypi/bootmodes/gpio.md
+++ b/hardware/raspberrypi/bootmodes/gpio.md
@@ -10,6 +10,8 @@ program_gpio_bootmode=n
 
 And reboot the Pi once to program the OTP with this setting. Where n is the bank of GPIOs which you wish to use. Bank 1 is GPIOs 22-26, bank 2 is GPIOs 39-43. Unless you have a compute module, you must use bank 1: the GPIOs in bank 2 are only available on the compute module.
 
+Once GPIO boot mode is enabled, the Raspberry Pi will no longer boot. You must pull up at least one boot mode GPIO pin in order for the Pi to boot.
+
 Once enabled, the GPIOs are mapped as follows:
 
 |Bank 1|Bank2|boot type|
@@ -21,3 +23,5 @@ Once enabled, the GPIOs are mapped as follows:
 |26    |43   |USB      |
 
 SD1 is the <xxx> SD card interface. SD2 is the <yyy> SD card interface. USB enables both USB device mode and USB host mode boot.
+
+The default pull resistance on the GPIO lines is 50K ohm, so a pull resistance of 5K ohm should suffice but still enable the GPIO to be operational but not consume a lot of power.

--- a/hardware/raspberrypi/bootmodes/gpio.md
+++ b/hardware/raspberrypi/bootmodes/gpio.md
@@ -1,6 +1,6 @@
 # GPIO boot mode
 
-**GPIO boot mode is only available on the Raspberry Pi 3A+, 3B, 3B+, Computer Module 3 and 3+**
+**GPIO boot mode is only available on the Raspberry Pi 3A+, 3B, 3B+, Compute Module 3 and 3+**
 
 The Raspberry Pi can be configured to allow the boot mode to be selected at power on using hardware attached to the GPIO connector: this is GPIO boot mode. This is done by setting bits in the OTP memory of the SoC. Once the bits are set, they permanently allocate 5 GPIOs to allow this selection to be made. Once the OTP bits are set they cannot be unset so you should think carefully about enabling this, since those 5 GPIO lines will always control booting. Although you can use the GPIOs for some other function once the Pi has booted, you must set them up so that they enable the desired boot modes when the Pi boots.
 

--- a/hardware/raspberrypi/bootmodes/gpio.md
+++ b/hardware/raspberrypi/bootmodes/gpio.md
@@ -2,7 +2,7 @@
 
 The Raspberry Pi can be configured to allow the boot mode to be selected at power on using hardware attached to the GPIO connector: this is GPIO boot mode. This is done by setting bits in the OTP memory of the SoC. Once the bits are set, they permanently allocate 5 GPIOs to allow this selection to be made. Once the OTP bits are set they cannot be unset so you should think carefully about enabling this, since those 5 GPIO lines will then be unavailable for any other use.
 
-To enable GPIO boot mode, add the following line to the [config.txt](../../../configurationconfig-txt/README.md) file:
+To enable GPIO boot mode, add the following line to the [config.txt](../../../configuration/config-txt/README.md) file:
 
 ```
 program_gpio_bootmode=n

--- a/hardware/raspberrypi/bootmodes/gpio.md
+++ b/hardware/raspberrypi/bootmodes/gpio.md
@@ -47,6 +47,4 @@ The various boot modes are attempted in the numerical order of the GPIO lines, i
 
 SD0 is the Broadcom SD card / MMC interface. When the boot ROM within the SoC runs, it always connects SD0 to the built-in microSD card slot. On Compute Modules with an eMMC device, SD0 is connected to that; on the Compute Module Lite SD0 is available on the edge connector and connects to the microSD card slot in the CMIO carrier board. SD1 is the Arasan SD card / MMC interface which is also capable of SDIO. All Raspberry Pi models with built-in wifi use SD1 to connect to the wifi chip via SDIO.
 
-It is possible to reassign both SD0 and SD1 to different uses after the Pi has booted, but the boot ROM will always use the assignments noted above at boot time.
-
 The default pull resistance on the GPIO lines is 50K ohm, as documented on page 102 of the [BCM2835 ARM peripherals datasheet](../../hardware/raspberrypi/bcm2835/BCM2835-ARM-Peripherals.pdf). A pull resistance of 5K ohm is recommended to pull a GPIO line up: this will allow the GPIO to function but not consume too much power.

--- a/hardware/raspberrypi/bootmodes/gpio.md
+++ b/hardware/raspberrypi/bootmodes/gpio.md
@@ -1,0 +1,1 @@
+# GPIO boot mode

--- a/hardware/raspberrypi/bootmodes/gpio.md
+++ b/hardware/raspberrypi/bootmodes/gpio.md
@@ -12,7 +12,7 @@ Where n is the bank of GPIOs which you wish to use. Then reboot the Pi once to p
 
 Once GPIO boot mode is enabled, the Raspberry Pi will no longer boot. You must pull up at least one boot mode GPIO pin in order for the Pi to boot.
 
-Once enabled, the GPIOs are polled in numerical order as follows:
+Once enabled, the GPIOs are allocated to boot modes as follows:
 
 |Bank 1|Bank2|boot type|
 |:----:|:---:|:-------:|
@@ -21,6 +21,8 @@ Once enabled, the GPIOs are polled in numerical order as follows:
 |24    |41   |NAND     |
 |25    |42   |SPI      |
 |26    |43   |USB      |
+
+The various boot modes are attempted in the numerical order of the GPIO pins, i.e. SD0, then SD1, then NAND and so on.
 
 SD1 is the Broadcom SD card / MMC interface, which is used by default for the built-in SD card slot, and on the Compute Module for the eMMC. SD1 is the Arasan SD card / MMC interface which is also capable of SDIO. All Raspberry Pi models with built-in wifi use SD1 to connect to the wifi chip via SDIO.
 

--- a/hardware/raspberrypi/bootmodes/gpio.md
+++ b/hardware/raspberrypi/bootmodes/gpio.md
@@ -8,7 +8,7 @@ To enable GPIO boot mode, add the following line to the [config.txt](../../../co
 program_gpio_bootmode=n
 ```
 
-Where n is the bank of GPIOs which you wish to use. Then reboot the Pi once to program the OTP with this setting. Bank 0 is GPIOs 22-26, bank 1 is GPIOs 39-43. Unless you have a Compute Module, you must use bank 0: the GPIOs in bank 1 are only available on the Compute Module. Because of the way the OTP bits are arranged, if you first program GPIO boot mode for bank 0, you then have the option of selecting bank 1 later. The reverse is not true: once bank 1 has been selected for GPIO boot mode, you cannot select bank 0.
+Where n is the bank of GPIOs which you wish to use. Then reboot the Pi once to program the OTP with this setting. Bank 1 is GPIOs 22-26, bank 2 is GPIOs 39-43. Unless you have a Compute Module, you must use bank 1: the GPIOs in bank 1 are only available on the Compute Module. Because of the way the OTP bits are arranged, if you first program GPIO boot mode for bank 1, you then have the option of selecting bank 2 later. The reverse is not true: once bank 2 has been selected for GPIO boot mode, you cannot select bank 1.
 
 Once GPIO boot mode is enabled, the Raspberry Pi will no longer boot. You must pull up at least one boot mode GPIO pin in order for the Pi to boot.
 

--- a/hardware/raspberrypi/bootmodes/gpio.md
+++ b/hardware/raspberrypi/bootmodes/gpio.md
@@ -1,6 +1,6 @@
 # GPIO boot mode
 
-The Raspberry Pi can be configured to allow the boot mode to be selected at power on using hardware attached to the GPIO connector: this is GPIO boot mode. This is done by setting bits in the OTP memory of the SoC. Once the bits are set, they permanently allocates 5 GPIOs to allow this selection to be made. Once the OTP bits are set they cannot be unset so you should think carefully about enabling this, since those 5 GPIO lines will then be permanently unavailable for any other use.
+The Raspberry Pi can be configured to allow the boot mode to be selected at power on using hardware attached to the GPIO connector: this is GPIO boot mode. This is done by setting bits in the OTP memory of the SoC. Once the bits are set, they permanently allocate 5 GPIOs to allow this selection to be made. Once the OTP bits are set they cannot be unset so you should think carefully about enabling this, since those 5 GPIO lines will then be permanently unavailable for any other use.
 
 To enable GPIO boot mode, add the following line to the config.txt file:
 

--- a/hardware/raspberrypi/bootmodes/gpio.md
+++ b/hardware/raspberrypi/bootmodes/gpio.md
@@ -15,7 +15,7 @@ Where n is the bank of GPIOs which you wish to use. Then reboot the Pi once to p
 Once GPIO boot mode is enabled, the Raspberry Pi will no longer boot. You must pull up at least one boot mode GPIO pin in order for the Pi to boot.
 
 ## GPIO boot mode pin assignments
-### Raspberry Pi 3B
+### Raspberry Pi 3B and Compute Module 3
 
 |Bank 1|Bank 2|boot type|
 |:----:|:---:|:--------:|
@@ -27,7 +27,7 @@ Once GPIO boot mode is enabled, the Raspberry Pi will no longer boot. You must p
 
 USB in the table above selects both USB device boot mode and USB host boot mode. In order to use a USB boot mode, it must by enabled in the OTP memory. For more information, see [USB device boot](device.md) and [USB host boot](host.md).
 
-### Raspberry Pi 3B+
+### Raspberry Pi 3A+, 3B+ and Compute Module 3+
 
 |Bank 1|Bank 2|boot type|
 |:----:|:---:|:--------:|

--- a/hardware/raspberrypi/bootmodes/gpio.md
+++ b/hardware/raspberrypi/bootmodes/gpio.md
@@ -14,7 +14,7 @@ Once GPIO boot mode is enabled, the Raspberry Pi will no longer boot. You must p
 
 Once enabled, the GPIOs are allocated to boot modes as follows:
 
-|Bank 1|Bank2|boot type|
+|Bank 1|Bank 2|boot type|
 |:----:|:---:|:-------:|
 |22    |39   |SD0      |
 |23    |40   |SD1      |

--- a/hardware/raspberrypi/bootmodes/gpio.md
+++ b/hardware/raspberrypi/bootmodes/gpio.md
@@ -24,4 +24,4 @@ Once enabled, the GPIOs are mapped as follows:
 
 SD1 is the <xxx> SD card interface. SD2 is the <yyy> SD card interface. USB enables both USB device mode and USB host mode boot.
 
-The default pull resistance on the GPIO lines is 50K ohm, so a pull resistance of 5K ohm should suffice but still enable the GPIO to be operational but not consume a lot of power.
+The default pull resistance on the GPIO lines is 50K ohm, as documented on page 102 of the [BCM2835 ARM peripherals datasheet](hardware/raspberrypi/bcm2835/BCM2835-ARM-Peripherals.pdf). A pull resistance of 5K ohm is recommended to pull a GPIO line up or down: this will allow the GPIO to function but not consume too much power.

--- a/hardware/raspberrypi/bootmodes/gpio.md
+++ b/hardware/raspberrypi/bootmodes/gpio.md
@@ -2,7 +2,7 @@
 
 The Raspberry Pi can be configured to allow the boot mode to be selected at power on using hardware attached to the GPIO connector: this is GPIO boot mode. This is done by setting bits in the OTP memory of the SoC. Once the bits are set, they permanently allocate 5 GPIOs to allow this selection to be made. Once the OTP bits are set they cannot be unset so you should think carefully about enabling this, since those 5 GPIO lines will then be unavailable for any other use.
 
-To enable GPIO boot mode, add the following line to the config.txt file:
+To enable GPIO boot mode, add the following line to the [config.txt](configuration/config-txt/README.md) file:
 
 ```
 program_gpio_bootmode=n


### PR DESCRIPTION
Currently, there is no specific page which documents GPIO boot mode. This PR proposes to add one. This will clarify that this is a specific boot mode, enabled by a specific GPIO. It will also document exactly which GPIO activates which type of boot (SD, MSD, Ethernet etc) - the current docs are not ideal in this regard.