### PR TITLE
Document 256GB SD card boot limit on all but 2837B0-based Pi's

### DIFF
--- a/installation/sd-cards.md
+++ b/installation/sd-cards.md
@@ -14,7 +14,7 @@ The card class determines the sustained write speed for the card; a class 4 card
 
 ## SD card physical size
 
-The original Raspberry Pi Model A and Raspberry Pi Model B require full-size SD cards. The newer [Raspberry Pi Model A+](https://www.raspberrypi.org/products/raspberry-pi-1-model/), [Raspberry Pi Model B+](https://www.raspberrypi.org/products/raspberry-pi-1-model-b/), [Raspberry Pi 2 Model B](https://www.raspberrypi.org/products/raspberry-pi-2-model-b/), [Raspberry Pi Zero](https://www.raspberrypi.org/products/raspberry-pi-zero/), and [Raspberry Pi 3 Model B](https://www.raspberrypi.org/products/raspberry-pi-3-model-b/) require micro SD cards.
+The original Raspberry Pi Model A and Raspberry Pi Model B require full-size SD cards. All newer models of Raspberry Pi require micro SD cards.
 
 ## Troubleshooting
 

--- a/installation/sd-cards.md
+++ b/installation/sd-cards.md
@@ -6,7 +6,7 @@ The Raspberry Pi should work with any compatible SD card, although there are som
 
 For installation of NOOBS or the image installation of Raspbian, the minimum recommended card size is 8GB. For Raspbian Lite image installations we recommend a minimum of 4GB. Some distributions, specifically LibreELEC and Arch, can run on much smaller cards. If you're planning to use a card of 64GB or more with NOOBS, see [this page](sdxc_formatting.md) first.
 
-**Note:** THe maximum size of SD card which most Raspberry Pis can boot from is 256GB. Only Raspberry Pi 3B+, 3A+ and Compute Module 3+ can boot from SD cards with a capacity larger than 256GB. This is due to a bug in the boot ROM within the SoC.
+**Note:** The maximum size of SD card which most Raspberry Pis can boot from is 256GB. Only Raspberry Pi 3B+, 3A+ and Compute Module 3+ can boot from SD cards with a capacity larger than 256GB. This is due to a bug in the boot ROM within the SoC.
 
 ## SD card class
 

--- a/installation/sd-cards.md
+++ b/installation/sd-cards.md
@@ -2,15 +2,17 @@
 
 The Raspberry Pi should work with any compatible SD card, although there are some guidelines that should be followed:
 
-## SD card size (capacity). 
+## SD card size (capacity) 
 
 For installation of NOOBS or the image installation of Raspbian, the minimum recommended card size is 8GB. For Raspbian Lite image installations we recommend a minimum of 4GB. Some distributions, specifically LibreELEC and Arch, can run on much smaller cards. If you're planning to use a card of 64GB or more with NOOBS, see [this page](sdxc_formatting.md) first.
 
-## SD card class. 
+**Note:** Only Raspberry Pi 3B+, 3A+ and Compute Module 3+ can boot from SD cards with a capacity larger than 256GB. This is due to a bug in the boot ROM within the SoC.
+
+## SD card class
 
 The card class determines the sustained write speed for the card; a class 4 card will be able to write at 4MB/s, whereas a class 10 should be able to attain 10 MB/s. However, it should be noted that this does not mean a class 10 card will outperform a class 4 card for general usage, because often this write speed is achieved at the cost of read speed and increased seek times.
 
-## SD card physical size. 
+## SD card physical size
 
 The original Raspberry Pi Model A and Raspberry Pi Model B require full-size SD cards. The newer [Raspberry Pi Model A+](https://www.raspberrypi.org/products/raspberry-pi-1-model/), [Raspberry Pi Model B+](https://www.raspberrypi.org/products/raspberry-pi-1-model-b/), [Raspberry Pi 2 Model B](https://www.raspberrypi.org/products/raspberry-pi-2-model-b/), [Raspberry Pi Zero](https://www.raspberrypi.org/products/raspberry-pi-zero/), and [Raspberry Pi 3 Model B](https://www.raspberrypi.org/products/raspberry-pi-3-model-b/) require micro SD cards.
 

--- a/installation/sd-cards.md
+++ b/installation/sd-cards.md
@@ -6,7 +6,7 @@ The Raspberry Pi should work with any compatible SD card, although there are som
 
 For installation of NOOBS or the image installation of Raspbian, the minimum recommended card size is 8GB. For Raspbian Lite image installations we recommend a minimum of 4GB. Some distributions, specifically LibreELEC and Arch, can run on much smaller cards. If you're planning to use a card of 64GB or more with NOOBS, see [this page](sdxc_formatting.md) first.
 
-**Note:** The maximum size of SD card which most Raspberry Pis can boot from is 256GB. Only Raspberry Pi 3B+, 3A+ and Compute Module 3+ can boot from SD cards with a capacity larger than 256GB. This is due to a bug in the boot ROM within the SoC.
+**Note:** The maximum size of SD card which most Raspberry Pis can boot from is 256GB, due to a bug in the SoC. The Raspberry Pi 3A+, 3B+ and Compute Module 3+ can successfuly boot from an SD card larger than 256 GB since they have a newer SoC, the Broadcom 2837B0.
 
 ## SD card class
 

--- a/installation/sd-cards.md
+++ b/installation/sd-cards.md
@@ -6,7 +6,7 @@ The Raspberry Pi should work with any compatible SD card, although there are som
 
 For installation of NOOBS or the image installation of Raspbian, the minimum recommended card size is 8GB. For Raspbian Lite image installations we recommend a minimum of 4GB. Some distributions, specifically LibreELEC and Arch, can run on much smaller cards. If you're planning to use a card of 64GB or more with NOOBS, see [this page](sdxc_formatting.md) first.
 
-**Note:** The maximum size of SD card which most Raspberry Pis can boot from is 256GB, due to a bug in the SoC. The Raspberry Pi 3A+, 3B+ and Compute Module 3+ can successfuly boot from an SD card larger than 256 GB since they have a newer SoC, the Broadcom 2837B0.
+**Note:** Only the Raspberry Pi 3A+, 3B+ and Compute Module 3+ can boot from an SD card larger than 256 GB. This is because there was a bug in the SoC used on previous models of Pi. 
 
 ## SD card class
 

--- a/installation/sd-cards.md
+++ b/installation/sd-cards.md
@@ -6,7 +6,7 @@ The Raspberry Pi should work with any compatible SD card, although there are som
 
 For installation of NOOBS or the image installation of Raspbian, the minimum recommended card size is 8GB. For Raspbian Lite image installations we recommend a minimum of 4GB. Some distributions, specifically LibreELEC and Arch, can run on much smaller cards. If you're planning to use a card of 64GB or more with NOOBS, see [this page](sdxc_formatting.md) first.
 
-**Note:** Only Raspberry Pi 3B+, 3A+ and Compute Module 3+ can boot from SD cards with a capacity larger than 256GB. This is due to a bug in the boot ROM within the SoC.
+**Note:** THe maximum size of SD card which most Raspberry Pis can boot from is 256GB. Only Raspberry Pi 3B+, 3A+ and Compute Module 3+ can boot from SD cards with a capacity larger than 256GB. This is due to a bug in the boot ROM within the SoC.
 
 ## SD card class
 


### PR DESCRIPTION
Also remove extraneous periods from end of headings.