### PR TITLE
Add codec key OTP register numbers

### DIFF
--- a/hardware/raspberrypi/otpbits.md
+++ b/hardware/raspberrypi/otpbits.md
@@ -26,6 +26,8 @@ This list contains the publicly available information on the registers. If a reg
 28 – serial number   
 29 – ~(serial number)   
 30 – revision number   
+45 - MPG2 decode key   
+46 - WVC1 decode key   
 64/65 – MAC address; if set, system will use this in preference to the automatically generated address based on the serial number    
 66 – advanced boot register
    - Bits 0-6: GPIO for ETH_CLK output pin


### PR DESCRIPTION
After setting decode_MPG2 and decode_WVC1 _and_ checking whether the
codec is enabled, these register contain a copy of the keys.