### PR TITLE
Mount the boot partition on the pi, for updating

### DIFF
--- a/hardware/raspberrypi/bootmodes/net_tutorial.md
+++ b/hardware/raspberrypi/bootmodes/net_tutorial.md
@@ -219,11 +219,12 @@ sudo systemctl restart dnsmasq
 
 This should now allow your Raspberry Pi client to attempt to boot through until it tries to load a root file system (which it doesn't have).
 
-At this point, export the `/nfs/client1` file system created earlier.
+At this point, export the `/nfs/client1` file system created earlier, and the TFTP boot folder.
 
 ```bash
 sudo apt-get install nfs-kernel-server
 echo "/nfs/client1 *(rw,sync,no_subtree_check,no_root_squash)" | sudo tee -a /etc/exports
+echo "/tftpboot *(rw,sync,no_subtree_check,no_root_squash)" | sudo tee -a /etc/exports
 ```
 
 Restart RPC-Bind and the NFS server in order to have them detect the new files.
@@ -243,6 +244,9 @@ root=/dev/nfs nfsroot=10.42.0.211:/nfs/client1,vers=3 rw ip=dhcp rootwait elevat
 
 You should substitute the IP address here with the IP address you have noted down. Also remove any part of the command line starting with init=.
 
-Finally, edit `/nfs/client1/etc/fstab` and remove the `/dev/mmcblkp1` and `p2` lines (only `proc` should be left).
+Finally, edit `/nfs/client1/etc/fstab` and remove the `/dev/mmcblkp1` and `p2` lines (only `proc` should be left). Then, add the boot partition back in:
+```
+echo "10.42.0.211:/tftpboot /boot nfs defaults,vers=3 0 0" | sudo tee -a /etc/fstab
+```
 
 Good luck! If it doesn't boot on the first attempt, keep trying. It can take a minute or so for the Raspberry Pi to boot, so be patient.


### PR DESCRIPTION
If an updated package puts files into /boot, it'll be applied, but if you don't have /boot mounted, you'll end up with the TFTP boot not being in sync with the rest of the filesystem.

For me, this recently manifested as USB devices [keyboard, mouse] not working after a kernel update.

An couple alternative solutions are to serve TFTP directly out of the boot folder on the NFS-exported root, or use symlinks to point /tftpboot into /nfs/client1 on the server.

But, in the spirit of keeping /boot separate for all the classic reasons [and, in my case, serving out of a NAS that made that setup nonobvious], I follow the rest of the instructions as-is, then mount the boot partition back into the filesystem via fstab