### PR TITLE
Update building.md

### DIFF
--- a/linux/kernel/building.md
+++ b/linux/kernel/building.md
@@ -51,7 +51,7 @@ make bcmrpi_defconfig
 ```bash
 cd linux
 KERNEL=kernel7
-make bcm2709_defconfig
+make bcmrpi3_defconfig
 ```
 
 Build and install the kernel, modules, and Device Tree blobs; this step takes a **long** time:


### PR DESCRIPTION
It seems "bcm2709_defconfig" is replaced with "bcmrpi3_defconfig"