### PR TITLE
configuration/config-txt/video.md: clarify hdmi_blanking option

### DIFF
--- a/configuration/config-txt/video.md
+++ b/configuration/config-txt/video.md
@@ -116,7 +116,7 @@ The `hdmi_pixel_encoding` command forces the pixel encoding mode. By default, it
 
 ### hdmi_blanking
 
-The `hdmi_blanking` command controls what happens when the operating system asks for the display to be put into standby mode, using DPMS, to save power. If this option is not set or set to 0, the HDMI output is blanked but not switched off. In order to mimic the behaviour of other computers, you can set the HDMI output to switch off as well by setting this option to 1. In response to the HDMI signal being switched off, the attached display will go into a low power standby mode.
+The `hdmi_blanking` command controls what happens when the operating system asks for the display to be put into standby mode, using DPMS, to save power. If this option is not set or set to 0, the HDMI output is blanked but not switched off. In order to mimic the behaviour of other computers, you can set the HDMI output to switch off as well by setting this option to 1: the attached display will go into a low power standby mode.
 
 **NOTE:** This feature may cause issues when using applications which don't use the framebuffer, such as omxplayer.
 

--- a/configuration/config-txt/video.md
+++ b/configuration/config-txt/video.md
@@ -118,6 +118,8 @@ The `hdmi_pixel_encoding` command forces the pixel encoding mode. By default, it
 
 The `hdmi_blanking` command controls what happens when the operating system asks for the display to be put into standby mode, using DPMS, to save power. If this option is not set or set to 0, the HDMI output is blanked but not switched off. In order to mimic the behaviour of other computers, you can set the HDMI output to switch off as well by setting this option to 1: the attached display will go into a low power standby mode.
 
+**On the Raspberry Pi 4, setting hdmi_blanking=1 will not cause the HDMI output to be disabled, since this feature has not yet been implemented.**
+
 **NOTE:** This feature may cause issues when using applications which don't use the framebuffer, such as omxplayer.
 
 | hdmi_blanking | result |

--- a/configuration/config-txt/video.md
+++ b/configuration/config-txt/video.md
@@ -116,14 +116,14 @@ The `hdmi_pixel_encoding` command forces the pixel encoding mode. By default, it
 
 ### hdmi_blanking
 
-The `hdmi_blanking` command allows you to choose whether the HDMI output should be switched off when DPMS is triggered. This is to mimic the behaviour of other computers. After a specific amount of time, the display will become blank and go into low-power/standby mode due to receiving no signal.
+The `hdmi_blanking` command controls what happens when the operating system asks for the display to be put into standby mode to save power. If this option is not set or set to 0, the HDMI output is blanked but not switched off. In order to mimic the behaviour of other computers, you can set the HDMI output to switch off as well by setting this option to 1. In response to the HDMI signal being switched off, the attached display will go into a low power standby mode.
 
 **NOTE:** This feature may cause issues when using applications which don't use the framebuffer, such as omxplayer.
 
 | hdmi_blanking | result |
 | --- | --- |
-| 0 | HDMI Output will blank instead of being disabled |
-| 1 | HDMI Output will be disabled rather than just blanking |
+| 0 | HDMI output will blanked |
+| 1 | HDMI output will be switched off and blanked |
 
 ### hdmi_drive
 

--- a/configuration/config-txt/video.md
+++ b/configuration/config-txt/video.md
@@ -116,7 +116,7 @@ The `hdmi_pixel_encoding` command forces the pixel encoding mode. By default, it
 
 ### hdmi_blanking
 
-The `hdmi_blanking` command controls what happens when the operating system asks for the display to be put into standby mode to save power. If this option is not set or set to 0, the HDMI output is blanked but not switched off. In order to mimic the behaviour of other computers, you can set the HDMI output to switch off as well by setting this option to 1. In response to the HDMI signal being switched off, the attached display will go into a low power standby mode.
+The `hdmi_blanking` command controls what happens when the operating system asks for the display to be put into standby mode, using DPMS, to save power. If this option is not set or set to 0, the HDMI output is blanked but not switched off. In order to mimic the behaviour of other computers, you can set the HDMI output to switch off as well by setting this option to 1. In response to the HDMI signal being switched off, the attached display will go into a low power standby mode.
 
 **NOTE:** This feature may cause issues when using applications which don't use the framebuffer, such as omxplayer.
 

--- a/configuration/config-txt/video.md
+++ b/configuration/config-txt/video.md
@@ -118,7 +118,7 @@ The `hdmi_pixel_encoding` command forces the pixel encoding mode. By default, it
 
 The `hdmi_blanking` command controls what happens when the operating system asks for the display to be put into standby mode, using DPMS, to save power. If this option is not set or set to 0, the HDMI output is blanked but not switched off. In order to mimic the behaviour of other computers, you can set the HDMI output to switch off as well by setting this option to 1: the attached display will go into a low power standby mode.
 
-**On the Raspberry Pi 4, setting hdmi_blanking=1 will not cause the HDMI output to be disabled, since this feature has not yet been implemented.**
+**On the Raspberry Pi 4, setting hdmi_blanking=1 will not cause the HDMI output to be switched off, since this feature has not yet been implemented.**
 
 **NOTE:** This feature may cause issues when using applications which don't use the framebuffer, such as omxplayer.
 

--- a/configuration/config-txt/video.md
+++ b/configuration/config-txt/video.md
@@ -122,7 +122,7 @@ The `hdmi_blanking` command controls what happens when the operating system asks
 
 | hdmi_blanking | result |
 | --- | --- |
-| 0 | HDMI output will blanked |
+| 0 | HDMI output will be blanked |
 | 1 | HDMI output will be switched off and blanked |
 
 ### hdmi_drive


### PR DESCRIPTION
The wording was not ideal. I would propose running this through copy edit to apply more polish.

Also, is there anything specific to the Pi 4 that we need to mention here?