### PR TITLE
Update video.md: long overdue update to sdtv_mode

### DIFF
--- a/configuration/config-txt/video.md
+++ b/configuration/config-txt/video.md
@@ -4,7 +4,7 @@
 
 ### sdtv_mode
 
-The `sdtv_mode` command defines the TV standard used for composite video output. On the original Raspberry Pi, composite video is output on the RCA socket. On other Raspberry Pi's, except for Pi Zero and Compute Module, composite video is output along with sound on the 4 pole TRRS ("headphone") socket. (The Pi Zero and Compute Module do not have a connector for composite video output). The default value of `sdtv_mode` is `0`.
+The `sdtv_mode` command defines the TV standard used for composite video output. On the original Raspberry Pi, composite video is output on the RCA socket. On other Raspberry Pi's, except for Pi Zero and Compute Module, composite video is output along with sound on the 4 pole TRRS ("headphone") socket. On the Pi Zero, there is an unpopulated header labelled "TV" which outputs composite video. On the Compute Module, composite video is available via the TVDAC pin. The default value of `sdtv_mode` is `0`.
 
 | sdtv_mode | result |
 | --- | --- |

--- a/configuration/config-txt/video.md
+++ b/configuration/config-txt/video.md
@@ -4,7 +4,7 @@
 
 ### sdtv_mode
 
-The `sdtv_mode` command defines the TV standard used for composite video output over the yellow RCA jack. The default value is `0`.
+The `sdtv_mode` command defines the TV standard used for composite video output. On the original Raspberry Pi, composite video is output on the RCA socket. On other Raspberry Pi's, except for Pi Zero and Compute Module, composite video is output along with sound on the 4 pole TRRS ("headphone") socket. (The Pi Zero and Compute Module do not have a connector for composite video output). The default value of `sdtv_mode` is `0`.
 
 | sdtv_mode | result |
 | --- | --- |


### PR DESCRIPTION
The page currently says composite is output on the yellow RCA jack. This is wrong - original Pi's had an RCA socket, not jack, and they were not all yellow. Also, most Pi models output composite via the TRRS socket. Finally, Zero and CM don't have a connector for composite.