### PR TITLE
[UPDATE] Minor grammar changes to README

### DIFF
--- a/configuration/README.md
+++ b/configuration/README.md
@@ -5,35 +5,35 @@ Some basic guides to configuring your Raspberry Pi.
 ## Contents
 
 - [raspi-config](raspi-config.md)
-    - The Raspberry Pi configuration tool in Raspbian, allowing you to easily enable features such as the camera, and to change your specific settings such as keyboard layout
+    - The Raspberry Pi configuration tool in Raspbian that allows you to easily enable features such as the camera, and to change your specific settings such as keyboard layout
 - [config.txt](config-txt/README.md)
     - The Raspberry Pi configuration file
 - [Wireless networking](wireless/README.md)
     - Configuring your Pi to connect to a wireless network using the Raspberry Pi 3's or Pi Zero W's inbuilt wireless connectivity, or a USB wireless dongle
 - [Wireless access point](wireless/access-point.md)
-    - Configuring your Pi as a wireless access point using the Raspberry Pi 3 and Pi Zero W's inbuilt wireless connectivity, or a USB wireless dongle
+    - Configuring your Pi as a wireless access point using the Raspberry Pi 3 or Pi Zero W's inbuilt wireless connectivity, or a USB wireless dongle
 - [Using a proxy](use-a-proxy.md)
     - Setting up your Pi to access the internet via a proxy server
 - [HDMI Config](hdmi-config.md)
-    - Guide to setting up your HDMI device, including custom settings
+    - Setting up your HDMI device, including custom settings
 - [Screen Layout Editor](arandr.md)
-    - Guide to setting up your display devices using the provided graphical editor
+    - Setting up your display devices using the provided graphical editor
 - [Audio config](audio-config.md)
-    - Switch your audio output between HDMI and the 3.5mm jack
+    - Switching your audio output between HDMI and the 3.5mm jack
 - [Camera config](camera.md)
     - Installing and setting up the Raspberry Pi camera board
 - [External storage config](external-storage.md)
     - Mounting and setting up external storage on a Raspberry Pi
 - [Localisation](localisation.md)
-    - Setting up your Pi to work in your local language/time zone
+    - Setting up your Pi to work in your local language & time zone
 - [Default pin configuration](pin-configuration.md)
     - Changing the default pin states.
 - [Device Trees config](device-tree.md)
     - Device Trees, overlays, and parameters
 - [Kernel command line](cmdline-txt.md)
-    - How to set options in the kernel command line
+    - Setting options in the kernel command line
 - [UART configuration](uart.md)
-    - How to set up the on-board UARTs
+    - Setting up the on-board UARTs
 - [Firmware warning icons](warning-icons.md)
     - Description of warning icons displayed if the firmware detects issues
 - [LED warning flash codes](led_blink_warnings.md)
@@ -41,7 +41,7 @@ Some basic guides to configuring your Raspberry Pi.
 - [Securing your Raspberry Pi](security.md)
     - Some basic advice for making your Raspberry Pi more secure
 - [Screensaver](screensaver.md)
-    - How to configure screen blanking/screen saver
+    - Configuring the screen saver and screen blanking
 - [The boot folder](boot_folder.md)
     - What it's for and what's in it
 

--- a/configuration/README.md
+++ b/configuration/README.md
@@ -37,7 +37,7 @@ Some basic guides to configuring your Raspberry Pi.
 - [Firmware warning icons](warning-icons.md)
     - Description of warning icons displayed if the firmware detects issues
 - [LED warning flash codes](led_blink_warnings.md)
-    - Description of the meaning of LED warning flashes that are shown if a Pi fails to boot or has to shut down
+    - Description of LED warning flashes that are shown if a Pi fails to boot or has to shut down
 - [Securing your Raspberry Pi](security.md)
     - Some basic advice for making your Raspberry Pi more secure
 - [Screensaver](screensaver.md)

--- a/configuration/README.md
+++ b/configuration/README.md
@@ -5,13 +5,13 @@ Some basic guides to configuring your Raspberry Pi.
 ## Contents
 
 - [raspi-config](raspi-config.md)
-    - The Raspberry Pi configuration tool in Raspbian that allows you to easily enable features such as the camera, and to change your specific settings such as keyboard layout
+    - The Raspberry Pi configuration tool in Raspbian, which allows you to easily enable features such as the camera, and to change your specific settings such as keyboard layout
 - [config.txt](config-txt/README.md)
     - The Raspberry Pi configuration file
 - [Wireless networking](wireless/README.md)
     - Configuring your Pi to connect to a wireless network using the Raspberry Pi 3's or Pi Zero W's inbuilt wireless connectivity, or a USB wireless dongle
 - [Wireless access point](wireless/access-point.md)
-    - Configuring your Pi as a wireless access point using the Raspberry Pi 3 or Pi Zero W's inbuilt wireless connectivity, or a USB wireless dongle
+    - Configuring your Pi as a wireless access point using Raspberry Pi 3 or Raspberry Pi Zero W's inbuilt wireless connectivity, or a USB wireless dongle
 - [Using a proxy](use-a-proxy.md)
     - Setting up your Pi to access the internet via a proxy server
 - [HDMI Config](hdmi-config.md)
@@ -25,7 +25,7 @@ Some basic guides to configuring your Raspberry Pi.
 - [External storage config](external-storage.md)
     - Mounting and setting up external storage on a Raspberry Pi
 - [Localisation](localisation.md)
-    - Setting up your Pi to work in your local language & time zone
+    - Setting up your Pi to work in your local language and time zone
 - [Default pin configuration](pin-configuration.md)
     - Changing the default pin states.
 - [Device Trees config](device-tree.md)


### PR DESCRIPTION
I changed the grammar on some of the descriptions of the guides, making them more grammatically parallel to each other and adding some other small changes.