### PR TITLE
Fix broken command and link

### DIFF
--- a/configuration/wireless/access-point.md
+++ b/configuration/wireless/access-point.md
@@ -7,7 +7,7 @@ The Raspberry Pi can be used as a wireless access point, running a standalone ne
 
 Note that this documentation was tested on a Raspberry Pi 3, and it is possible that some USB dongles may need slight changes to their settings. If you are having trouble with a USB wireless dongle, please check the forums.
 
-To add a Raspberry Pi-based access point to an existing network, see [this section](#user-content-using-the-raspberry-pi-as-an-access-point-to-share-an-internet-connection-bridge).
+To add a Raspberry Pi-based access point to an existing network, see [this section](#internet-sharing).
 
 In order to work as an access point, the Raspberry Pi will need to have access point software installed, along with DHCP server software to provide connecting devices with a network address. Ensure that your Raspberry Pi is using an up-to-date version of Raspbian dated 2017 or later.
 

--- a/configuration/wireless/access-point.md
+++ b/configuration/wireless/access-point.md
@@ -7,7 +7,7 @@ The Raspberry Pi can be used as a wireless access point, running a standalone ne
 
 Note that this documentation was tested on a Raspberry Pi 3, and it is possible that some USB dongles may need slight changes to their settings. If you are having trouble with a USB wireless dongle, please check the forums.
 
-To add a Raspberry Pi-based access point to an existing network, see [this section](#internet-sharing).
+To add a Raspberry Pi-based access point to an existing network, see [this section](#user-content-using-the-raspberry-pi-as-an-access-point-to-share-an-internet-connection-bridge).
 
 In order to work as an access point, the Raspberry Pi will need to have access point software installed, along with DHCP server software to provide connecting devices with a network address. Ensure that your Raspberry Pi is using an up-to-date version of Raspbian dated 2017 or later.
 

--- a/configuration/wireless/access-point.md
+++ b/configuration/wireless/access-point.md
@@ -188,6 +188,7 @@ ssh pi@192.168.4.1
 
 By this point, the Raspberry Pi is acting as an access point, and other devices can associate with it. Associated devices can access the Raspberry Pi access point via its IP address for operations such as `rsync`, `scp`, or `ssh`.
 
+<a name="internet-sharing"></a>
 ## Using the Raspberry Pi as an access point to share an internet connection (bridge)
 
 One common use of the Raspberry Pi as an access point is to provide wireless connections to a wired Ethernet connection, so that anyone logged into the access point can access the internet, providing of course that the wired Ethernet on the Pi can connect to the internet via some sort of router.

--- a/configuration/wireless/access-point.md
+++ b/configuration/wireless/access-point.md
@@ -9,21 +9,7 @@ Note that this documentation was tested on a Raspberry Pi 3, and it is possible 
 
 To add a Raspberry Pi-based access point to an existing network, see [this section](#internet-sharing).
 
-In order to work as an access point, the Raspberry Pi will need to have access point software installed, along with DHCP server software to provide connecting devices with a network address. Ensure that your Raspberry Pi is using an up-to-date version of Raspbian dated 2017 or later.
-
-Use the following to update your Raspbian installation:
-
-```
-sudo apt update
-sudo apt upgrade
-sudo apt dist-upgrade
-```
-
-If an updated kernel was installed, consider rebooting:
-
-```
-sudo reboot
-```
+In order to work as an access point, the Raspberry Pi will need to have access point software installed, along with DHCP server software to provide connecting devices with a network address.
 
 To create an access point, we'll need DNSMasq and HostAPD. Install all the required software in one go with this command:
 

--- a/configuration/wireless/access-point.md
+++ b/configuration/wireless/access-point.md
@@ -16,7 +16,7 @@ Use the following to update your Raspbian installation:
 ```
 sudo apt update
 sudo apt upgrade
-sudo dist-upgrade
+sudo apt dist-upgrade
 ```
 
 If an updated kernel was installed, consider rebooting:


### PR DESCRIPTION
A heading had been changed so the link to it was broken.

Also fixed where the wrong command was given for upgrading:
`sudo dist-upgrade` -> `sudo apt dist-upgrade`