### PR TITLE
configuration/config-txt/memory.md: Max for gpu_mem should be 512

### DIFF
--- a/configuration/config-txt/memory.md
+++ b/configuration/config-txt/memory.md
@@ -2,7 +2,9 @@
 
 ## gpu_mem
 
-GPU memory in megabytes, sets the memory split between the CPU and GPU; the CPU gets the remaining memory. The minimum value is `16`; the maximum value is `192`, `448`, or `944`, depending on whether you are using a 256MB, 512MB, or 1024MB Pi. The default value is `64`. For the Raspberry Pi 4, which is available in 1GB, 2GB and 4GB versions, the minimum and maximum value are the same as for a 1GB device.
+GPU memory in megabytes, sets the memory split between the CPU and GPU; the CPU gets the remaining memory. The minimum value is `16`; the maximum value is `192`, `448`, or `512`, depending on whether you are using a 256MB, 512MB, or 1024MB Pi. The default value is `64`. For the Raspberry Pi 4, which is available in 1GB, 2GB and 4GB versions, the minimum and maximum value are the same as for a 1GB device.
+
+(Note that it is possible to set gpu_mem to higher than `512`, although this is untested and is therefore unlikely to work correctly).
 
 Setting `gpu_mem` to low values may automatically disable certain firmware features, as there are some things the GPU cannot do if it has access to too little memory. So if a feature you are trying to use isn't working, try setting a larger GPU memory split.
 


### PR DESCRIPTION
Per timg236 on the forums (see https://www.raspberrypi.org/forums/viewtopic.php?f=28&t=247820#p1518230):

> There's no guarantee that anything > 512MB will work and is completely untested.

So fix the docs to specify 512 as the max for gpu_mem, and add a warning that it is possible to set gpu_mem greater than this but this is likely to cause breakage.