### PR TITLE
fix markdown heading typos

### DIFF
--- a/hardware/raspberrypi/bcm2837/README.md
+++ b/hardware/raspberrypi/bcm2837/README.md
@@ -1,4 +1,3 @@
-
 # BCM2837
 
 This is the Broadcom chip used in the Raspberry Pi 3, and in later models of the Raspberry Pi 2. The underlying architecture of the BCM2837 is identical to the BCM2836. The only significant difference is the replacement of the ARMv7 quad core cluster with a quad-core ARM Cortex A53 (ARMv8) cluster.

--- a/remote-access/ssh/android.md
+++ b/remote-access/ssh/android.md
@@ -3,7 +3,7 @@
 To use SSH on your mobile device you need to download a client. There are several different good quality clients available, such as [Termius](http://www.termius.com), [JuiceSSH](https://juicessh.com/), and [Connectbot](https://connectbot.org/). For this tutorial we will use Termius, because it is a popular cross-platform SSH client. The process will be similar for other clients. 
 
 
-##1. Add your Raspberry Pi as a host
+## 1. Add your Raspberry Pi as a host
 
 Download Termius from [Google Play](https://play.google.com/store/apps/details?id=com.server.auditor.ssh.client), if you haven't installed it already. Click to open the app.
 
@@ -16,7 +16,7 @@ Enter an `alias`, such as Raspberry Pi. Then enter the IP address under `hostnam
 If you do not know the IP address, type `hostname -I` in the command line on the Raspberry Pi. See [here](../ip-address.md) for more ways to find your IP address. The default login for Raspbian is `pi` with the password `raspberry`.
 
 
-##2. Connect
+## 2. Connect
 
 When you have saved the new host, you will be sent back to the ‘Hosts’ screen. There, you will find the new entry. Make sure your mobile device has wireless connectivity turned on, and that it is connected to the same network as your Raspberry Pi.
 
@@ -37,7 +37,7 @@ You can type `exit` to close the terminal window.
 If a dialogue saying `Connection failed Connecting to 192.xxx.xxx.xxx port 22` appears, it is likely that you have entered an incorrect IP address. If the IP address is correct, wireless connectivity on your mobile device might be turned off; the Raspberry Pi might be turned off; or the Raspberry Pi and your mobile device may be connected to different networks.
 
 
-##3. Modify an entry, troubleshooting, and more
+## 3. Modify an entry, troubleshooting, and more
 
 A connection might be unsuccessful for various reasons. The most likely reasons are that your device or Raspberry Pi are [not connected properly](../../configuration/wireless/wireless-cli.md); [SSH is disabled](../../configuration/raspi-config.md); there is a typo in your code, or the IP address or credentials have changed. In the latter cases, you will need to update the host.
 

--- a/remote-access/ssh/ios.md
+++ b/remote-access/ssh/ios.md
@@ -1,10 +1,10 @@
-#SSH USING iOS
+# SSH USING iOS
 
 To use SSH on your mobile device you need to download a client. There are several good quality clients available, such as [Termius](http://www.termius.com), [Prompt 2](https://panic.com/prompt/), and  [Cathode](http://www.secretgeometry.com/apps/cathode/). 
 
 For this tutorial we will use Termius, because it is a popular cross-platform SSH client. The process will be similar for other clients. 
 
-##1. Add your Raspberry Pi as a host.
+## 1. Add your Raspberry Pi as a host.
 Download Termius from [iTunes](https://itunes.apple.com/us/app/termius-ssh-shell-console/id549039908?mt=8), if you haven’t installed it yet. Click to open the app.
 
 A prompt asking you to allow notifications will pop up. You should click ‘Allow’ (recommended). Now follow the instruction on the screen: `Start by adding a new host`. Tap `New Host` and a new window will pop up.
@@ -16,7 +16,7 @@ Enter an `alias`, such as ‘Raspberry Pi’. Then enter the IP address under `h
 If you do not know the IP address, type `hostname -I` in the command line on the Raspberry Pi. See [here](../ip-address.md) for more ways to find your IP address. The default login for Raspbian is `pi` with the password `raspberry`.
 
 
-##2. Connect
+## 2. Connect
 
 When you have saved the new host, you will be sent back to the ‘Hosts’ screen. There you will find the new entry. Make sure your mobile device has wireless connectivity turned on, and is connected to the same network as your Raspberry Pi.
 
@@ -37,7 +37,7 @@ You can type `exit` to close the terminal window.
 
 If a red exclamation mark appears, this indicates that something has gone wrong. Tap the exclamation mark to see the error description. ‘Connection establishment time out’ indicates that you have probably entered an incorrect IP address. If the IP address is correct, wireless connectivity on your mobile device might be turned off; the Raspberry Pi might be turned off; or the Raspberry Pi and your mobile device might be connected to different networks.
 
-##3. Modify an entry, troubleshooting, and more
+## 3. Modify an entry, troubleshooting, and more
 A connection might be unsuccessful for various reasons. It is likely that your device or Raspberry Pi is [not connected properly](../../configuration/wireless/wireless-cli.md); [SSH is disabled](../../configuration/raspi-config.md); there is a typo in your code; or the IP address or credentials have changed. In the latter cases, you will need to update the host.
 
 To do so, go to the ‘Hosts’ screen, swipe left on the host you need to edit, and new functions will appear. Tap edit. A new screen titled ‘Edit Host’ will pop up.

--- a/remote-access/ssh/windows.md
+++ b/remote-access/ssh/windows.md
@@ -4,7 +4,7 @@ Depending on the version of Windows you are using and what software you have alr
 
 Look for `putty.exe` under the heading `For Windows on Intel x86`. 
 
-##1. Add your Raspberry Pi as a host
+## 1. Add your Raspberry Pi as a host
 Start PuTTY.  You will see the configuration screen below:
 
 ![PuTTY configuration](images/ssh-win-config.png)
@@ -13,7 +13,7 @@ Type the IP address of the Pi into the `Host Name` field and click the `Open` bu
 
 If you do not know the IP address, type `hostname -I` in the Raspberry Pi command line. There are more ways to find your IP address [here](../ip-address.md).
 
-##2. Connect
+## 2. Connect
 When the connection works you will see the security warning shown below. You can safely ignore it, and click the 'Yes' button. You will only see this warning the first time PuTTY connects to a Raspberry Pi that it has not seen before.
 
 ![PuTTY warning](images/ssh-win-warning.png)


### PR DESCRIPTION
fixed `#text` to `# text`; this way github renders the text correctly