### PR TITLE
"grep XX | awk {print}" shows unfamiliarity with awk command

### DIFF
--- a/hardware/raspberrypi/bootmodes/net_tutorial.md
+++ b/hardware/raspberrypi/bootmodes/net_tutorial.md
@@ -64,7 +64,7 @@ sudo umount dev sys proc
 Find the settings of your local network. You need to find the address of your router (or gateway), which can be done with:
 
 ```bash
-ip route | grep default | awk '{print $3}'
+ip route | awk '/default/ {print $3}'
 ```
 
 Then run:


### PR DESCRIPTION
`Awk` has a `grep`-capable pattern-matcher; using `grep` before `awk` and using `awk` like a `cut` implies the author is new to the command line, and I'd like him/her to not appear that way.