### PR TITLE
Added details for Windows 10's «OpenSSH Client»

### DIFF
--- a/remote-access/ssh/README.md
+++ b/remote-access/ssh/README.md
@@ -49,9 +49,10 @@ If you have loaded Raspbian onto a blank SD card, you will have two partitions. 
 
 ## 4. Set up your client
 
-SSH is built into Linux distributions and Mac OS. For Windows and mobile devices, third-party SSH clients are available. See the following guides for using SSH with the OS on your computer or device:
+SSH is built into Linux distributions and Mac OS, and is an optional function in Windows 10. For older Windows version and mobile devices, third-party SSH clients are available. See the following guides for using SSH with the OS on your computer or device:
 
 - [Linux & Mac OS](unix.md)
+- [Windows 10](windows10.md)
 - [Windows](windows.md)
 - [iOS](ios.md)
 - [Android](android.md)

--- a/remote-access/ssh/README.md
+++ b/remote-access/ssh/README.md
@@ -49,7 +49,7 @@ If you have loaded Raspbian onto a blank SD card, you will have two partitions. 
 
 ## 4. Set up your client
 
-SSH is built into Linux distributions and Mac OS, and is an optional function in Windows 10. For older Windows versions and mobile devices, third-party SSH clients are available. See the following guides for using SSH with the OS on your computer or device:
+SSH is built into Linux distributions and Mac OS, and is an optional feature in Windows 10. For older Windows versions and mobile devices, third-party SSH clients are available. See the following guides for using SSH with the OS on your computer or device:
 
 - [Linux & Mac OS](unix.md)
 - [Windows 10](windows10.md)

--- a/remote-access/ssh/README.md
+++ b/remote-access/ssh/README.md
@@ -49,7 +49,7 @@ If you have loaded Raspbian onto a blank SD card, you will have two partitions. 
 
 ## 4. Set up your client
 
-SSH is built into Linux distributions and Mac OS, and is an optional function in Windows 10. For older Windows version and mobile devices, third-party SSH clients are available. See the following guides for using SSH with the OS on your computer or device:
+SSH is built into Linux distributions and Mac OS, and is an optional function in Windows 10. For older Windows versions and mobile devices, third-party SSH clients are available. See the following guides for using SSH with the OS on your computer or device:
 
 - [Linux & Mac OS](unix.md)
 - [Windows 10](windows10.md)

--- a/remote-access/ssh/windows10.md
+++ b/remote-access/ssh/windows10.md
@@ -1,0 +1,35 @@
+# SSH using Windows 10
+
+You can use SSH to connect to your Raspberry Pi from a Windows 10 computer that is using *October 2018 Update* or later without having to use third-party clients.
+
+If you haven't already done so, go to Settings > Apps > Apps & Functions > Manage optional features > Add a feature, and choose to install *OpenSSH Client*.
+
+You will need to know your Raspberry Pi's IP address to connect to it. To find this, type `hostname -I` from your Raspberry Pi terminal.
+
+If you are running the Pi without a screen (headless), you can also look at the device list on your router or use a tool like `nmap`, which is described in detail in our [IP Address](../ip-address.md) document.
+
+To connect to your Pi from a different computer, copy and paste the following command into the terminal window but replace `<IP>` with the IP address of the Raspberry Pi. Use `Ctrl + Shift + V` to paste in the terminal.
+
+```
+ssh pi@<IP>
+```
+
+If you receive a `connection timed out` error it is likely that you have entered the wrong IP address for the Raspberry Pi.
+
+When the connection works you will see a security/authenticity warning. Type `yes` to continue. You will only see this warning the first time you connect.
+
+In the event your Pi has taken the IP address of a device to which your computer has connected before (even if this was on another network), you may be given a warning and asked to clear the record from your list of known devices. Following this instruction and trying the `ssh` command again should be successful.
+
+Next you will be prompted for the password for the `pi` login: the default password on Raspbian is `raspberry`. For security reasons it is highly recommended to change the default password on the Raspberry Pi. You should now be able to see the Raspberry Pi prompt, which will be identical to the one found on the Raspberry Pi itself.
+
+If you have set up another user on the Raspberry Pi, you can connect to it in the same way, replacing the username with your own, e.g. `eben@192.168.1.5`
+
+```
+pi@raspberrypi ~ $
+```
+
+You are now connected to the Pi remotely, and can execute commands.
+
+For further documentation on the `ssh` command just enter `man ssh` into the Terminal.
+
+To configure your Pi to allow passwordless SSH access with a public/private key pair, see the [passwordless SSH](passwordless.md) guide.

--- a/remote-access/ssh/windows10.md
+++ b/remote-access/ssh/windows10.md
@@ -30,6 +30,4 @@ pi@raspberrypi ~ $
 
 You are now connected to the Pi remotely, and can execute commands.
 
-For further documentation on the `ssh` command just enter `man ssh` into the Terminal.
-
 To configure your Pi to allow passwordless SSH access with a public/private key pair, see the [passwordless SSH](passwordless.md) guide.

--- a/remote-access/ssh/windows10.md
+++ b/remote-access/ssh/windows10.md
@@ -8,26 +8,26 @@ You will need to know your Raspberry Pi's IP address to connect to it. To find t
 
 If you are running the Pi without a screen (headless), you can also look at the device list on your router or use a tool like `nmap`, which is described in detail in our [IP Address](../ip-address.md) document.
 
-To connect to your Pi from a different computer, copy and paste the following command into the terminal window but replace `<IP>` with the IP address of the Raspberry Pi. Use `Ctrl + Shift + V` to paste in the terminal.
+To connect to your Pi from a different computer, copy and paste the following command into the terminal window, but replace `<IP>` with the IP address of the Raspberry Pi. Use `Ctrl + Shift + V` to paste in the terminal.
 
 ```
 ssh pi@<IP>
 ```
 
-If you receive a `connection timed out` error it is likely that you have entered the wrong IP address for the Raspberry Pi.
+If you have set up another user on the Raspberry Pi, you can connect to it in the same way, replacing the default `pi` user with your own username, e.g. `ssh eben@192.168.1.5`.
+
+If you receive a `connection timed out` error, it is likely that you have entered the wrong IP address for the Raspberry Pi.
 
 When the connection works you will see a security/authenticity warning. Type `yes` to continue. You will only see this warning the first time you connect.
 
-In the event your Pi has taken the IP address of a device to which your computer has connected before (even if this was on another network), you may be given a warning and asked to clear the record from your list of known devices. Following this instruction and trying the `ssh` command again should be successful.
+In the event that your Pi has taken the IP address of a device to which your computer has connected before (even if this was on another network), you may be given a warning and asked to clear the record from your list of known devices. Following this instruction and trying the `ssh` command again should be successful.
 
-Next you will be prompted for the password for the `pi` login: the default password on Raspbian is `raspberry`. For security reasons it is highly recommended to change the default password on the Raspberry Pi. You should now be able to see the Raspberry Pi prompt, which will be identical to the one found on the Raspberry Pi itself.
-
-If you have set up another user on the Raspberry Pi, you can connect to it in the same way, replacing the username with your own, e.g. `eben@192.168.1.5`
+Next you will be prompted for the password for the user as which you are trying to connect: the default password for the `pi` user on Raspbian is `raspberry`. For security reasons it is highly recommended to change the default password on the Raspberry Pi. You should now be able to see the Raspberry Pi prompt, which will be identical to the one found on the Raspberry Pi itself.
 
 ```
 pi@raspberrypi ~ $
 ```
 
-You are now connected to the Pi remotely, and can execute commands.
+You are now connected to the Raspberry Pi remotely, and can execute commands.
 
-To configure your Pi to allow passwordless SSH access with a public/private key pair, see the [passwordless SSH](passwordless.md) guide.
+To configure your Raspberry Pi to allow passwordless SSH access with a public/private key pair, see the [passwordless SSH](passwordless.md) guide.

--- a/remote-access/ssh/windows10.md
+++ b/remote-access/ssh/windows10.md
@@ -2,7 +2,7 @@
 
 You can use SSH to connect to your Raspberry Pi from a Windows 10 computer that is using *October 2018 Update* or later without having to use third-party clients.
 
-If you haven't already done so, go to Settings > Apps > Apps & Functions > Manage optional features > Add a feature, and choose to install *OpenSSH Client*.
+If you haven't already done so, go to Settings > Apps > Apps & features > Manage optional features > Add a feature, and choose to install *OpenSSH Client*.
 
 You will need to know your Raspberry Pi's IP address to connect to it. To find this, type `hostname -I` from your Raspberry Pi terminal.
 


### PR DESCRIPTION
Now that Windows 10 has finally got a first-party SSH client, I figured out that it'd be helpful to add details about it to the SSH guides.

It's for the most part the same as the SSH guide for Unix, but with some extra info on how to turn on W10's SSH client and without the X window forwarding section.