### PR TITLE
test different list item indicator characters

### DIFF
--- a/hardware/raspberrypi/bootmodes/host.md
+++ b/hardware/raspberrypi/bootmodes/host.md
@@ -6,19 +6,19 @@ The USB host boot mode follows this sequence:
 
 * Enable the USB port and wait for D+ line to be pulled high indicating a USB 2.0 device (we only support USB2.0)
 * If the device is a hub:
-    * Enable power to all downstream ports of the hub
-    * For each port, loop for a maximum of two seconds (or five seconds if `program_usb_boot_timeout=1` has been set)
-        * Release from reset and wait for D+ to be driven high to indicate that a device is connected
-        * If a device is detected:
+    + Enable power to all downstream ports of the hub
+    + For each port, loop for a maximum of two seconds (or five seconds if `program_usb_boot_timeout=1` has been set)
+        - Release from reset and wait for D+ to be driven high to indicate that a device is connected
+        - If a device is detected:
             * Send "Get Device Descriptor"
-                * If VID == SMSC && PID == 9500
-                    * Add device to Ethernet device list
+                + If VID == SMSC && PID == 9500
+                    - Add device to Ethernet device list
             * If class interface == mass storage class
-                * Add device to mass storage device list
+                + Add device to mass storage device list
 * Else
-    * Enumerate single device
+    + Enumerate single device
 * Go through mass storage device list
-    * [Boot from mass storage device](msd.md)
+    + [Boot from mass storage device](msd.md)
 * Go through Ethernet device list
-    * [Boot from Ethernet](net.md)
+    + [Boot from Ethernet](net.md)
 


### PR DESCRIPTION
At present, raspberrypi.org uses a red hyphen to indicate all unordered list items. Markdown supports using different characters in the source: *, - and +. Test how raspberrypi.org renders these by applying them to different levels of the multi-level lists on hardware/raspberrypi/bootmodes/host.md.

The motivation for doing this is that it makes it much more obvious at which indent level each list item is, if the indent level above and below it uses a different indicator character.