### PR TITLE
Modules install command fix

### DIFF
--- a/linux/kernel/building.md
+++ b/linux/kernel/building.md
@@ -194,7 +194,7 @@ sudo mount /dev/sdb7 mnt/ext4
 Next, install the modules:
 
 ```bash
-sudo make ARCH=arm CROSS_COMPILE=arm-linux-gnueabihf- INSTALL_MOD_PATH=mnt/ext4 modules_install
+sudo env PATH=$PATH make ARCH=arm CROSS_COMPILE=arm-linux-gnueabihf- INSTALL_MOD_PATH=mnt/ext4 modules_install
 ```
 
 Finally, copy the kernel and Device Tree blobs onto the SD card, making sure to back up your old kernel:


### PR DESCRIPTION
Running modules installation command produces "make: arm-linux-gnueabihf-gcc: Command not found" error. This is caused by running this command from root via sudo, where the path to the toolchain is not available. Passing PATH variable to the command fixes this problem.

Also here is related discussion on this topic: https://www.raspberrypi.org/forums/viewtopic.php?t=209621