### PR TITLE
Update access-point.md

### DIFF
--- a/configuration/wireless/access-point.md
+++ b/configuration/wireless/access-point.md
@@ -73,7 +73,8 @@ There are many more options for dnsmasq; see the [dnsmasq documentation](http://
 
 Reload `dnsmasq` to use the updated configuration:
 ```
-sudo systemctl reload dnsmasq
+sudo systemctl enable dnsmasq
+sudo systemctl start dnsmasq
 ```
 
 <a name="hostapd-config"></a>


### PR DESCRIPTION
'reload dnsmasq' causes an error on RPi Zero W (Raspbian Buster). enable+start works great.