### PR TITLE
linux/users.md: Improve sudo setup of new user

### DIFF
--- a/linux/usage/users.md
+++ b/linux/usage/users.md
@@ -30,25 +30,21 @@ Upon creating a new user, the contents of `/etc/skel/` will be copied to the new
 
 ## Sudoers
 
-The default `pi` user on Raspbian is a sudoer. This gives the ability to run commands as root when preceded by `sudo`, and to switch to the root user with `sudo su`.
+The default `pi` user on Raspbian is a member of the `sudo` group. This gives the ability to run commands as root when preceded by `sudo`, and to switch to the root user with `sudo su`.
 
-To add a new user to sudoers, type `sudo visudo` (from a sudoer user) and find the line `root    ALL=(ALL:ALL) ALL`, under the commented header `# User privilege specification`. Copy this line and switch from `root` to the username. To allow passwordless root access, change to `NOPASSWD: ALL`. The example below gives the user `bob` passwordless sudo access:
-
-```bash
-# User privilege specification
-root  ALL=(ALL:ALL) ALL
-bob   ALL = NOPASSWD: ALL
-```
-
-Save and exit to apply the changes. Be careful, as it's possible to remove your own sudo rights by accident.
-
-You can change the editor the `visudo` command uses (the default is Nano) by entering:
+To add a new user to the `sudo` group, use the adduser command:
 
 ```bash
-update-alternatives --set editor /usr/bin/vim.tiny
+sudo adduser bob sudo
 ```
 
-This sets the editor to Vim.
+Note that the user `bob` will be prompted to enter their password when they run `sudo`. This differs from the behaviour of the `pi` user, since `pi` is not prompted for their password. If you wish to remove the password prompt from the new user, create a custom sudoers file and place it in the `/etc/sudoers.d` directory:
+
+```bash
+echo 'bob ALL=(ALL) NO PASSWD: ALL' | sudo tee -a /etc/sudoers.d/010_bob-nopasswd
+```
+
+Note that it is standard practice on Linux to have the user prompted for their password when they run `sudo`, since it makes the system slightly more secure.
 
 ## Delete a user
 


### PR DESCRIPTION
Taking all the comments from #1195, this PR proposes the solution agreed by consensus. The approach is:

- the new user should be added to the secondary group `sudo` using adduser
- mention the user will prompted for their password
- give instructions for how to set new user so they won't be asked for password when sudo-ing

The original author of #1195 is @milliways2.

 @lurch and @XECDesign (both from Raspberry Pi) voted for the above approach.