### PR TITLE
external-storage.md: use umask=000 only for FAT and NTFS

### DIFF
--- a/configuration/external-storage.md
+++ b/configuration/external-storage.md
@@ -68,9 +68,11 @@ You can modify the `fstab` file to define the location where the storage device 
 4. Add the following line in the `fstab` file:
 
     ```
-    UUID=5C24-1453 /mnt/mydisk FSTYPE defaults,auto,umask=000,users,rw,nofail 0 0
+    UUID=5C24-1453 /mnt/mydisk FSTYPE defaults,auto,users,rw,nofail 0 0
     ```
    Replace FSTYPE with the type of your file system, which you found in step 2 of 'Mounting a storage device' above.
+   
+5. If the filesystem type is FAT or NTFS, add the option `umask=000` immediately after `nofail` - this will allow all users on this Pi to read and write to every file on the storage device.
 
 Now that you have set an entry in `fstab`, you can start up your Raspberry Pi with or without the storage device attached. Before you unplug the device you must either shut down the Pi, or manually unmount it using the steps in 'Unmounting a storage device' below.
 

--- a/configuration/external-storage.md
+++ b/configuration/external-storage.md
@@ -72,7 +72,7 @@ You can modify the `fstab` file to define the location where the storage device 
     ```
    Replace FSTYPE with the type of your file system, which you found in step 2 of 'Mounting a storage device' above.
    
-5. If the filesystem type is FAT or NTFS, add the option `umask=000` immediately after `nofail` - this will allow all users full read/write access to every file on the storage device.
+5. If the filesystem type is FAT or NTFS, add `,umask=000` immediately after `nofail` - this will allow all users full read/write access to every file on the storage device.
 
 Now that you have set an entry in `fstab`, you can start up your Raspberry Pi with or without the storage device attached. Before you unplug the device you must either shut down the Pi, or manually unmount it using the steps in 'Unmounting a storage device' below.
 

--- a/configuration/external-storage.md
+++ b/configuration/external-storage.md
@@ -72,7 +72,7 @@ You can modify the `fstab` file to define the location where the storage device 
     ```
    Replace FSTYPE with the type of your file system, which you found in step 2 of 'Mounting a storage device' above.
    
-5. If the filesystem type is FAT or NTFS, add the option `umask=000` immediately after `nofail` - this will allow all users on this Pi to read and write to every file on the storage device.
+5. If the filesystem type is FAT or NTFS, add the option `umask=000` immediately after `nofail` - this will allow all users full read/write access to every file on the storage device.
 
 Now that you have set an entry in `fstab`, you can start up your Raspberry Pi with or without the storage device attached. Before you unplug the device you must either shut down the Pi, or manually unmount it using the steps in 'Unmounting a storage device' below.
 


### PR DESCRIPTION
Per discussion on #1051, update instructions to use umask=000 only when mounting FAT or NTFS filesystem.

Since instructions don't currently deal with trying to mount an HFS or HFS+ filesystem, don't bother mentioning that. If folk need this, it can be added in a future PR.