### PR TITLE
Add missing code block closing to updating.md

### DIFF
--- a/linux/kernel/updating.md
+++ b/linux/kernel/updating.md
@@ -8,7 +8,9 @@ If you use the standard Raspbian update/upgrade process (found [here](../../rasp
 
 To use rpi-update, execute it using sudo as follows:
 
-```sudo rpi-update```
+```
+sudo rpi-update
+```
 
 The `rpi-update` utility will download the Linux kernel and Raspberry Pi firmware that are currently being tested and install them onto your Pi. Note that `rpi-update` does not provide a way to revert the changes that it makes to your system.
 

--- a/linux/kernel/updating.md
+++ b/linux/kernel/updating.md
@@ -8,7 +8,7 @@ If you use the standard Raspbian update/upgrade process (found [here](../../rasp
 
 To use rpi-update, execute it using sudo as follows:
 
-```sudo rpi-update
+```sudo rpi-update```
 
 The `rpi-update` utility will download the Linux kernel and Raspberry Pi firmware that are currently being tested and install them onto your Pi. Note that `rpi-update` does not provide a way to revert the changes that it makes to your system.
 


### PR DESCRIPTION
The closing backticks are missing from the code block which contains the usage of rpi-update command.