### PR TITLE
Update boot.md

### DIFF
--- a/configuration/config-txt/boot.md
+++ b/configuration/config-txt/boot.md
@@ -35,7 +35,7 @@ Set the `disable_commandline_tags` command to `1` to stop `start.elf` from filli
 
 ## kernel
 
-`kernel` is the alternative filename on the boot partition to use when loading the kernel. The default value on the Pi 1, Pi Zero, and Compute Module is `kernel.img`, and on the Pi 2, Pi 3, and Compute Module 3 it is `kernel7.img`. If `kernel8.img` is present on the Pi 3 or Compute Module 3, it will be loaded in preference and entered in 64-bit mode. **NOTE**: This must be an uncompressed kernel image file.
+`kernel` is the alternative filename on the boot partition to use when loading the kernel. The default value on the Pi 1, Pi Zero, and Compute Module is `kernel.img`; on the Pi 2, Pi 3 and Compute Module 3 it is `kernel7.img`; on the Pi 4, it is `kernel7l.img`. If `kernel8.img` is present on the Pi 3 or Compute Module 3, it will be loaded in preference and entered in 64-bit mode. **NOTE**: This must be an uncompressed kernel image file.
 
 ## kernel_address
 


### PR DESCRIPTION
Added comment to mention the default kernel booted on the Pi 4 is now kernel7l.img.