### PR TITLE
Add Pi 4 to the list of devices in "USB device boot mode".

### DIFF
--- a/hardware/raspberrypi/bootmodes/device.md
+++ b/hardware/raspberrypi/bootmodes/device.md
@@ -9,6 +9,7 @@ The following devices can boot using USB device boot mode:
 * Pi A
 * Pi A+
 * Pi 3A+
+* Pi 4
 
 When this boot mode is activated (usually after a failure to boot from the SD card), the Raspberry Pi puts its USB port into device mode and awaits a USB reset from the host. Example code showing how the host needs to talk to the Pi can be found [here](https://github.com/raspberrypi/usbboot).
 


### PR DESCRIPTION
As hinted at by changes in the usb boot code (https://github.com/raspberrypi/usbboot), booting as a USB device should be possible on the Pi 4.

This closes #1327.