### PR TITLE
About (re)starting dnsmasq service

### DIFF
--- a/configuration/wireless/access-point.md
+++ b/configuration/wireless/access-point.md
@@ -71,7 +71,7 @@ So for `wlan0`, we are going to provide IP addresses between 192.168.4.2 and 192
 
 There are many more options for dnsmasq; see the [dnsmasq documentation](http://www.thekelleys.org.uk/dnsmasq/doc.html) for more details.
 
-Start `dnsmasq` (it was stopped), it will use the updated configuration:
+Start `dnsmasq` (it was stopped), it will now use the updated configuration:
 ```
 sudo systemctl start dnsmasq
 ```

--- a/configuration/wireless/access-point.md
+++ b/configuration/wireless/access-point.md
@@ -71,9 +71,9 @@ So for `wlan0`, we are going to provide IP addresses between 192.168.4.2 and 192
 
 There are many more options for dnsmasq; see the [dnsmasq documentation](http://www.thekelleys.org.uk/dnsmasq/doc.html) for more details.
 
-Reload `dnsmasq` to use the updated configuration:
+Start `dnsmasq` (it was stopped), it will use the updated configuration:
 ```
-sudo systemctl reload dnsmasq
+sudo systemctl start dnsmasq
 ```
 
 <a name="hostapd-config"></a>


### PR DESCRIPTION
The line
sudo systemctl reload dnsmasq
generates an error, because the dnsmasq is not running (at least it happens in the last raspbian: Raspbian Buster Lite, Minimal image based on Debian Buster, Version: September 2019)