### PR TITLE
Update msd.md

### DIFF
--- a/hardware/raspberrypi/bootmodes/msd.md
+++ b/hardware/raspberrypi/bootmodes/msd.md
@@ -47,7 +47,7 @@ You can now boot from an USB Mass Storage device in the same way as booting from
 
 The Raspberry Pi 3B+ and CM3+ support USB Mass Storage boot out of the box. The settings specific to the previous versions of Raspberry Pi do not have to be executed.
 
-This is verified using the following steps, this is the same (procedure)[../../../installation/installing-images/] as for SD cards.
+This is verified using the following steps, this is the same [procedure](../../../installation/installing-images/) as for SD cards.
 
 On Windows you may have to initialise a (clean) harddrive before it's visible and has a drive letter (which may be required to write the image).
 

--- a/hardware/raspberrypi/bootmodes/msd.md
+++ b/hardware/raspberrypi/bootmodes/msd.md
@@ -69,4 +69,4 @@ The Raspberry Pi 4's bootcode is stored in [EEPROM](../booteeprom.md) and can be
 
 - The default timeout for checking bootable USB devices is 2 seconds. Some flash drives and rotational harddrives power up too slowly. It’s possible to extend this timeout to five seconds (add a new file `timeout` to the SD card), but there are devices that fail to respond within this period as well.
 - Some flash drives have a very specific protocol requirement that is not handled by the bootcode and may thus be incompatible.
-- 3.5" HDD's commonly require 12V as well as 5V and may draw too much current for the Pi's USB connection. Use an externally powered 3.5" HDD in this case.
+- Lack of power can be an issue, as some devices draw too much current from the Raspberry Pi's USB connection and fail to start, or prevent the Raspberry Pi from booting. An external power supply for the device will be required in these cases.

--- a/hardware/raspberrypi/bootmodes/msd.md
+++ b/hardware/raspberrypi/bootmodes/msd.md
@@ -4,17 +4,17 @@
 
 This tutorial explains how to boot your Raspberry Pi from a USB mass storage device such as a flash drive or a USB hard disk. Note that this feature does not work with all USB mass storage devices.
 
-See the [documentation](README.md) for the boot sequence and alternative boot modes (Network, USB device, GPIO or SD boot).
+See the [bootmodes documentation](README.md) for the boot sequence and alternative boot modes (Network, USB device, GPIO or SD boot).
 
 Note that "USB Mass Storage Boot" is different from "USB Device Boot Mode". The [device boot mode](device.md) allows a Raspberry Pi connected to a computer to boot using files on that computer.
 
-[Pi 2B v1.2 up to 3](#raspberry-pi-2b-v12-3a-3b-cm3)
+[Pi 2B v1.2 up to 3](#pi2to3)
 
-[Pi 3B+ CM3+](#raspberry-pi-3b-cm3)
+[Pi 3B+ CM3+](#pi3plus)
 
-[Unsupported devices](#unsupported-devices)
+[Unsupported devices](#unsupported)
 
-<a name="Raspberry Pi 2B v1.2, 3A+, 3B, CM3"></a>
+<a name="pi2to3"></a>
 ## Raspberry Pi 2B v1.2, 3A+, 3B, CM3
 
 On the Raspberry Pi 2B v1.2, 3A+, 3B, CM3, first USB [host boot mode](host.md) should be enabled. This is to allow Mass Storage Boot / Network boot (Network boot not supported on 3A+).
@@ -50,33 +50,33 @@ If you wish, you can remove the `program_usb_boot_mode` line from config.txt, so
 
 You can now boot from an USB Mass Storage device in the same way as booting from SD, see the following paragraph for Raspberry Pi 3B+, CM3+.
 
-<a name="Raspberry Pi 3B+, CM3+"></a>
+<a name="pi3plus"></a>
 ## Raspberry Pi 3B+, CM3+
 
 The Raspberry Pi 3B+ and CM3+ support USB Mass Storage boot out of the box. The settings specific to the previous versions of Raspberry Pi do not have to be executed.
 
-This is the same [procedure](../../../installation/installing-images/installation/installing-images/) as for SD cards.
-
-On Windows you may have to initialise a (clean) harddrive before it's visible and has a drive letter (which may be required to write the image).
+This is the same [procedure](../../../installation/installing-images) as for SD cards.
 
 After preparing the storage device, connect the drive to the Raspberry Pi and power up the Pi (be aware of the extra USB power usage from external drive).
 After five to ten seconds, the Raspberry Pi should begin booting and show the rainbow splash screen on an attached display. Make sure that you do not have an SD card inserted in the Pi, since if you do, it will boot from that first.
 
-<a name="unsupported devices"></a>
+<a name="unsupported"></a>
 ## Unsupported devices
 
 Including Raspberry Pi 1, 2 (V1.1), Compute Module, Zero.
 
-The boot code for USB is stored in the BCM2837(B0) device only. The Pi 1 A/B, Pi 2 B (v1.1), and Pi Zero will all require SD cards as they are based on the BCM2835 and BCM2836. This boot code for USB is stored in ROM (except Pi 4B) which by definition cannot be changed.
+The boot code for USB Mass Storage boot is stored in the BCM2837(B0)'s ROM only. Earlier versions such as the BCM2836 and BCM2835 do not have this version of bootcode with USB Mass Storage boot.
+
+Since up to the Pi 4B, the boot code is written in ROM (Read only memory) it cannot be updated. For this reason the Pi 1 A/B, Pi 2 B (v1.1), and Pi Zero will all require SD cards.
 
 An alternative is to use the 'special bootcode.bin-only boot mode' as described [here](README.md). This still requires/boots from an SD-card, but `bootcode.bin` is the only file read from the SD-Card.
 
 ### Raspberry Pi 4
 
-Regarding the Raspberry Pi 4, the bootcode is stored in [EEPROM](../booteeprom.md) and can be updated. Support for mass storage boot will be added in a future update.
+The Raspberry Pi 4's bootcode is stored in [EEPROM](../booteeprom.md) and can be updated. Support for mass storage boot will be added in a future update.
 
 ## Known issues
 
 - The default timeout for checking bootable USB devices is 2 seconds. Some flash drives and rotational harddrives power up too slowly. It’s possible to extend this timeout to five seconds (add a new file `timeout` to the SD card), but there are devices that fail to respond within this period as well.
-- Some flash drives have a very specific protocol requirement that we don’t handle; as a result of this, we can’t talk to these drives correctly.
+- Some flash drives have a very specific protocol requirement that is not handled by the bootcode and may thus be incompatible.
 - 3.5" HDD's commonly require 12V as well as 5V and may draw too much current for the Pi's USB connection. Use an externally powered 3.5" HDD in this case.

--- a/hardware/raspberrypi/bootmodes/msd.md
+++ b/hardware/raspberrypi/bootmodes/msd.md
@@ -67,6 +67,6 @@ The Raspberry Pi 4's bootcode is stored in [EEPROM](../booteeprom.md) and can be
 
 ## Known issues
 
-- The default timeout for checking bootable devices is 2 seconds. Some flash drives and rotational harddrives power up too slowly. It’s possible to extend this timeout to five seconds (add a new file `timeout` to the SD card), but there are devices that fail to respond within this period as well.
+- The default timeout for checking bootable USB devices is 2 seconds. Some flash drives and rotational harddrives power up too slowly. It’s possible to extend this timeout to five seconds (add a new file `timeout` to the SD card), but there are devices that fail to respond within this period as well.
 - Some flash drives have a very specific protocol requirement that is not handled by the bootcode and may thus be incompatible.
 - 3.5" HDD's commonly require 12V as well as 5V and may draw too much current for the Pi's USB connection. Use an externally powered 3.5" HDD in this case.

--- a/hardware/raspberrypi/bootmodes/msd.md
+++ b/hardware/raspberrypi/bootmodes/msd.md
@@ -66,7 +66,7 @@ Including Raspberry Pi 1, 2 (V1.1), Compute Module, Zero
 
 The boot code for USB is stored in the BCM2837 device only, so the Pi 1 A/B, Pi 2 B (v1.1), and Pi Zero will all require SD cards as they are based on the BCM2835 and BCM2836. This boot code is stored in ROM (except Pi 4B) which by definition cannot be changed.
 
-Regarding the Raspberry Pi 4, the bootcode is stored in [EEPROM](../booteeprom.md) and can be updated. Support for mass storage boot will be added in a future update. In the meanwhile you can use the alternative below. 
+Regarding the Raspberry Pi 4, the bootcode is stored in [EEPROM](../booteeprom.md) and can be updated. Support for mass storage boot will be added in a future update. In the meantime you can use the alternative below. 
 
 An alternative is to use the 'special bootcode.bin-only boot mode' as described [here](./). This still requires/boots from an SD-card, but `bootcode.bin` is the only file read from the SD-Card.
 

--- a/hardware/raspberrypi/bootmodes/msd.md
+++ b/hardware/raspberrypi/bootmodes/msd.md
@@ -4,16 +4,17 @@
 
 This tutorial explains how to boot your Raspberry Pi from a USB mass storage device such as a flash drive or a USB hard disk. Note that this feature does not work with all USB mass storage devices.
 
-See the [documentation](./) for the boot sequence and alternative boot modes (Network, USB device, GPIO or SD boot).
+See the [documentation](README.md) for the boot sequence and alternative boot modes (Network, USB device, GPIO or SD boot).
 
-Note that "USB Mass Storage Boot" is different from "USB Device Boot Mode", the device boot mode allows a Raspberry Pi connected to a computer to boot using files on that computer.
+Note that "USB Mass Storage Boot" is different from "USB Device Boot Mode". The [device boot mode](device.md) allows a Raspberry Pi connected to a computer to boot using files on that computer.
 
-[Pi 2B v1.2 up to 3](./#raspberry-pi-2b-v12-3a-3b-cm3)
+[Pi 2B v1.2 up to 3](#raspberry-pi-2b-v12-3a-3b-cm3)
 
 [Pi 3B+ CM3+](#raspberry-pi-3b-cm3)
 
 [Unsupported devices](#unsupported-devices)
 
+<a name="Raspberry Pi 2B v1.2, 3A+, 3B, CM3"></a>
 ## Raspberry Pi 2B v1.2, 3A+, 3B, CM3
 
 On the Raspberry Pi 2B v1.2, 3A+, 3B, CM3, first USB [host boot mode](host.md) should be enabled. This is to allow Mass Storage Boot / Network boot (Network boot not supported on 3A+).
@@ -49,17 +50,19 @@ If you wish, you can remove the `program_usb_boot_mode` line from config.txt, so
 
 You can now boot from an USB Mass Storage device in the same way as booting from SD, see the following paragraph for Raspberry Pi 3B+, CM3+.
 
+<a name="Raspberry Pi 3B+, CM3+"></a>
 ## Raspberry Pi 3B+, CM3+
 
 The Raspberry Pi 3B+ and CM3+ support USB Mass Storage boot out of the box. The settings specific to the previous versions of Raspberry Pi do not have to be executed.
 
-This is verified using the following steps, this is the same [procedure](../../../installation/installing-images/) as for SD cards.
+This is the same [procedure](../../../installation/installing-images/installation/installing-images/) as for SD cards.
 
 On Windows you may have to initialise a (clean) harddrive before it's visible and has a drive letter (which may be required to write the image).
 
-After preparing the storage device, connect the drive to the Raspberry Pi and power up the Pi (mind extra USB power usage from external drive).
+After preparing the storage device, connect the drive to the Raspberry Pi and power up the Pi (be aware of the extra USB power usage from external drive).
 After five to ten seconds, the Raspberry Pi should begin booting and show the rainbow splash screen on an attached display. Make sure that you do not have an SD card inserted in the Pi, since if you do, it will boot from that first.
 
+<a name="unsupported devices"></a>
 ## Unsupported devices
 
 Including Raspberry Pi 1, 2 (V1.1), Compute Module, Zero
@@ -68,10 +71,10 @@ The boot code for USB is stored in the BCM2837 device only, so the Pi 1 A/B, Pi 
 
 Regarding the Raspberry Pi 4, the bootcode is stored in [EEPROM](../booteeprom.md) and can be updated. Support for mass storage boot will be added in a future update. In the meantime you can use the alternative below. 
 
-An alternative is to use the 'special bootcode.bin-only boot mode' as described [here](./). This still requires/boots from an SD-card, but `bootcode.bin` is the only file read from the SD-Card.
+An alternative is to use the 'special bootcode.bin-only boot mode' as described [here](README.md). This still requires/boots from an SD-card, but `bootcode.bin` is the only file read from the SD-Card.
 
 ## Known issues
 
 - The default timeout for checking bootable USB devices is 2 seconds. Some flash drives and rotational harddrives power up too slowly. It’s possible to extend this timeout to five seconds (add a new file `timeout` to the SD card), but there are devices that fail to respond within this period as well.
 - Some flash drives have a very specific protocol requirement that we don’t handle; as a result of this, we can’t talk to these drives correctly.
-- 3.5" HDD's commonly require 12V as well as 5V and may draw too much current for the Pi's USB connections.
+- 3.5" HDD's commonly require 12V as well as 5V and may draw too much current for the Pi's USB connection. Use an externally powered 3.5" HDD in this case.

--- a/hardware/raspberrypi/bootmodes/msd.md
+++ b/hardware/raspberrypi/bootmodes/msd.md
@@ -84,16 +84,6 @@ https://www.raspberrypi.org/blog/pi-3-booting-part-i-usb-mass-storage-boot/
 
 ## Known issues
 
-- The default timeout for checking bootable USB devices is 2 seconds. Some flash drives and rotational harddrives power up too slowly. It’s possible to extend this timeout to five seconds (add a new file 'timeout'to the SD card), but there are devices that fail to respond within this period as well, such as the Verbatim PinStripe 64GB. 
-- Some flash drives have a very specific protocol requirement that we don’t handle; as a result of this, we can’t talk to these drives correctly. An example of such a drive would be the Kingston Data Traveller 100 G3 32G.
-- 3.5" HDD's commonly require 12V as well as 5V and commonly draw too much current for the Pi's USB connections.
-
-## Known working devices
-
-| Device Name                                       | Reported by |
-|---|---|
-| Sandisk Cruzer Fit 16GB                           | [Henry Budden](http://www.raspberrypitutorials.yolasite.com/) |
-| Sandisk Cruzer Blade 16Gb                         | [Henry Budden](http://www.raspberrypitutorials.yolasite.com/) |
-| Samsung 32GB USB 3.0 drive                        | [Henry Budden](http://www.raspberrypitutorials.yolasite.com/) |
-| MeCo 16GB USB 3.0                                 | [Henry Budden](http://www.raspberrypitutorials.yolasite.com/) |
-| Kingston A400 240GB (external 2.0 USB case MA6116) Raspbian Buster Lite | Paul-Ver | 
+- The default timeout for checking bootable USB devices is 2 seconds. Some flash drives and rotational harddrives power up too slowly. It’s possible to extend this timeout to five seconds (add a new file 'timeout'to the SD card), but there are devices that fail to respond within this period as well.
+- Some flash drives have a very specific protocol requirement that we don’t handle; as a result of this, we can’t talk to these drives correctly.
+- 3.5" HDD's commonly require 12V as well as 5V and may draw too much current for the Pi's USB connections.

--- a/hardware/raspberrypi/bootmodes/msd.md
+++ b/hardware/raspberrypi/bootmodes/msd.md
@@ -68,7 +68,7 @@ Including Raspberry Pi 1, 2 (V1.1), Compute Module, Zero
 
 The boot code for USB is stored in the BCM2837 device only, so the Pi 1 A/B, Pi 2 B (v1.1), and Pi Zero will all require SD cards as they are based on the BCM2835 and BCM2836. This boot code is stored in ROM (except Pi 4B) which by definition cannot be changed.
 
-An alternative is to use the 'special bootcode.bin-only boot mode' as described [here](./). This still requires/boots from an SD-card but allows to run on an USB Device.
+An alternative is to use the 'special bootcode.bin-only boot mode' as described [here](./). This still requires/boots from an SD-card, but bootcode.bin is the only file read from the SD-Card.
 
 
 ## Extra info

--- a/hardware/raspberrypi/bootmodes/msd.md
+++ b/hardware/raspberrypi/bootmodes/msd.md
@@ -4,7 +4,7 @@
 
 This tutorial explains how to boot your Raspberry Pi from a USB mass storage device such as a flash drive or a USB hard disk. Note that this feature does not work with all USB mass storage devices.
 
-See the [documentation](https://www.raspberrypi.org/documentation/hardware/raspberrypi/bootmodes/) for the boot sequence and alternative boot modes (Network, USB device, GPIO or SD boot).
+See the [documentation](./) for the boot sequence and alternative boot modes (Network, USB device, GPIO or SD boot).
 
 Note that "USB Mass Storage Boot" is different from "USB Device Boot Mode", the device boot mode allows a Raspberry Pi connected to a computer to boot using files on that computer.
 
@@ -13,11 +13,11 @@ Note that "USB Mass Storage Boot" is different from "USB Device Boot Mode", the 
 **These models are not supported for USB Mass Storage Boot.**
 The boot code for USB is stored in the BCM2837 device only, so the Pi 1 A/B, Pi 2 B (v1.1), and Pi Zero will all require SD cards as they are based on the BCM2835 and BCM2836. This boot code is stored in ROM (except Pi 4B) which by definition cannot be changed.
 
-An alternative is to use the 'special bootcode.bin-only boot mode' as described [here](https://www.raspberrypi.org/documentation/hardware/raspberrypi/bootmodes/). This still requires/boots from an SD-card but allows to run on an USB Device.
+An alternative is to use the 'special bootcode.bin-only boot mode' as described [here](./). This still requires/boots from an SD-card but allows to run on an USB Device.
 
 ## Raspberry Pi 2B v1.2, 3A+, 3B
 
-On the Raspberry Pi 2B v1.2, 3A+, 3B, first USB [host boot mode](https://www.raspberrypi.org/documentation/hardware/raspberrypi/bootmodes/host.md) should be enabled. This is to allow Mass Storage Boot / Network boot (Network boot not supported on 3A+).
+On the Raspberry Pi 2B v1.2, 3A+, 3B, first USB [host boot mode](host.md) should be enabled. This is to allow Mass Storage Boot / Network boot (Network boot not supported on 3A+).
 
 To enable USB host boot mode, the Raspberry Pi needs to be booted from an SD card with a special option to set the USB host boot mode bit in the OTP (one-time programmable) memory. 
 
@@ -54,7 +54,7 @@ You can now boot from an USB Mass Storage device in the same way as booting from
 
 The Raspberry Pi 3B+ supports USB Mass Storage boot out of the box. The settings specific to the previous versions of Raspberry Pi do not have to be executed.
 
-This is verified using the following steps, this is the same (procedure)[https://www.raspberrypi.org/documentation/installation/installing-images/] as for SD cards though many alternative ways are functional:
+This is verified using the following steps, this is the same (procedure)[../../../installation/installing-images/] as for SD cards though many alternative ways are functional:
 
 1. Download Raspbian Buster Lite
 

--- a/hardware/raspberrypi/bootmodes/msd.md
+++ b/hardware/raspberrypi/bootmodes/msd.md
@@ -8,16 +8,9 @@ See the [documentation](./) for the boot sequence and alternative boot modes (Ne
 
 Note that "USB Mass Storage Boot" is different from "USB Device Boot Mode", the device boot mode allows a Raspberry Pi connected to a computer to boot using files on that computer.
 
-## Raspberry Pi 1, 2 (V1.1), Compute Module, Zero
+## Raspberry Pi 2B v1.2, 3A+, 3B, CM3
 
-**These models are not supported for USB Mass Storage Boot.**
-The boot code for USB is stored in the BCM2837 device only, so the Pi 1 A/B, Pi 2 B (v1.1), and Pi Zero will all require SD cards as they are based on the BCM2835 and BCM2836. This boot code is stored in ROM (except Pi 4B) which by definition cannot be changed.
-
-An alternative is to use the 'special bootcode.bin-only boot mode' as described [here](./). This still requires/boots from an SD-card but allows to run on an USB Device.
-
-## Raspberry Pi 2B v1.2, 3A+, 3B
-
-On the Raspberry Pi 2B v1.2, 3A+, 3B, first USB [host boot mode](host.md) should be enabled. This is to allow Mass Storage Boot / Network boot (Network boot not supported on 3A+).
+On the Raspberry Pi 2B v1.2, 3A+, 3B, CM3, first USB [host boot mode](host.md) should be enabled. This is to allow Mass Storage Boot / Network boot (Network boot not supported on 3A+).
 
 To enable USB host boot mode, the Raspberry Pi needs to be booted from an SD card with a special option to set the USB host boot mode bit in the OTP (one-time programmable) memory. 
 
@@ -50,7 +43,7 @@ If you wish, you can remove the `program_usb_boot_mode` line from config.txt, so
 
 You can now boot from an USB Mass Storage device in the same way as booting from SD, see the following paragraph for Raspberry Pi 3B+.
 
-## Raspberry Pi 3B+
+## Raspberry Pi 3B+, CM3+
 
 The Raspberry Pi 3B+ supports USB Mass Storage boot out of the box. The settings specific to the previous versions of Raspberry Pi do not have to be executed.
 
@@ -78,12 +71,21 @@ According to rpdom in a [forum post](https://www.raspberrypi.org/forums/viewtopi
 
 The Pi4 uses a different boot loader to the earlier models. It is stored in eeprom on the board instead of part in the chip and part on the SD card. An update and instructions on how to apply it will be issued when the USB and network boot is ready.
 
+## Unsupported devices
+
+Including Raspberry Pi 1, 2 (V1.1), Compute Module, Zero
+
+The boot code for USB is stored in the BCM2837 device only, so the Pi 1 A/B, Pi 2 B (v1.1), and Pi Zero will all require SD cards as they are based on the BCM2835 and BCM2836. This boot code is stored in ROM (except Pi 4B) which by definition cannot be changed.
+
+An alternative is to use the 'special bootcode.bin-only boot mode' as described [here](./). This still requires/boots from an SD-card but allows to run on an USB Device.
+
+
 ## Extra info
 
 https://www.raspberrypi.org/blog/pi-3-booting-part-i-usb-mass-storage-boot/
 
 ## Known issues
 
-- The default timeout for checking bootable USB devices is 2 seconds. Some flash drives and rotational harddrives power up too slowly. It’s possible to extend this timeout to five seconds (add a new file 'timeout'to the SD card), but there are devices that fail to respond within this period as well.
+- The default timeout for checking bootable USB devices is 2 seconds. Some flash drives and rotational harddrives power up too slowly. It’s possible to extend this timeout to five seconds (add a new file `timeout` to the SD card), but there are devices that fail to respond within this period as well.
 - Some flash drives have a very specific protocol requirement that we don’t handle; as a result of this, we can’t talk to these drives correctly.
 - 3.5" HDD's commonly require 12V as well as 5V and may draw too much current for the Pi's USB connections.

--- a/hardware/raspberrypi/bootmodes/msd.md
+++ b/hardware/raspberrypi/bootmodes/msd.md
@@ -2,22 +2,22 @@
 
 **USB mass storage boot is available on Raspberry Pi 2B v1.2, 3A+, 3B, and 3B+ only. Support for USB mass storage boot will be added to the Raspberry Pi 4B in a future software update.**
 
-This tutorial explains how to boot your Raspberry Pi from a USB mass storage device such as a flash drive or a USB hard disk. Note that this feature does not work with all USB mass storage devices.
+This page explains how to boot your Raspberry Pi from a USB mass storage device such as a flash drive or a USB hard disk. Note that this feature does not work with all USB mass storage devices.
 
 See the [bootmodes documentation](README.md) for the boot sequence and alternative boot modes (Network, USB device, GPIO or SD boot).
 
-Note that "USB Mass Storage Boot" is different from "USB Device Boot Mode". The [device boot mode](device.md) allows a Raspberry Pi connected to a computer to boot using files on that computer.
+Note that "USB mass storage boot" is different from "USB device boot mode". The [device boot mode](device.md) allows a Raspberry Pi connected to a computer to boot using files on that computer.
+
+For devices that are not supported, an alternative is to use the 'special bootcode.bin-only boot mode' as described [here](README.md). This still requires/boots from an SD-card, but `bootcode.bin` is the only file read from the SD-Card.
 
 [Pi 2B v1.2 up to 3](#pi2to3)
 
 [Pi 3B+ CM3+](#pi3plus)
 
-[Unsupported devices](#unsupported)
-
 <a name="pi2to3"></a>
 ## Raspberry Pi 2B v1.2, 3A+, 3B, CM3
 
-On the Raspberry Pi 2B v1.2, 3A+, 3B, CM3, first USB [host boot mode](host.md) should be enabled. This is to allow Mass Storage Boot / Network boot (Network boot not supported on 3A+).
+On the Raspberry Pi 2B v1.2, 3A+, 3B, CM3, first USB [host boot mode](host.md) should be enabled. This is to allow "mass storage boot" and ["network boot"](net.md) (Network boot not supported on 3A+).
 
 To enable USB host boot mode, the Raspberry Pi needs to be booted from an SD card with a special option to set the USB host boot mode bit in the OTP (one-time programmable) memory. 
 
@@ -48,35 +48,25 @@ Check that the output `0x3020000a` is shown. If it is not, then the OTP bit has 
 
 If you wish, you can remove the `program_usb_boot_mode` line from config.txt, so that if you put the SD card into another Raspberry Pi, it won't program USB host boot mode. Make sure there is no blank line at the end of config.txt.
 
-You can now boot from an USB Mass Storage device in the same way as booting from SD, see the following paragraph for Raspberry Pi 3B+, CM3+.
+You can now boot from an USB mass storage device in the same way as booting from SD, see the following paragraph for Raspberry Pi 3B+, CM3+.
 
 <a name="pi3plus"></a>
 ## Raspberry Pi 3B+, CM3+
 
-The Raspberry Pi 3B+ and CM3+ support USB Mass Storage boot out of the box. The settings specific to the previous versions of Raspberry Pi do not have to be executed.
+The Raspberry Pi 3B+ and CM3+ support USB mass storage boot out of the box. The settings specific to the previous versions of Raspberry Pi do not have to be executed.
 
 This is the same [procedure](../../../installation/installing-images) as for SD cards.
 
-After preparing the storage device, connect the drive to the Raspberry Pi and power up the Pi (be aware of the extra USB power usage from external drive).
+After preparing the storage device, connect the drive to the Raspberry Pi and power up the Pi (be aware of the extra USB power usage from the external drive).
 After five to ten seconds, the Raspberry Pi should begin booting and show the rainbow splash screen on an attached display. Make sure that you do not have an SD card inserted in the Pi, since if you do, it will boot from that first.
 
-<a name="unsupported"></a>
-## Unsupported devices
-
-Including Raspberry Pi 1, 2 (V1.1), Compute Module, Zero.
-
-The boot code for USB Mass Storage boot is stored in the BCM2837(B0)'s ROM only. Earlier versions such as the BCM2836 and BCM2835 do not have this version of bootcode with USB Mass Storage boot.
-
-Since up to the Pi 4B, the boot code is written in ROM (Read only memory) it cannot be updated. For this reason the Pi 1 A/B, Pi 2 B (v1.1), and Pi Zero will all require SD cards.
-
-An alternative is to use the 'special bootcode.bin-only boot mode' as described [here](README.md). This still requires/boots from an SD-card, but `bootcode.bin` is the only file read from the SD-Card.
-
-### Raspberry Pi 4
+<a name="pi4"></a>
+## Raspberry Pi 4
 
 The Raspberry Pi 4's bootcode is stored in [EEPROM](../booteeprom.md) and can be updated. Support for mass storage boot will be added in a future update.
 
 ## Known issues
 
-- The default timeout for checking bootable USB devices is 2 seconds. Some flash drives and rotational harddrives power up too slowly. It’s possible to extend this timeout to five seconds (add a new file `timeout` to the SD card), but there are devices that fail to respond within this period as well.
+- The default timeout for checking bootable devices is 2 seconds. Some flash drives and rotational harddrives power up too slowly. It’s possible to extend this timeout to five seconds (add a new file `timeout` to the SD card), but there are devices that fail to respond within this period as well.
 - Some flash drives have a very specific protocol requirement that is not handled by the bootcode and may thus be incompatible.
 - 3.5" HDD's commonly require 12V as well as 5V and may draw too much current for the Pi's USB connection. Use an externally powered 3.5" HDD in this case.

--- a/hardware/raspberrypi/bootmodes/msd.md
+++ b/hardware/raspberrypi/bootmodes/msd.md
@@ -4,7 +4,20 @@
 
 This tutorial explains how to boot your Raspberry Pi from a USB mass storage device such as a flash drive or a USB hard disk. Note that this feature does not work with all USB mass storage devices.
 
-## Program USB host boot mode (Raspberry Pi 3A+ and 3B only)
+See the [documentation](https://www.raspberrypi.org/documentation/hardware/raspberrypi/bootmodes/) for the boot sequence and alternative boot modes (Network, USB device, GPIO or SD boot).
+
+Note that "USB Mass Storage Boot" is different from "USB Device Boot Mode", the device boot mode allows a Raspberry Pi connected to a computer to boot using files on that computer.
+
+## Raspberry Pi 1, 2 (V1.1), Compute Module, Zero
+
+**These models are not supported for USB Mass Storage Boot.**
+The boot code for USB is stored in the BCM2837 device only, so the Pi 1 A/B, Pi 2 B (v1.1), and Pi Zero will all require SD cards as they are based on the BCM2835 and BCM2836. This boot code is stored in ROM (except Pi 4B) which by definition cannot be changed.
+
+An alternative is to use the 'special bootcode.bin-only boot mode' as described [here](https://www.raspberrypi.org/documentation/hardware/raspberrypi/bootmodes/). This still requires/boots from an SD-card but allows to run on an USB Device.
+
+## Raspberry Pi 2B v1.2, 3A+, 3B
+
+On the Raspberry Pi 2B v1.2, 3A+, 3B, first USB [host boot mode](https://www.raspberrypi.org/documentation/hardware/raspberrypi/bootmodes/host.md) should be enabled. This is to allow Mass Storage Boot / Network boot (Network boot not supported on 3A+).
 
 To enable USB host boot mode, the Raspberry Pi needs to be booted from an SD card with a special option to set the USB host boot mode bit in the OTP (one-time programmable) memory. 
 
@@ -35,12 +48,52 @@ Check that the output `0x3020000a` is shown. If it is not, then the OTP bit has 
 
 If you wish, you can remove the `program_usb_boot_mode` line from config.txt, so that if you put the SD card into another Raspberry Pi, it won't program USB host boot mode. Make sure there is no blank line at the end of config.txt.
 
-## Prepare the USB mass storage device
+You can now boot from an USB Mass Storage device in the same way as booting from SD, see the following paragraph for Raspberry Pi 3B+.
 
-Copy a Raspbian or Raspbian Lite installation image directly onto your USB device, in the same way that you would for an SD card. To perform this step, follow the instructions [here](../../../installation/installing-images/README.md), remembering to select the drive that corresponds to your USB mass storage device. Make sure that you use a recent version of Raspbian/Raspbian Lite.
+## Raspberry Pi 3B+
 
-Once you have finished imaging your USB mass storage device, remove it from your computer and insert it into your Raspberry Pi.
+The Raspberry Pi 3B+ supports USB Mass Storage boot out of the box. The settings specific to the previous versions of Raspberry Pi do not have to be executed.
 
-## Boot your Raspberry Pi from the USB mass storage device
+This is verified using the following steps, this is the same (procedure)[https://www.raspberrypi.org/documentation/installation/installing-images/] as for SD cards though many alternative ways are functional:
 
-Attach the USB mass storage device to your Raspberry Pi, and power up the Pi. After five to ten seconds, the Raspberry Pi should begin booting and show the rainbow splash screen on an attached display. Make sure that you do not have an SD card inserted in the Pi, since if you do, it will boot from that first.
+1. Download Raspbian Buster Lite
+
+2. Unzip the .zip file (tested with 7zip, but any other should be fine) to an .img file.
+
+3. Initialise the drive (tested with MBR scheme, no partition/clean disk).
+
+4. Flash the .img file to the external drive (tested using Win32DiskImager on Windows 10)
+
+5. Unmount and disconnect the drive.
+
+6. Connect the drive to the Raspberry Pi and power up the Pi (mind extra USB power usage from external drive).
+
+7. After five to ten seconds, the Raspberry Pi should begin booting and show the rainbow splash screen on an attached display. Make sure that you do not have an SD card inserted in the Pi, since if you do, it will boot from that first.
+
+## Raspberry Pi 4B
+
+Support for USB mass storage boot will be added to the Raspberry Pi 4B in a future software update.
+
+According to rpdom in a [forum post](https://www.raspberrypi.org/forums/viewtopic.php?t=243995#p1488036):
+
+The Pi4 uses a different boot loader to the earlier models. It is stored in eeprom on the board instead of part in the chip and part on the SD card. An update and instructions on how to apply it will be issued when the USB and network boot is ready.
+
+## Extra info
+
+https://www.raspberrypi.org/blog/pi-3-booting-part-i-usb-mass-storage-boot/
+
+## Known issues
+
+- The default timeout for checking bootable USB devices is 2 seconds. Some flash drives and rotational harddrives power up too slowly. It’s possible to extend this timeout to five seconds (add a new file 'timeout'to the SD card), but there are devices that fail to respond within this period as well, such as the Verbatim PinStripe 64GB. 
+- Some flash drives have a very specific protocol requirement that we don’t handle; as a result of this, we can’t talk to these drives correctly. An example of such a drive would be the Kingston Data Traveller 100 G3 32G.
+- 3.5" HDD's commonly require 12V as well as 5V and commonly draw too much current for the Pi's USB connections.
+
+## Known working devices
+
+| Device Name                                       | Reported by |
+|---|---|
+| Sandisk Cruzer Fit 16GB                           | [Henry Budden](http://www.raspberrypitutorials.yolasite.com/) |
+| Sandisk Cruzer Blade 16Gb                         | [Henry Budden](http://www.raspberrypitutorials.yolasite.com/) |
+| Samsung 32GB USB 3.0 drive                        | [Henry Budden](http://www.raspberrypitutorials.yolasite.com/) |
+| MeCo 16GB USB 3.0                                 | [Henry Budden](http://www.raspberrypitutorials.yolasite.com/) |
+| Kingston A400 240GB (external 2.0 USB case MA6116) Raspbian Buster Lite | Paul-Ver | 

--- a/hardware/raspberrypi/bootmodes/msd.md
+++ b/hardware/raspberrypi/bootmodes/msd.md
@@ -68,7 +68,7 @@ Including Raspberry Pi 1, 2 (V1.1), Compute Module, Zero
 
 The boot code for USB is stored in the BCM2837 device only, so the Pi 1 A/B, Pi 2 B (v1.1), and Pi Zero will all require SD cards as they are based on the BCM2835 and BCM2836. This boot code is stored in ROM (except Pi 4B) which by definition cannot be changed.
 
-An alternative is to use the 'special bootcode.bin-only boot mode' as described [here](./). This still requires/boots from an SD-card, but bootcode.bin is the only file read from the SD-Card.
+An alternative is to use the 'special bootcode.bin-only boot mode' as described [here](./). This still requires/boots from an SD-card, but `bootcode.bin` is the only file read from the SD-Card.
 
 
 ## Extra info

--- a/hardware/raspberrypi/bootmodes/msd.md
+++ b/hardware/raspberrypi/bootmodes/msd.md
@@ -10,11 +10,6 @@ Note that "USB mass storage boot" is different from "USB device boot mode". The 
 
 For devices that are not supported, an alternative is to use the 'special bootcode.bin-only boot mode' as described [here](README.md). This still requires/boots from an SD-card, but `bootcode.bin` is the only file read from the SD-Card.
 
-[Pi 2B v1.2 up to 3](#pi2to3)
-
-[Pi 3B+ CM3+](#pi3plus)
-
-<a name="pi2to3"></a>
 ## Raspberry Pi 2B v1.2, 3A+, 3B, CM3
 
 On the Raspberry Pi 2B v1.2, 3A+, 3B, CM3, first USB [host boot mode](host.md) should be enabled. This is to allow "mass storage boot" and ["network boot"](net.md) (Network boot not supported on 3A+).
@@ -50,7 +45,6 @@ If you wish, you can remove the `program_usb_boot_mode` line from config.txt, so
 
 You can now boot from an USB mass storage device in the same way as booting from SD, see the following paragraph for Raspberry Pi 3B+, CM3+.
 
-<a name="pi3plus"></a>
 ## Raspberry Pi 3B+, CM3+
 
 The Raspberry Pi 3B+ and CM3+ support USB mass storage boot out of the box. The settings specific to the previous versions of Raspberry Pi do not have to be executed.

--- a/hardware/raspberrypi/bootmodes/msd.md
+++ b/hardware/raspberrypi/bootmodes/msd.md
@@ -65,13 +65,15 @@ After five to ten seconds, the Raspberry Pi should begin booting and show the ra
 <a name="unsupported devices"></a>
 ## Unsupported devices
 
-Including Raspberry Pi 1, 2 (V1.1), Compute Module, Zero
+Including Raspberry Pi 1, 2 (V1.1), Compute Module, Zero.
 
-The boot code for USB is stored in the BCM2837 device only, so the Pi 1 A/B, Pi 2 B (v1.1), and Pi Zero will all require SD cards as they are based on the BCM2835 and BCM2836. This boot code is stored in ROM (except Pi 4B) which by definition cannot be changed.
-
-Regarding the Raspberry Pi 4, the bootcode is stored in [EEPROM](../booteeprom.md) and can be updated. Support for mass storage boot will be added in a future update. In the meantime you can use the alternative below. 
+The boot code for USB is stored in the BCM2837(B0) device only. The Pi 1 A/B, Pi 2 B (v1.1), and Pi Zero will all require SD cards as they are based on the BCM2835 and BCM2836. This boot code for USB is stored in ROM (except Pi 4B) which by definition cannot be changed.
 
 An alternative is to use the 'special bootcode.bin-only boot mode' as described [here](README.md). This still requires/boots from an SD-card, but `bootcode.bin` is the only file read from the SD-Card.
+
+### Raspberry Pi 4
+
+Regarding the Raspberry Pi 4, the bootcode is stored in [EEPROM](../booteeprom.md) and can be updated. Support for mass storage boot will be added in a future update.
 
 ## Known issues
 

--- a/hardware/raspberrypi/bootmodes/msd.md
+++ b/hardware/raspberrypi/bootmodes/msd.md
@@ -45,23 +45,14 @@ You can now boot from an USB Mass Storage device in the same way as booting from
 
 ## Raspberry Pi 3B+, CM3+
 
-The Raspberry Pi 3B+ supports USB Mass Storage boot out of the box. The settings specific to the previous versions of Raspberry Pi do not have to be executed.
+The Raspberry Pi 3B+ and CM3+ support USB Mass Storage boot out of the box. The settings specific to the previous versions of Raspberry Pi do not have to be executed.
 
-This is verified using the following steps, this is the same (procedure)[../../../installation/installing-images/] as for SD cards though many alternative ways are functional:
+This is verified using the following steps, this is the same (procedure)[../../../installation/installing-images/] as for SD cards.
 
-1. Download Raspbian Buster Lite
+On Windows you may have to initialise a (clean) harddrive before it's visible and has a drive letter (which may be required to write the image).
 
-2. Unzip the .zip file (tested with 7zip, but any other should be fine) to an .img file.
-
-3. Initialise the drive (tested with MBR scheme, no partition/clean disk).
-
-4. Flash the .img file to the external drive (tested using Win32DiskImager on Windows 10)
-
-5. Unmount and disconnect the drive.
-
-6. Connect the drive to the Raspberry Pi and power up the Pi (mind extra USB power usage from external drive).
-
-7. After five to ten seconds, the Raspberry Pi should begin booting and show the rainbow splash screen on an attached display. Make sure that you do not have an SD card inserted in the Pi, since if you do, it will boot from that first.
+After preparing the storage device, connect the drive to the Raspberry Pi and power up the Pi (mind extra USB power usage from external drive).
+After five to ten seconds, the Raspberry Pi should begin booting and show the rainbow splash screen on an attached display. Make sure that you do not have an SD card inserted in the Pi, since if you do, it will boot from that first.
 
 ## Raspberry Pi 4B
 

--- a/hardware/raspberrypi/bootmodes/msd.md
+++ b/hardware/raspberrypi/bootmodes/msd.md
@@ -63,4 +63,4 @@ The Raspberry Pi 4's bootcode is stored in [EEPROM](../booteeprom.md) and can be
 
 - The default timeout for checking bootable USB devices is 2 seconds. Some flash drives and rotational harddrives power up too slowly. It’s possible to extend this timeout to five seconds (add a new file `timeout` to the SD card), but there are devices that fail to respond within this period as well.
 - Some flash drives have a very specific protocol requirement that is not handled by the bootcode and may thus be incompatible.
-- Lack of power can be an issue, as some devices draw too much current from the Raspberry Pi's USB connection and fail to start, or prevent the Raspberry Pi from booting. An external power supply for the device will be required in these cases.
+- Lack of power can be an issue, so it is recommended to use a powered USB hub, particuarly if you are attaching more than one storage device to the Raspberry Pi. If your device has its own power supply, then use that.

--- a/hardware/raspberrypi/bootmodes/msd.md
+++ b/hardware/raspberrypi/bootmodes/msd.md
@@ -8,6 +8,12 @@ See the [documentation](./) for the boot sequence and alternative boot modes (Ne
 
 Note that "USB Mass Storage Boot" is different from "USB Device Boot Mode", the device boot mode allows a Raspberry Pi connected to a computer to boot using files on that computer.
 
+[Pi 2B v1.2 up to 3](./#raspberry-pi-2b-v12-3a-3b-cm3)
+
+[Pi 3B+ CM3+](#raspberry-pi-3b-cm3)
+
+[Unsupported devices](#unsupported-devices)
+
 ## Raspberry Pi 2B v1.2, 3A+, 3B, CM3
 
 On the Raspberry Pi 2B v1.2, 3A+, 3B, CM3, first USB [host boot mode](host.md) should be enabled. This is to allow Mass Storage Boot / Network boot (Network boot not supported on 3A+).
@@ -41,7 +47,7 @@ Check that the output `0x3020000a` is shown. If it is not, then the OTP bit has 
 
 If you wish, you can remove the `program_usb_boot_mode` line from config.txt, so that if you put the SD card into another Raspberry Pi, it won't program USB host boot mode. Make sure there is no blank line at the end of config.txt.
 
-You can now boot from an USB Mass Storage device in the same way as booting from SD, see the following paragraph for Raspberry Pi 3B+.
+You can now boot from an USB Mass Storage device in the same way as booting from SD, see the following paragraph for Raspberry Pi 3B+, CM3+.
 
 ## Raspberry Pi 3B+, CM3+
 
@@ -54,26 +60,15 @@ On Windows you may have to initialise a (clean) harddrive before it's visible an
 After preparing the storage device, connect the drive to the Raspberry Pi and power up the Pi (mind extra USB power usage from external drive).
 After five to ten seconds, the Raspberry Pi should begin booting and show the rainbow splash screen on an attached display. Make sure that you do not have an SD card inserted in the Pi, since if you do, it will boot from that first.
 
-## Raspberry Pi 4B
-
-Support for USB mass storage boot will be added to the Raspberry Pi 4B in a future software update.
-
-According to rpdom in a [forum post](https://www.raspberrypi.org/forums/viewtopic.php?t=243995#p1488036):
-
-The Pi4 uses a different boot loader to the earlier models. It is stored in eeprom on the board instead of part in the chip and part on the SD card. An update and instructions on how to apply it will be issued when the USB and network boot is ready.
-
 ## Unsupported devices
 
 Including Raspberry Pi 1, 2 (V1.1), Compute Module, Zero
 
 The boot code for USB is stored in the BCM2837 device only, so the Pi 1 A/B, Pi 2 B (v1.1), and Pi Zero will all require SD cards as they are based on the BCM2835 and BCM2836. This boot code is stored in ROM (except Pi 4B) which by definition cannot be changed.
 
+Regarding the Raspberry Pi 4, the bootcode is stored in [EEPROM](../booteeprom.md) and can be updated. Support for mass storage boot will be added in a future update. In the meanwhile you can use the alternative below. 
+
 An alternative is to use the 'special bootcode.bin-only boot mode' as described [here](./). This still requires/boots from an SD-card, but `bootcode.bin` is the only file read from the SD-Card.
-
-
-## Extra info
-
-https://www.raspberrypi.org/blog/pi-3-booting-part-i-usb-mass-storage-boot/
 
 ## Known issues
 


### PR DESCRIPTION
Updated the file to properly include 3B+ and 4B added background info from other sources on raspberrypi.org
I'm specifically curious if the part on Raspberry Pi 3B+, the info included in brackets "(" ")", which are test notes are relevant for this page. But my feeling is that they are important for reproducibility.

- Made it more clear that Pi 3B+ supports Mass Storage boot out of the box (Tested myself)
- Changed the text on setting up into a step-by-step guide with comments on how it was tested in my case.
- Split the article per version of Raspberry Pi, to keep it more readable. (In the original article 3B and 3B+ weren't as well separated)
- Added a reference to the 'Special bootcode.bin boot mode', which can be an interesting alternative for Pi 1/2 users.
- Added known issues.
- Added list of known working devices
- Added extra info; reference to Blog post of developer during Beta of USB Mass storage boot.