### PR TITLE
Resource busy on osx

### DIFF
--- a/installation/installing-images/mac.md
+++ b/installation/installing-images/mac.md
@@ -29,11 +29,13 @@
    This can take more than 15 minutes, depending on the image file size. 
    Check the progress by pressing Ctrl+T.
    
+    If the command reports `dd: /dev/rdisk2: Resource busy`, you need to unmount the volume first `sudo diskutil unmountDisk /dev/disk2`.
+
     If the command reports `dd: bs: illegal numeric value`, change the block size `bs=1m` to `bs=1M`.
-    
+
     If the command reports `dd: /dev/rdisk2: Operation not permitted` you need to disable SIP before continuing.
 
-    If the command reports the error `dd: /dev/rdisk3: Permission denied`, the partition table of the SD card is being protected against being overwritten by Mac OS. Erase the SD card's partition table using this command:
+    If the command reports `dd: /dev/rdisk3: Permission denied`, the partition table of the SD card is being protected against being overwritten by Mac OS. Erase the SD card's partition table using this command:
     
     ```
     sudo diskutil partitionDisk /dev/diskN 1 MBR "Free Space" "%noformat%" 100%


### PR DESCRIPTION
The old documentation to create an sd card on osx was better. Adding missing step to unmount the volume.

```
$ sudo dd bs=1m if=image.img of=/dev/rdisk2 conv=sync
dd: /dev/rdisk2: Resource busy
$ sudo diskutil unmountDisk /dev/disk2
Unmount of all volumes on disk2 was successful
```