### PR TITLE
building.md: Add extra packages to be able to cross-compile the kernel

### DIFF
--- a/configuration/wireless/access-point.md
+++ b/configuration/wireless/access-point.md
@@ -135,8 +135,8 @@ sudo systemctl start hostapd
 Do a quick check of their status to ensure they are active and running:
 
 ```
-sudo systemctl status hostapd
-sudo systemctl status dnsmasq
+systemctl status hostapd
+systemctl status dnsmasq
 ```
 
 ### Add routing and masquerade

--- a/configuration/wireless/access-point.md
+++ b/configuration/wireless/access-point.md
@@ -135,8 +135,8 @@ sudo systemctl start hostapd
 Do a quick check of their status to ensure they are active and running:
 
 ```
-systemctl status hostapd
-systemctl status dnsmasq
+sudo systemctl status hostapd
+sudo systemctl status dnsmasq
 ```
 
 ### Add routing and masquerade

--- a/linux/kernel/building.md
+++ b/linux/kernel/building.md
@@ -118,7 +118,7 @@ See [**Choosing sources**](#choosing_sources) above for instructions on how to c
 
 To build the sources for cross-compilation, make sure you have the dependencies needed on your machine by executing:
 ```bash
-sudo apt install git bc bison flex libssl-dev make
+sudo apt install git bc bison flex libssl-dev make libc6-dev libncurses5-dev
 ```
 If you find you need other things, please submit a pull request to change the documentation.
 


### PR DESCRIPTION
I started a fresh Linux Mint 19 XFCE installation and then wanted to build the Raspberry Pi kernel.
Following the documentation, I was missing two packages:
- libc6-dev (build error because sys/types.h was missing)
- libncurses5-dev (needed when you run make menuconfig...)

Adding those two missing packages solved the issue and I was able to build the kernel without problems.