### PR TITLE
Removed note about old Fail2ban version in repository

### DIFF
--- a/configuration/security.md
+++ b/configuration/security.md
@@ -234,8 +234,6 @@ Install fail2ban using the following command:
 sudo apt install fail2ban
 ```
 
-Note that the version of Fail2ban in the repository (v0.8.13) does not support IPv6 networks. If you use IPv6, you will need to install version v0.10 or higher from source. Please see the [Fail2ban](http://www.fail2ban.org) website for more information on how to do this.
-
 On installation, Fail2ban creates a folder `/etc/fail2ban` in which there is a configuration file called `jail.conf`. This needs to be copied to `jail.local` to enable it. Inside this configuration file are a set of default options, together with options for checking specific services for abnormalities. Do the following to examine/change the rules that are used for `ssh`:
 
 ```bash


### PR DESCRIPTION
I just installed fail2ban on my Raspberry Pi 3 (Raspbian GNU/Linux 10 (buster)) and the version that installed was v0.10.2.
This seems to make this note unnecessary.