### PR TITLE
otpbits.md: revision number -> revision code

### DIFF
--- a/hardware/raspberrypi/otpbits.md
+++ b/hardware/raspberrypi/otpbits.md
@@ -25,7 +25,7 @@ This list contains the publicly available information on the registers. If a reg
 18 – copy of bootmode register   
 28 – serial number   
 29 – ~(serial number)   
-30 – [revision number](./revision-codes/README.md)   
+30 – [revision code](./revision-codes/README.md)<sup>1</sup>   
 36-43 - [customer OTP values](../industrial/README.md)   
 45 - MPG2 decode key   
 46 - WVC1 decode key   
@@ -39,3 +39,5 @@ This list contains the publicly available information on the registers. If a reg
    - Bit 25: ETH_CLK frequency:
       - 0 - 25MHz
       - 1 - 24MHz  
+
+<sup>1</sup>Also contains bits to disable overvoltage, OTP programming, and OTP reading.


### PR DESCRIPTION
Minor nit - for consistency. I suspect 'revision number' was their original name, when they were purely sequential.

Also mention this register stores other things too - currently 3 features not related to the revision code. Not sure if this is really needed, but it improves the 'discoverability' of this information slightly.