### PR TITLE
Change in Price for "Raspberry Pi 4 Model B 2GB"

### DIFF
--- a/faqs/README.md
+++ b/faqs/README.md
@@ -133,7 +133,7 @@ The following prices are exclusive of any local taxes and shipping/handling fees
 | Raspberry Pi 3 Model A+ | $25 |
 | Raspberry Pi 3 Model B+ | $35 |
 | Raspberry Pi 4 Model B 1GB | $35 |
-| Raspberry Pi 4 Model B 2GB | $45 |
+| Raspberry Pi 4 Model B 2GB | $35 |
 | Raspberry Pi 4 Model B 4GB | $55 |
 | Raspberry Pi Zero | $5 |
 | Raspberry Pi Zero W |$10 |


### PR DESCRIPTION
This pull request updates the price of the Raspberry Pi 4 Model B 2GB in FAQs, as I saw it shows Raspberry Pi 4 Model B 2GB for $45 which is not up-to-date.