### PR TITLE
update arm versions in kernel building instructions

### DIFF
--- a/linux/kernel/building.md
+++ b/linux/kernel/building.md
@@ -52,7 +52,7 @@ make bcmrpi_defconfig
 
 ```bash
 cd linux
-KERNEL=kernel7
+KERNEL=kernel7l
 make bcm2709_defconfig
 ```
 


### PR DESCRIPTION
I'm running Raspbian Buster Lite, 2020-02-12.

On pi 2 I get:
```
pi@raspberrypi:~ $ cat /sys/firmware/devicetree/base/model;echo
Raspberry Pi 2 Model B Rev 1.1
pi@raspberrypi:~ $ lscpu | grep arm
Architecture:        armv7l
```

On pi 3+ I get:
```
pi@raspberrypi:~/mcp3008hwspi $ cat /sys/firmware/devicetree/base/model;echo
Raspberry Pi 3 Model B Plus Rev 1.3
pi@raspberrypi:~/mcp3008hwspi $ lscpu | grep arm
Architecture:        armv7l
```

However [build instructions](https://github.com/raspberrypi/documentation/blob/master/linux/kernel/building.md#raspberry-pi-2-pi-3-pi-3-and-compute-module-3-default-build-configuration) for both Pi 2 and Pi 3+ call for `KERNEL=kernel7` instead of `KERNEL=kernel7l`.