### PR TITLE
Modify kernel configuring page

### DIFF
--- a/linux/kernel/configuring.md
+++ b/linux/kernel/configuring.md
@@ -12,33 +12,7 @@ The `menuconfig` tool requires the `ncurses` development headers to compile prop
 $ sudo apt install libncurses5-dev
 ```
 
-You'll also need to download and prepare your kernel sources, as described in the [build guide](building.md). In particular, ensure you have installed the default configuration.
-
-For all models of Raspberry Pi 1 (includes Compute Module and Pi Zero):
-
-```
-$ KERNEL=kernel
-$ make bcmrpi_defconfig
-```
-
-If you're cross-compiling, the second line should be:
-
-```
-make ARCH=arm CROSS_COMPILE=arm-linux-gnueabihf- bcmrpi_defconfig
-```
-
-For all models of Raspberry Pi 2/3 (includes 3B+, 3A+ and Compute Module 3):
-
-```
-$ KERNEL=kernel7
-$ make bcm2709_defconfig
-```
-
-If you're cross-compiling, the second line should be:
-
-```
-make ARCH=arm CROSS_COMPILE=arm-linux-gnueabihf- bcm2709_defconfig
-```
+You'll also need to download and prepare your kernel sources, as described in the [build guide](building.md#choosing_sources). In particular, ensure you have installed the [default configuration](building.md#default_configuration).
 
 ## Using menuconfig
 


### PR DESCRIPTION
It didn't cover configuring the kernel for Pi4, so link it to the kernel building page, which does cover the Pi4 (and eliminate some redundancy).