### PR TITLE
Update the just updated access-point-bridged.md

### DIFF
--- a/configuration/wireless/access-point-bridged.md
+++ b/configuration/wireless/access-point-bridged.md
@@ -112,7 +112,13 @@ Add the following line near the beginning of the file (above the first `interfac
 ```
 denyinterfaces wlan0 eth0
 ```
-Interface `br0` will be configured in accordance with the defaults via DHCP; no specific entry is necessary. Save the file to complete the IP configuration of the machine.
+Go to the end of the file and add the following:
+
+```
+
+interface br0
+```
+With this line, interface `br0` will be configured in accordance with the defaults via DHCP. Save the file to complete the IP configuration of the machine.
 
 <a name="ap-config"></a>
 ## Configure the access point software


### PR DESCRIPTION
As per a Mar. 7 comment I made on #1333 that didn't get included in the merge.
Declaring "interface br0" in dhcpcd.conf is mandatory I think. The dhcpcd.conf manpage says so, since br is a "virtual" interface. The original write-up worked without it, but no longer. Uncovered in #1423
Thanks.