### PR TITLE
Fix example of default location for ssh keys

### DIFF
--- a/remote-access/ssh/passwordless.md
+++ b/remote-access/ssh/passwordless.md
@@ -20,7 +20,7 @@ To generate new SSH keys enter the following command:
 ssh-keygen
 ```
 
-Upon entering this command, you'll be asked where to save the key. We suggest you save it in the default location (`/home/pi/.ssh/id_rsa`) by just hitting `Enter`.
+Upon entering this command, you'll be asked where to save the key. We suggest you save it in the default location (`~/.ssh/id_rsa`) by just hitting `Enter`.
 
 You'll also be asked to enter a passphrase. This is extra security which will make the key unusable without your passphrase, so if someone else copied your key, they could not impersonate you to gain access. If you choose to use a passphrase, type it here and press `Enter`, then type it again when prompted. Leave the field empty for no passphrase.
 


### PR DESCRIPTION
The ssh keys are generated on the computer that is used to connect to the Raspberry Pi. The default location for the ssh keys most likely isn't '/home/pi/.ssh/id_rsa', but generally is '~/.ssh/id_rsa'. 
This was confusing, since it could be interpreted as having to generate the ssh keys on the Raspberry Pi itself.