### PR TITLE
Fix instructions for enabling camera

### DIFF
--- a/usage/camera/README.md
+++ b/usage/camera/README.md
@@ -20,7 +20,7 @@ Open the `raspi-config` tool from the Terminal:
 sudo raspi-config
 ```
 
-Select `Enable camera` and hit `Enter`, then go to `Finish` and you'll be prompted to reboot.
+Select `Interfacing Options` then `Camera` and hit `Enter`. Choose `Yes` then `Ok`. Go to `Finish` and you'll be prompted to reboot.
 
 ## Using the camera
 


### PR DESCRIPTION
This reflects the latest `raspi-config` menu navigation required to enable the camera interface.

Not sure if there still needs to be some mention of these "old" instructions, or whether they're simply incorrect.