### PR TITLE
installing-images/mac: Don't use conv=sync with dd

### DIFF
--- a/installation/installing-images/mac.md
+++ b/installation/installing-images/mac.md
@@ -61,7 +61,7 @@ If you specify the wrong device in the instructions, you could overwrite your pr
 - Copy the image
 
   ```bash
-  sudo dd bs=1m if=path_of_your_image.img of=/dev/rdiskN conv=sync
+  sudo dd bs=1m if=path_of_your_image.img of=/dev/rdiskN; sync
   ```
 
    Replace `N` with the number that you noted before. Note the ```rdisk``` ('raw disk')


### PR DESCRIPTION
The conv=sync option is for padding input blocks to the input block size.
This is not what we want. OS X's dd does not have the oflag=fsync option
that we would use on we would use on GNU/Linux, but calling "sync" after dd
is an option.

Fixes: 4dbfa3508837 ("installing-images: dd - use conv=fsync and conv=sync for Linux and Mac (#695)")
Signed-off-by: John Brooks <john@fastquake.com>