### PR TITLE
Add rpi-update docs

### DIFF
--- a/linux/kernel/updating.md
+++ b/linux/kernel/updating.md
@@ -1,6 +1,6 @@
 # Updating the kernel
 
-If you use the standard Raspbian update/upgrade process (found [here](../../raspbian/updating.md)), this will automatically update the kernel to the latest stable version. This is the recommended procedure. However, in certain circumstances, you may wish to update to the latest 'bleeding edge' or test kernel. You should only do this if recommended to do so by a Raspberry Pi engineer, or there is a specific feature only available in this latest software.
+If you use the standard Raspbian update/upgrade process (found [here](../../raspbian/updating.md)), this will automatically update the kernel to the latest stable version. This is the recommended procedure. However, in certain circumstances, you may wish to update to the latest 'bleeding edge' or test kernel. You should only do this if recommended to do so by a Raspberry Pi engineer, or if there is a specific feature only available in this latest software.
 
 Instructions for upgrading to the latest pre-release and testing software can be found [here](../../raspbian/applications/rpi-update.md). This page also has instructions on how to return to the standard software.
 

--- a/linux/kernel/updating.md
+++ b/linux/kernel/updating.md
@@ -1,32 +1,6 @@
 # Updating the kernel
 
-If you use the standard Raspbian update/upgrade process (found [here](../../raspbian/updating.md)), this will automatically update the kernel to the latest stable version. This is the recommended procedure. However, in certain circumstances, you may wish to update to the latest 'bleeding edge' or test kernel.
+If you use the standard Raspbian update/upgrade process (found [here](../../raspbian/updating.md)), this will automatically update the kernel to the latest stable version. This is the recommended procedure. However, in certain circumstances, you may wish to update to the latest 'bleeding edge' or test kernel. You should only do this if recommended to do so by a Raspberry Pi engineer, or there is a specific feature only available in this latest software.
 
-### Manual updates using rpi-update
+Instructions for upgrading to the latest pre-release and testing software can be found [here](../../raspbian/applications/rpi-update.md). This page also has instructions on how to return to the standard software.
 
-**Do not use `rpi-update` unless you have been recommended to do so by a Raspberry Pi engineer. This is because it updates the Linux kernel and Raspberry Pi firmware to the very latest version which is currently under test. It may therefore make your Pi unstable, or cause random breakage.**
-
-To use rpi-update, execute it using sudo as follows:
-
-```
-sudo rpi-update
-```
-
-The `rpi-update` utility will download the Linux kernel and Raspberry Pi firmware that are currently being tested and install them onto your Pi. Note that `rpi-update` does not provide a way to revert the changes that it makes to your system.
-
-After upgrading the kernel, you must reboot your Pi to switch to the updated version.
-
-If you're using a compiled kernel, rpi-update will overwrite it, and you will need to [rebuild](building.md) and reinstall your kernel.
-
-Custom [configurations](configuring.md) can usually be copied over between minor kernel updates, but it's safer to use the `diff` utility to see what's changed and repeat your changes on the new configuration.
-
-### Reverting back to current stock Raspbian kernel
-
-The Raspberry Pi Foundation kernel is supplied by the `raspberrypi-kernel` package, and the bootloader and firmware are supplied by the `raspberrypi-bootloader` package. To revert to the current stock Raspbian kernel after trying `rpi-update` or a custom kernel, you need to reinstall both these packages as follows:
-
-```
-sudo apt update
-sudo apt install --reinstall raspberrypi-bootloader raspberrypi-kernel
-```
-
-Note that this will install the latest stable versions of the kernel, bootloader and firmware that are available from the package repository, which may not be the same versions that you were running before you ran `rpi-update`.

--- a/linux/kernel/updating.md
+++ b/linux/kernel/updating.md
@@ -4,3 +4,6 @@ If you use the standard Raspbian update/upgrade process (found [here](../../rasp
 
 Instructions for upgrading to the latest pre-release and testing software can be found [here](../../raspbian/applications/rpi-update.md). This page also has instructions on how to return to the standard software.
 
+It is also possible to build your own kernel using the latest top of tree code from the Raspberry Pi kernel respository. Instructions for building and installing can be found [here](./building.md)
+
+

--- a/raspbian/README.md
+++ b/raspbian/README.md
@@ -21,3 +21,4 @@ Raspbian is a community project under active development, with an emphasis on im
     - [vcgencmd](applications/vcgencmd.md)
     - [vcdbg](applications/vcdbg.md)
     - [tvservice](applications/tvservice.md)
+    - [rpi-update](applications/rpi-update.md)

--- a/raspbian/applications/README.md
+++ b/raspbian/applications/README.md
@@ -13,3 +13,5 @@
     - Information on the vcdbg application, used to recover debugging information from the VideoCore GPU.
 - [tvservice](tvservice.md)
     - Command line application for getting and setting information about the attached display/audio devices. 
+- [rpi-update](rpi-update.md)
+    - Command line application for updating to pre-release and beta software.

--- a/raspbian/applications/rpi-update.md
+++ b/raspbian/applications/rpi-update.md
@@ -14,7 +14,7 @@ All the source data used by `rpi-update` comes from the Github repo https://gith
 
 ## Running `rpi-update`
 
-If you are sure that you need to use `rpi-update`, it is advisable to take a backup of your current system first as running `rpi-update` could result in a non-booting system.
+If you are sure that you need to use `rpi-update`, it is advisable to take a [backup](../../linux/filesystem/backup.md) of your current system first as running `rpi-update` could result in a non-booting system.
 
 `rpi-update` needs to be run as root. Once the update is complete you will need to reboot.
 

--- a/raspbian/applications/rpi-update.md
+++ b/raspbian/applications/rpi-update.md
@@ -4,7 +4,7 @@
 
 **WARNING: Pre-release versions of software are not guaranteed to work. You should not use `rpi-update` on any system unless recommended to do so by a Raspberry Pi engineer. It may leave your system unreliable or even completely broken. It should not be used as part of any regular update process**
 
-The `rpi-update` script is supplied by a third party, `Hexxeh`, and the source can be found on Github at https://github.com/Hexxeh/rpi-update
+The `rpi-update` script is supplied by a third party, `Hexxeh`, and also supported by Raspberry Pi engineers. The script source can be found on Github at https://github.com/Hexxeh/rpi-update
 
 ## What it does
 

--- a/raspbian/applications/rpi-update.md
+++ b/raspbian/applications/rpi-update.md
@@ -2,15 +2,15 @@
 
 `rpi-update` is a command line application that will update your Raspbian kernel and VideoCore firmware to the latest pre-release versions.
 
-**WARNING: Pre-release versions of software are not guaranteed to work. You should not use `rpi-update` on any system unless recommended to do so by a Raspberry Pi engineer. It may leave your system unreliable or even completely broken. It should not be used as part of any regular update process**
+**WARNING: Pre-release versions of software are not guaranteed to work. You should not use `rpi-update` on any system unless recommended to do so by a Raspberry Pi engineer. It may leave your system unreliable or even completely broken. It should not be used as part of any regular update process.**
 
 The `rpi-update` script is supplied by a third party, "Hexxeh", and also supported by Raspberry Pi engineers. The script source can be found on Github at https://github.com/Hexxeh/rpi-update
 
 ## What it does
 
-`rpi-update` will download the latest pre-release version of the linux kernel, it's matching modules, device tree files, along with the latest versions of the VideoCore firmware. It will then install these files to the boot partition of the SD card, overwriting any previous versions. 
+`rpi-update` will download the latest pre-release version of the linux kernel, its matching modules, device tree files, along with the latest versions of the VideoCore firmware. It will then install these files to the boot partition of the SD card, overwriting any previous versions. 
 
-All the source data used by `rpi-update` comes from the Github repo https://github.com/Hexxeh/rpi-firmware. This repository simply  contains a subset of the data from the [official firmware repository](https://github.com/raspberrypi/firmware), as not all the data from that repo is required. 
+All the source data used by `rpi-update` comes from the GitHub repo https://github.com/Hexxeh/rpi-firmware. This repository simply  contains a subset of the data from the [official firmware repository](https://github.com/raspberrypi/firmware), as not all the data from that repo is required. 
 
 ## Running `rpi-update`
 
@@ -23,17 +23,13 @@ sudo rpi-update
 sudo reboot
 ```
 
-It has a number of options, which are documented at the Hexxeh Github repository at https://github.com/Hexxeh/rpi-update
+It has a number of options, which are documented at the Hexxeh GitHub repository at https://github.com/Hexxeh/rpi-update
 
 ## How to get back to safety
 
-If you have done a `rpi-update` and things are not working as you wish, if your Raspberry Pi is still bootable you can return to the stable release using:
+If you have done an `rpi-update` and things are not working as you wish, if your Raspberry Pi is still bootable you can return to the stable release using:
 
 ```
 sudo apt-get update
 sudo apt install --reinstall libraspberrypi0 libraspberrypi-{bin,dev,doc} raspberrypi-bootloader raspberrypi-kernel
 ```
-
-
-
-

--- a/raspbian/applications/rpi-update.md
+++ b/raspbian/applications/rpi-update.md
@@ -4,11 +4,11 @@
 
 **WARNING: Pre-release versions of software are not guaranteed to work. You should not use `rpi-update` on any system unless recommended to do so by a Raspberry Pi engineer. It may leave your system unreliable or even completely broken. It should not be used as part of any regular update process.**
 
-The `rpi-update` script is supplied by a third party, "Hexxeh", and also supported by Raspberry Pi engineers. The script source can be found on Github at https://github.com/Hexxeh/rpi-update
+The `rpi-update` script is supplied by a third party, "Hexxeh", and also supported by Raspberry Pi engineers. The script source can be found on GitHub at https://github.com/Hexxeh/rpi-update
 
 ## What it does
 
-`rpi-update` will download the latest pre-release version of the linux kernel, its matching modules, device tree files, along with the latest versions of the VideoCore firmware. It will then install these files to the boot partition of the SD card, overwriting any previous versions. 
+`rpi-update` will download the latest pre-release version of the linux kernel, its matching modules, device tree files, along with the latest versions of the VideoCore firmware. It will then install these files to relevant locations on the SD card, overwriting any previous versions. 
 
 All the source data used by `rpi-update` comes from the GitHub repo https://github.com/Hexxeh/rpi-firmware. This repository simply  contains a subset of the data from the [official firmware repository](https://github.com/raspberrypi/firmware), as not all the data from that repo is required. 
 

--- a/raspbian/applications/rpi-update.md
+++ b/raspbian/applications/rpi-update.md
@@ -1,6 +1,6 @@
 # rpi-update
 
-`rpi-update` is a command line application that will update your Raspbian kernel and Videocore firmware to the latest pre-release versions.
+`rpi-update` is a command line application that will update your Raspbian kernel and VideoCore firmware to the latest pre-release versions.
 
 **WARNING: Pre-release versions of software are not guaranteed to work. You should not use `rpi-update` on any system unless recommended to do so by a Raspberry Pi engineer. It may leave your system unreliable or even completely broken. It should not be used as part of any regular update process**
 
@@ -8,7 +8,7 @@ The `rpi-update` script is supplied by a third party, "Hexxeh", and also support
 
 ## What it does
 
-`rpi-update` will download the latest pre-release version of the linux kernel, it's matching modules, device tree files, along with the latest versions of the Videocore firmware. It will then install these files to the boot partition of the SD card, overwriting any previous versions. 
+`rpi-update` will download the latest pre-release version of the linux kernel, it's matching modules, device tree files, along with the latest versions of the VideoCore firmware. It will then install these files to the boot partition of the SD card, overwriting any previous versions. 
 
 All the source data used by `rpi-update` comes from the Github repo https://github.com/Hexxeh/rpi-firmware. This repository simply  contains a subset of the data from the [official firmware repository](https://github.com/raspberrypi/firmware), as not all the data from that repo is required. 
 
@@ -31,7 +31,7 @@ If you have done a `rpi-update` and things are not working as you wish, if your 
 
 ```
 sudo apt-get update
-sudo apt-get install --reinstall raspberrypi-bootloader raspberrypi-kernel
+sudo apt install --reinstall libraspberrypi0 libraspberrypi-{bin,dev,doc} raspberrypi-bootloader raspberrypi-kernel
 ```
 
 

--- a/raspbian/applications/rpi-update.md
+++ b/raspbian/applications/rpi-update.md
@@ -2,7 +2,7 @@
 
 `rpi-update` is a command line application that will update your Raspbian kernel and Videocore firmware to the latest pre-release versions.
 
-**WARNING: Pre-release versions of software are not guaranteed to work. You should not use `rpi-update` on any system unless recommended to do so by a Raspberry Pi engineer. It may leave your system unreliable or even completely broken. It should not be use as part of any regular update process**
+**WARNING: Pre-release versions of software are not guaranteed to work. You should not use `rpi-update` on any system unless recommended to do so by a Raspberry Pi engineer. It may leave your system unreliable or even completely broken. It should not be used as part of any regular update process**
 
 The `rpi-update` script is supplied by a third party, `Hexxeh`, and the source can be found on Github at https://github.com/Hexxeh/rpi-update
 
@@ -10,7 +10,7 @@ The `rpi-update` script is supplied by a third party, `Hexxeh`, and the source c
 
 `rpi-update` will download the latest pre-release version of the linux kernel, it's matching modules, device tree settings, along with the latest version of the Videocore firmware. It will then install these files to the boot partition of the SD card, overwriting any previous versions. 
 
-All the source data used by `rpi-update` comes from the Github repo https://github.com/Hexxeh/rpi-firmware. This repository simply  contains a subset of the data from the official firmware repository, as not all the data from that repo is required. 
+All the source data used by `rpi-update` comes from the Github repo https://github.com/Hexxeh/rpi-firmware. This repository simply  contains a subset of the data from the [official firmware repository](https://github.com/raspberrypi/firmware), as not all the data from that repo is required. 
 
 ## Running `rpi-update`
 

--- a/raspbian/applications/rpi-update.md
+++ b/raspbian/applications/rpi-update.md
@@ -14,6 +14,8 @@ All the source data used by `rpi-update` comes from the Github repo https://gith
 
 ## Running `rpi-update`
 
+If you are sure that you need to use `rpi-update`, it is advisable to take a backup of your current system first as running `rpi-update` could result in a non-booting system.
+
 `rpi-update` needs to be run as root. Once the update is complete you will need to reboot.
 
 ```

--- a/raspbian/applications/rpi-update.md
+++ b/raspbian/applications/rpi-update.md
@@ -1,0 +1,37 @@
+# rpi-update
+
+`rpi-update` is a command line application that will update your Raspbian kernel and Videocore firmware to the latest pre-release versions.
+
+**WARNING: Pre-release versions of software are not guaranteed to work. You should not use `rpi-update` on any system unless recommended to do so by a Raspberry Pi engineer. It may leave your system unreliable or even completely broken. It should not be use as part of any regular update process**
+
+The `rpi-update` script is supplied by a third party, `Hexxeh`, and the source can be found on Github at https://github.com/Hexxeh/rpi-update
+
+## What it does
+
+`rpi-update` will download the latest pre-release version of the linux kernel, it's matching modules, device tree settings, along with the latest version of the Videocore firmware. It will then install these files to the boot partition of the SD card, overwriting any previous versions. 
+
+All the source data used by `rpi-update` comes from the Github repo https://github.com/Hexxeh/rpi-firmware. This repository simply  contains a subset of the data from the official firmware repository, as not all the data from that repo is required. 
+
+## Running `rpi-update`
+
+`rpi-update` needs to be run as root. Once the update is complete you will need to reboot.
+
+```
+sudo rpi-update
+sudo reboot
+```
+
+It has a number of options, which are documented at the Hexxeh Github repository at https://github.com/Hexxeh/rpi-update
+
+## How to get back to safety
+
+If you have done a `rpi-update` and things are not working as you wish, if your Raspberry Pi is still bootable you can return to the stable release using:
+
+```
+sudo apt-get update
+sudo apt-get install --reinstall raspberrypi-bootloader raspberrypi-kernel
+```
+
+
+
+

--- a/raspbian/applications/rpi-update.md
+++ b/raspbian/applications/rpi-update.md
@@ -33,3 +33,4 @@ If you have done an `rpi-update` and things are not working as you wish, if your
 sudo apt-get update
 sudo apt install --reinstall libraspberrypi0 libraspberrypi-{bin,dev,doc} raspberrypi-bootloader raspberrypi-kernel
 ```
+You will need to reboot your Raspberry Pi for these changes to take effect. 

--- a/raspbian/applications/rpi-update.md
+++ b/raspbian/applications/rpi-update.md
@@ -4,11 +4,11 @@
 
 **WARNING: Pre-release versions of software are not guaranteed to work. You should not use `rpi-update` on any system unless recommended to do so by a Raspberry Pi engineer. It may leave your system unreliable or even completely broken. It should not be used as part of any regular update process**
 
-The `rpi-update` script is supplied by a third party, `Hexxeh`, and also supported by Raspberry Pi engineers. The script source can be found on Github at https://github.com/Hexxeh/rpi-update
+The `rpi-update` script is supplied by a third party, "Hexxeh", and also supported by Raspberry Pi engineers. The script source can be found on Github at https://github.com/Hexxeh/rpi-update
 
 ## What it does
 
-`rpi-update` will download the latest pre-release version of the linux kernel, it's matching modules, device tree settings, along with the latest version of the Videocore firmware. It will then install these files to the boot partition of the SD card, overwriting any previous versions. 
+`rpi-update` will download the latest pre-release version of the linux kernel, it's matching modules, device tree files, along with the latest versions of the Videocore firmware. It will then install these files to the boot partition of the SD card, overwriting any previous versions. 
 
 All the source data used by `rpi-update` comes from the Github repo https://github.com/Hexxeh/rpi-firmware. This repository simply  contains a subset of the data from the [official firmware repository](https://github.com/raspberrypi/firmware), as not all the data from that repo is required. 
 


### PR DESCRIPTION
Really just an official page that just links to the github repo, but with the appropriate warnings and a method of getting back to safety. 