### PR TITLE
Update building.md

### DIFF
--- a/linux/kernel/building.md
+++ b/linux/kernel/building.md
@@ -131,7 +131,7 @@ See [**Choosing sources**](#choosing_sources) above for instructions on how to c
 
 To build the sources for cross-compilation, make sure you have the dependencies needed on your machine by executing:
 ```bash
-sudo apt install git bc bison flex libssl-dev make libc6-dev libncurses5-dev
+sudo apt install git bc bison flex libssl-dev make libc6-dev libncurses5-dev gcc-arm-linux-gnueabihf
 ```
 If you find you need other things, please submit a pull request to change the documentation.
 


### PR DESCRIPTION
Add gcc-arm-linux-gnueabihf dependency becasue with Ubuntu 20.04 the build failed:
`make: arm-linux-gnueabihf-gcc: Command not found`