### PR TITLE
WIP: Use visudo to edit any sudoers file

### DIFF
--- a/configuration/security.md
+++ b/configuration/security.md
@@ -90,7 +90,7 @@ and change the `pi` entry (or whichever usernames have superuser rights) to:
 pi ALL=(ALL) PASSWD: ALL
 ```
 
-Then save the file: it will be checked for any syntax errors. If no errors were detected, the file will be saved and you will be returned to the shell prompt (e.g. `pi@raspberry:~ $`). If errors were detected, you will be asked 'what now?' Press the 'enter' key on your keyboard: this will bring up a list of options. You will probably want to use press 'e' for '(e)dit sudoers file again,' so you can edit the file and fix the problem. **Note that choosing option 'Q' will save the file with any syntax errors still in place, which makes it impossible for _any_ user to use the sudo command.**
+Then save the file: it will be checked for any syntax errors. If no errors were detected, the file will be saved and you will be returned to the shell prompt. If errors were detected, you will be asked 'what now?' Press the 'enter' key on your keyboard: this will bring up a list of options. You will probably want to use 'e' for '(e)dit sudoers file again,' so you can edit the file and fix the problem. **Note that choosing option 'Q' will save the file with any syntax errors still in place, which makes it impossible for _any_ user to use the sudo command.**
 
 ## Ensure you have the latest security fixes
 

--- a/configuration/security.md
+++ b/configuration/security.md
@@ -90,7 +90,7 @@ and change the `pi` entry (or whichever usernames have superuser rights) to:
 pi ALL=(ALL) PASSWD: ALL
 ```
 
-Then save the file: it will be checked for any syntax errors. If not errors were detected, the file will be saved and you will be returned to the shell prompt (`username@host:directory $`). If errors were detected, you will be asked 'what now?' - press enter/return and it will show a list of options. You will probably want to use '(e)dit sudoers file again,' so you can go in and see what the problem is.
+Then save the file: it will be checked for any syntax errors. If no errors were detected, the file will be saved and you will be returned to the shell prompt (`username@host:directory $`). If errors were detected, you will be asked 'what now?' - press enter/return and it will show a list of options. You will probably want to use press 'e' for '(e)dit sudoers file again,' so you can edit the file and fix the problem. **Note that choosing option 'Q' will save the file with any syntax errors still in place, which makes it impossible for _any_ user to use the sudo command.**
 
 ## Ensure you have the latest security fixes
 

--- a/configuration/security.md
+++ b/configuration/security.md
@@ -90,7 +90,7 @@ and change the `pi` entry (or whichever usernames have superuser rights) to:
 pi ALL=(ALL) PASSWD: ALL
 ```
 
-Then save the file: it will be checked for any syntax errors. If no errors were detected, the file will be saved and you will be returned to the shell prompt (e.g. `pi@raspberry:~ $`). If errors were detected, you will be asked 'what now?' - press enter/return and it will show a list of options. You will probably want to use press 'e' for '(e)dit sudoers file again,' so you can edit the file and fix the problem. **Note that choosing option 'Q' will save the file with any syntax errors still in place, which makes it impossible for _any_ user to use the sudo command.**
+Then save the file: it will be checked for any syntax errors. If no errors were detected, the file will be saved and you will be returned to the shell prompt (e.g. `pi@raspberry:~ $`). If errors were detected, you will be asked 'what now?' Press the 'enter' key on your keyboard: this will bring up a list of options. You will probably want to use press 'e' for '(e)dit sudoers file again,' so you can edit the file and fix the problem. **Note that choosing option 'Q' will save the file with any syntax errors still in place, which makes it impossible for _any_ user to use the sudo command.**
 
 ## Ensure you have the latest security fixes
 

--- a/configuration/security.md
+++ b/configuration/security.md
@@ -81,13 +81,13 @@ Placing `sudo` in front of a command runs it as a superuser, and by default, tha
 To force `sudo` to require a password, enter:
 
 ```bash
-sudo nano /etc/sudoers.d/010_pi-nopasswd
+sudo visudo /etc/sudoers.d/010_pi-nopasswd
 ```
 
 and change the `pi` entry (or whichever usernames have superuser rights) to:
 
 ```bash
-alice ALL=(ALL) PASSWD: ALL
+pi ALL=(ALL) PASSWD: ALL
 ```
 
 Now save the file.

--- a/configuration/security.md
+++ b/configuration/security.md
@@ -90,7 +90,7 @@ and change the `pi` entry (or whichever usernames have superuser rights) to:
 pi ALL=(ALL) PASSWD: ALL
 ```
 
-Then save the file: it will be checked for any syntax errors. If no errors were detected, the file will be saved and you will be returned to the shell prompt (`username@host:directory $`). If errors were detected, you will be asked 'what now?' - press enter/return and it will show a list of options. You will probably want to use press 'e' for '(e)dit sudoers file again,' so you can edit the file and fix the problem. **Note that choosing option 'Q' will save the file with any syntax errors still in place, which makes it impossible for _any_ user to use the sudo command.**
+Then save the file: it will be checked for any syntax errors. If no errors were detected, the file will be saved and you will be returned to the shell prompt (e.g. `pi@raspberry:~ $`). If errors were detected, you will be asked 'what now?' - press enter/return and it will show a list of options. You will probably want to use press 'e' for '(e)dit sudoers file again,' so you can edit the file and fix the problem. **Note that choosing option 'Q' will save the file with any syntax errors still in place, which makes it impossible for _any_ user to use the sudo command.**
 
 ## Ensure you have the latest security fixes
 

--- a/configuration/security.md
+++ b/configuration/security.md
@@ -90,7 +90,7 @@ and change the `pi` entry (or whichever usernames have superuser rights) to:
 pi ALL=(ALL) PASSWD: ALL
 ```
 
-Now save the file.
+Then save the file: it will be checked for any syntax errors. If not errors were detected, the file will be saved and you will be returned to the shell prompt (`username@host:directory $`). If errors were detected, you will be asked 'what now?' - press enter/return and it will show a list of options. You will probably want to use '(e)dit sudoers file again,' so you can go in and see what the problem is.
 
 ## Ensure you have the latest security fixes
 

--- a/configuration/security.md
+++ b/configuration/security.md
@@ -76,7 +76,7 @@ sudo deluser -remove-home pi
 
 ## Make `sudo` require a password
 
-Placing `sudo` in front of a command runs it as a superuser, and by default, that does not need a password. In general, this is not a problem. However, if your Pi is exposed to the internet and somehow becomes exploited (perhaps via a webpage exploit for example), the attacker will be able to change things that require superuser credential, unless you have set `sudo` to require a password.
+Placing `sudo` in front of a command runs it as a superuser, and by default, that does not need a password. In general, this is not a problem. However, if your Pi is exposed to the internet and somehow becomes exploited (perhaps via a webpage exploit for example), the attacker will be able to change things that require superuser credentials, unless you have set `sudo` to require a password.
 
 To force `sudo` to require a password, enter:
 

--- a/linux/usage/root.md
+++ b/linux/usage/root.md
@@ -18,6 +18,6 @@ You can also run a superuser shell by using `sudo su`. When running commands as 
 
 ## Who can use sudo?
 
-It would defeat the point of the security if anyone could just put `sudo` in front of their commands, so only approved users can use `sudo` to gain administrator privileges. The `pi` user is included in the `sudoers` file of approved users. To allow other users to act as a superuser you can add the user to the `sudo` group with `usermod`, or add them using `visudo`.
+It would defeat the point of the security if anyone could just put `sudo` in front of their commands, so only approved users can use `sudo` to gain administrator privileges. The `pi` user is included in the `sudoers` file of approved users. To allow other users to act as a superuser, add the user to the `sudo` group with `usermod`.
 
 [Find out more about users](users.md).

--- a/linux/usage/root.md
+++ b/linux/usage/root.md
@@ -18,6 +18,6 @@ You can also run a superuser shell by using `sudo su`. When running commands as 
 
 ## Who can use sudo?
 
-It would defeat the point of the security if anyone could just put `sudo` in front of their commands, so only approved users can use `sudo` to gain administrator privileges. The `pi` user is included in the `sudoers` file of approved users. To allow other users to act as a superuser you can add the user to the `sudo` group with `usermod`, edit the `/etc/sudoers` file, or add them using `visudo`.
+It would defeat the point of the security if anyone could just put `sudo` in front of their commands, so only approved users can use `sudo` to gain administrator privileges. The `pi` user is included in the `sudoers` file of approved users. To allow other users to act as a superuser you can add the user to the `sudo` group with `usermod`, or add them using `visudo`.
 
 [Find out more about users](users.md).

--- a/linux/usage/users.md
+++ b/linux/usage/users.md
@@ -44,7 +44,7 @@ Note that the user `bob` will be prompted to enter their password when they run 
 1. Insert the following contents on a single line: `bob ALL=(ALL) NOPASSWD: ALL`
 1. Save the file and exit.
 
-Once you have exited the editor, the file will be checked for any syntax errors. If no errors were detected, the file will be saved and you will be returned to the shell prompt (e.g. `pi@raspberry:~ $`). If errors were detected, you will be asked 'what now?' Press the 'enter' key on your keyboard: this will bring up a list of options. You will probably want to use 'e' for '(e)dit sudoers file again,' so you can edit the file and fix the problem. **Note that choosing option 'Q' will save the file with any syntax errors still in place, which makes it impossible for _any_ user to use the sudo command.**
+Once you have exited the editor, the file will be checked for any syntax errors. If no errors were detected, the file will be saved and you will be returned to the shell prompt. If errors were detected, you will be asked 'what now?' Press the 'enter' key on your keyboard: this will bring up a list of options. You will probably want to use 'e' for '(e)dit sudoers file again,' so you can edit the file and fix the problem. **Note that choosing option 'Q' will save the file with any syntax errors still in place, which makes it impossible for _any_ user to use the sudo command.**
 
 Note that it is standard practice on Linux to have the user prompted for their password when they run `sudo`, since it makes the system slightly more secure.
 

--- a/linux/usage/users.md
+++ b/linux/usage/users.md
@@ -44,6 +44,8 @@ Note that the user `bob` will be prompted to enter their password when they run 
 1. Insert the following contents on a single line: `bob ALL=(ALL) NOPASSWD: ALL`
 1. Save the file and exit.
 
+Once you have exited the editor, the file will be checked for any syntax errors. If no errors were detected, the file will be saved and you will be returned to the shell prompt (e.g. `pi@raspberry:~ $`). If errors were detected, you will be asked 'what now?' - press enter/return and it will show a list of options. You will probably want to use press 'e' for '(e)dit sudoers file again,' so you can edit the file and fix the problem. **Note that choosing option 'Q' will save the file with any syntax errors still in place, which makes it impossible for _any_ user to use the sudo command.**
+
 Note that it is standard practice on Linux to have the user prompted for their password when they run `sudo`, since it makes the system slightly more secure.
 
 ## Delete a user

--- a/linux/usage/users.md
+++ b/linux/usage/users.md
@@ -44,7 +44,7 @@ Note that the user `bob` will be prompted to enter their password when they run 
 1. Insert the following contents on a single line: `bob ALL=(ALL) NOPASSWD: ALL`
 1. Save the file and exit.
 
-Once you have exited the editor, the file will be checked for any syntax errors. If no errors were detected, the file will be saved and you will be returned to the shell prompt (e.g. `pi@raspberry:~ $`). If errors were detected, you will be asked 'what now?' - press enter/return and it will show a list of options. You will probably want to use press 'e' for '(e)dit sudoers file again,' so you can edit the file and fix the problem. **Note that choosing option 'Q' will save the file with any syntax errors still in place, which makes it impossible for _any_ user to use the sudo command.**
+Once you have exited the editor, the file will be checked for any syntax errors. If no errors were detected, the file will be saved and you will be returned to the shell prompt (e.g. `pi@raspberry:~ $`). If errors were detected, you will be asked 'what now?' Press the 'enter' key on your keyboard: this will bring up a list of options. You will probably want to use 'e' for '(e)dit sudoers file again,' so you can edit the file and fix the problem. **Note that choosing option 'Q' will save the file with any syntax errors still in place, which makes it impossible for _any_ user to use the sudo command.**
 
 Note that it is standard practice on Linux to have the user prompted for their password when they run `sudo`, since it makes the system slightly more secure.
 

--- a/linux/usage/users.md
+++ b/linux/usage/users.md
@@ -38,11 +38,11 @@ To add a new user to the `sudo` group, use the `adduser` command:
 sudo adduser bob sudo
 ```
 
-Note that the user `bob` will be prompted to enter their password when they run `sudo`. This differs from the behaviour of the `pi` user, since `pi` is not prompted for their password. If you wish to remove the password prompt from the new user, create a custom sudoers file and place it in the `/etc/sudoers.d` directory:
+Note that the user `bob` will be prompted to enter their password when they run `sudo`. This differs from the behaviour of the `pi` user, since `pi` is not prompted for their password. If you wish to remove the password prompt from the new user, create a custom sudoers file and place it in the `/etc/sudoers.d` directory.
 
-```bash
-echo 'bob ALL=(ALL) NOPASSWD: ALL' | sudo tee /etc/sudoers.d/010_bob-nopasswd
-```
+1. Create the file using `sudo visudo /etc/sudoers.d/010_bob-nopasswd`.
+1. Insert the following contents on a single line: `bob ALL=(ALL) NOPASSWD: ALL`
+1. Save the file and exit.
 
 Note that it is standard practice on Linux to have the user prompted for their password when they run `sudo`, since it makes the system slightly more secure.
 

--- a/usage/terminal/README.md
+++ b/usage/terminal/README.md
@@ -34,7 +34,7 @@ Rather than type every command, the terminal allows you to scroll through previo
 
 ## Sudo
 
-Some commands that make permanent changes to the state of your system require you to have root privileges to run. The command `sudo` temporarily gives your account (if you're not already logged in as root) the ability to run these commands, provided your user name is in a list of users ('sudoers'). When you append `sudo` to the start of a command and press `enter` you will be asked for your password, if that is entered correctly then the command you want to run will be run using root privileges. Be careful though, some commands that require `sudo` to run can irreparably damage your system so be careful!
+Some commands that make permanent changes to the state of your system require you to have root privileges to run. The command `sudo` temporarily gives your account (if you're not already logged in as root) the ability to run these commands, provided your user name is in a list of users ('sudoers'). When you append `sudo` to the start of a command and press `enter`, the command following `sudo` will be run using root privileges. Be very careful: commands requiring root privileges can irreparably damage your system! Note that on some systems you will be prompted to enter your password when you run a command with `sudo`.
 
 Further information on `sudo` and the root user can be found on the [linux root page](../../linux/usage/root.md).
 


### PR DESCRIPTION
See #1107. 

There are currently 3 pages in this repo which have problems to do with the unsafe editing of sudo-related files:

- /linux/usage/users.md
- /linux/usage/root.md
- /configuration/security.md

There is also /usage/terminal/README.md which contains slightly wrong information (doesn't mention Raspbian has no sudo password on the pi user by default), and a grammatical error (comma splice).

This PR fixes them.