### PR TITLE
add note about legacy graphics driver for `display_lcd_rotate` property

### DIFF
--- a/configuration/config-txt/video.md
+++ b/configuration/config-txt/video.md
@@ -663,7 +663,7 @@ If using the VC4 FKMS V3D driver (this is the default on the Raspberry Pi 4), th
 
 ### display_lcd_rotate
 
-For the legacy graphics driver (default on models prior to the Pi4), use `display_lcd_rotate` to rotate or flip the LCD orientation. Parameters are the same as `display_hdmi_rotate`. For the modern graphics driver use `lcd_rotate`.
+For the legacy graphics driver (default on models prior to the Pi4), use `display_lcd_rotate` to rotate or flip the LCD orientation. Parameters are the same as `display_hdmi_rotate`. See also `lcd_rotate`.
 
 ### display_rotate
 

--- a/configuration/config-txt/video.md
+++ b/configuration/config-txt/video.md
@@ -663,7 +663,7 @@ If using the VC4 FKMS V3D driver (this is the default on the Raspberry Pi 4), th
 
 ### display_lcd_rotate
 
-Use `display_lcd_rotate` to rotate or flip the LCD orientation. Parameters are the same as `display_hdmi_rotate`.
+For the legacy graphics driver (default on models prior to the Pi4), use `display_lcd_rotate` to rotate or flip the LCD orientation. Parameters are the same as `display_hdmi_rotate`. For the modern graphics driver use `lcd_rotate`.
 
 ### display_rotate
 


### PR DESCRIPTION
As noted in #1596 the `display_lcd_rotate` property is only valid for use with the legacy graphics driver, but it's not immediately obvious in the documentation, so I added a note to specify such