### PR TITLE
Add CM4 revision code bits

### DIFF
--- a/hardware/raspberrypi/revision-codes/README.md
+++ b/hardware/raspberrypi/revision-codes/README.md
@@ -94,6 +94,7 @@ NOQuuuWuFMMMCCCCPPPPTTTTTTTTRRRR
 |          |              | f: Internal use only       |
 |          |              | 10: CM3+                   |
 |          |              | 11: 4B                     |
+|          |              | 12: CM4                    |
 | RRRR     | Revision     | 0, 1, 2, etc.              |
 
 <sup>1</sup> Information on programming the OTP bits can be found [here](../../industrial/README.md) and [here](../otpbits.md).


### PR DESCRIPTION
This is just an assumption that/question if I derived this correctly. CM4 code has been added in various places, so I guess it will be released next.

If this is wrong, would be great to know which value it will have instead, for our own model detection scripts and also `raspi-config`, I guess.