### PR TITLE
Clear out rc-local.md, point users to systemd, fix systemd page

### DIFF
--- a/linux/usage/rc-local.md
+++ b/linux/usage/rc-local.md
@@ -1,32 +1,3 @@
 # rc.local
 
-In order to have a command or program run when the Pi boots, you can add commands to the `rc.local` file. This is especially useful if you want to be able to plug your Pi in to power headless, and have it run a program without configuration or a manual start.
-
-NOTE: on Jessie, Stretch and Buster (which use systemd), `rc.local` has drawbacks: not all programs will run reliably, because not all services may be available when `rc.local` runs.  
-See [systemd](./systemd.md) for another way to have a command or program run when Raspberry Pi boots.
-
-An alternative for scheduled task management is [cron](cron.md).
-
-## Editing rc.local
-
-On your Pi, edit the file `/etc/rc.local` using the editor of your choice. You must edit with root, for example:
-
-```bash
-sudo nano /etc/rc.local
-```
-
-Add commands below the comment, but leave the line `exit 0` at the end, then save the file and exit.
-
-### Warning
-
-If your command runs continuously (perhaps runs an infinite loop) or is likely not to exit, you must be sure to fork the process by adding an ampersand to the end of the command, like so:
-
-```
-python3 /home/pi/myscript.py &
-```
-
-Otherwise, the script will not end and the Pi will not boot. The ampersand allows the command to run in a separate process and continue booting with the process running.
-
-Also, be sure to reference absolute filenames rather than relative to your home folder; for example, `/home/pi/myscript.py` rather than `myscript.py`.
-
-One more point to note is that all commands will be executed by the root user. This can lead to unexpected behaviour: for example, if a folder is created by a `mkdir` command in the script, the folder would have root ownership and would not be accessible by anyone other than the root user.
+The `rc.local` file is used on Raspberry Pi OS to print the IP address, or addresses, of the system to the screen at boot time. Because Raspberry Pi OS uses `systemd`, you should not use `rc.local` to run programs at startup. Instead, create a [`systemd` service](systemd.md).

--- a/linux/usage/systemd.md
+++ b/linux/usage/systemd.md
@@ -39,7 +39,7 @@ ExecStart=/home/pi/myprogram.sh
 WantedBy=multi-user.target graphical.target
 ```
 
-Let's say the above file is `/etc/systemd/user/myprogram.service`: this defines a new one-shot service named `myprogram`. The `myprogram` service will wait until `network-online.target` have been reached, then run `/home/pi/myprogram.sh`.
+Let's say the above file is `/etc/systemd/user/myprogram.service`: this defines a new one-shot service named `myprogram`. The `myprogram` service will wait until `network-online.target` has been reached, then run `/home/pi/myprogram.sh`.
 
 ### Example - simple service
 A simple service runs continuously for as long as its dependencies are met. We define `/etc/systemd/user/netmusicplayer.service` as follows:

--- a/linux/usage/systemd.md
+++ b/linux/usage/systemd.md
@@ -48,9 +48,8 @@ A simple service runs continuously for as long as its dependencies are met. We d
 [Unit]
 Description=Network music player
 Wants=network-online.target
-After=network-online.target
+After=network-online.target mpd.service
 Requires=mpd.service
-After=mpd.service
 
 [Service]
 Type=simple

--- a/linux/usage/systemd.md
+++ b/linux/usage/systemd.md
@@ -28,6 +28,7 @@ One-time services are used when you wish to run a program which does some work, 
 ```
 [Unit]
 Description=Run my program once at boot time
+Wants=network-online.target
 After=local-fs.target network-online.target
 
 [Service]
@@ -46,6 +47,7 @@ A simple service runs continuously for as long as its dependencies are met. We d
 ```
 [Unit]
 Description=Network music player
+Wants=network-online.target
 After=local-fs.target network-online.target
 Requires=mpd.target
 

--- a/linux/usage/systemd.md
+++ b/linux/usage/systemd.md
@@ -60,7 +60,7 @@ ExecStop=/home/pi/nmp.sh stop
 WantedBy=multi-user.target graphical.target
 ```
 
-Our `netmusicplayer` service is started up using the script `/home/pi/nmp.sh`. We also pass the `stop` parameter to that same script to stop the network music player. Because the network music player uses [`mpd`](https://www.musicpd.org/), we use the `Requires=` directive to specify that `mpd` must be running before `netmusicplayer` starts up.
+Our `netmusicplayer` service is started up using the script `/home/pi/nmp.sh`. The service also passes the `stop` parameter to that same script to stop the network music player. Because the network music player uses [`mpd`](https://www.musicpd.org/), we use the `Requires=` directive to specify that `mpd` must be running before `netmusicplayer` starts up.
 
 ## Install a service
 To install a service, use the `systemctl enable` command as follows:

--- a/linux/usage/systemd.md
+++ b/linux/usage/systemd.md
@@ -29,7 +29,7 @@ One-time services are used when you wish to run a program which does some work, 
 [Unit]
 Description=Run my program once at boot time
 Wants=network-online.target
-After=local-fs.target network-online.target
+After=network-online.target
 
 [Service]
 Type=oneshot
@@ -48,7 +48,7 @@ A simple service runs continuously for as long as its dependencies are met. We d
 [Unit]
 Description=Network music player
 Wants=network-online.target
-After=local-fs.target network-online.target
+After=network-online.target
 Requires=mpd.target
 
 [Service]

--- a/linux/usage/systemd.md
+++ b/linux/usage/systemd.md
@@ -38,7 +38,7 @@ ExecStart=/home/pi/myprogram.sh
 WantedBy=multi-user.target graphical.target
 ```
 
-Let's say the above file is `/etc/systemd/user/myprogram.service`: this defines a new oneshot service named `myprogram`. The `myprogram` service will wait until `local-fs.target` and `network-online.target` have been reached, then run `/home/pi/myprogram.sh`.
+Let's say the above file is `/etc/systemd/user/myprogram.service`: this defines a new one-shot service named `myprogram`. The `myprogram` service will wait until `local-fs.target` and `network-online.target` have been reached, then run `/home/pi/myprogram.sh`.
 
 ### Example - simple service
 A simple service runs continuously for as long as its dependencies are met. We define `/etc/systemd/user/netmusicplayer.service` as follows:

--- a/linux/usage/systemd.md
+++ b/linux/usage/systemd.md
@@ -2,7 +2,7 @@
 
 Raspberry Pi OS uses [`systemd`](https://www.freedesktop.org/wiki/Software/systemd/) to manage the running of services, including controlling what starts when Linux boots.
 
-## `rc.local` and service dependencies
+## Compatibility
 Unlike on older versions of Linux, `systemd` starts services based on their dependencies: services are no longer started in a predefined order. This means it is no longer guaranteed that `rc.local` will run after all other services have started. You should therefore not use `rc.local` to start programs at boot: instead, create a `systemd` service, specifying which other services it depends on.
 
 ## Service definitions
@@ -36,7 +36,7 @@ Type=oneshot
 ExecStart=/home/pi/myprogram.sh
 
 [Install]
-WantedBy=multi-user.target graphical.target
+WantedBy=multi-user.target
 ```
 
 Let's say the above file is `/etc/systemd/user/myprogram.service`: this defines a new one-shot service named `myprogram`. The `myprogram` service will wait until `network-online.target` has been reached, then run `/home/pi/myprogram.sh`.
@@ -49,7 +49,8 @@ A simple service runs continuously for as long as its dependencies are met. We d
 Description=Network music player
 Wants=network-online.target
 After=network-online.target
-Requires=mpd.target
+Requires=mpd.service
+After=mpd.service
 
 [Service]
 Type=simple
@@ -57,10 +58,10 @@ ExecStart=/home/pi/nmp.sh
 ExecStop=/home/pi/nmp.sh stop
 
 [Install]
-WantedBy=multi-user.target graphical.target
+WantedBy=multi-user.target
 ```
 
-Our `netmusicplayer` service is started up using the script `/home/pi/nmp.sh`. The service also passes the `stop` parameter to that same script to stop the network music player. Because the network music player uses [`mpd`](https://www.musicpd.org/), we use the `Requires=` directive to specify that `mpd` must be running before `netmusicplayer` starts up.
+Our `netmusicplayer` service is started up using the script `/home/pi/nmp.sh`. The service also passes the `stop` parameter to that same script to stop the network music player. Because the network music player uses [`mpd`](https://www.musicpd.org/), we use the `After=` and `Requires=` directives to specify that `mpd` must be running before `netmusicplayer` starts up.
 
 ## Enable and disable a service
 To enable a service, use the `systemctl enable` command as follows:

--- a/linux/usage/systemd.md
+++ b/linux/usage/systemd.md
@@ -3,7 +3,7 @@
 Raspberry Pi OS uses [`systemd`](https://www.freedesktop.org/wiki/Software/systemd/) to manage the running of services, including controlling what starts when Linux boots.
 
 ## `rc.local` under `systemd`
-Unlike on older versions of Linux, `systemd` starts services based on their dependencies: services are no longer started in a predefined order. This means it is no longer guaranteed that `rc.local` will run once all other services have started. You should therefore not use `rc.local` to start programs at boot.
+Unlike on older versions of Linux, `systemd` starts services based on their dependencies: services are no longer started in a predefined order. This means it is no longer guaranteed that `rc.local` will run after all other services have started. You should therefore not use `rc.local` to start programs at boot.
 
 ## Service definitions
 `Systemd` defines each service in a separate file. Under `systemd` services are a type of 'unit': units are system resources under the control of `systemd`. The basic format of a service definition is as follows:

--- a/linux/usage/systemd.md
+++ b/linux/usage/systemd.md
@@ -53,14 +53,14 @@ Requires=mpd.target
 
 [Service]
 Type=simple
-ExecStart=/home/pi/netmusicplayer.sh
-ExecStop=/home/pi/netmusicplayer.sh stop
+ExecStart=/home/pi/nmp.sh
+ExecStop=/home/pi/nmp.sh stop
 
 [Install]
 WantedBy=multi-user.target graphical.target
 ```
 
-Our `netmusicplayer` service is started up using the script `/home/pi/netmusicplayer.sh`. We can also pass the `stop` parameter to that same script to stop `netmusicplayer`. Because the network music player uses [`mpd`](https://www.musicpd.org/), we use the `Requires=` directive to specify that `mpd` must be running before `netmusicplayer` starts up.
+Our `netmusicplayer` service is started up using the script `/home/pi/nmp.sh`. We also pass the `stop` parameter to that same script to stop the network music player. Because the network music player uses [`mpd`](https://www.musicpd.org/), we use the `Requires=` directive to specify that `mpd` must be running before `netmusicplayer` starts up.
 
 ## Install a service
 To install a service, use the `systemctl enable` command as follows:

--- a/linux/usage/systemd.md
+++ b/linux/usage/systemd.md
@@ -62,8 +62,8 @@ WantedBy=multi-user.target graphical.target
 
 Our `netmusicplayer` service is started up using the script `/home/pi/nmp.sh`. The service also passes the `stop` parameter to that same script to stop the network music player. Because the network music player uses [`mpd`](https://www.musicpd.org/), we use the `Requires=` directive to specify that `mpd` must be running before `netmusicplayer` starts up.
 
-## Install a service
-To install a service, use the `systemctl enable` command as follows:
+## Enable and disable a service
+To enable a service, use the `systemctl enable` command as follows:
 
 ```
 sudo systemctl enable <service file>
@@ -75,7 +75,19 @@ For example:
 sudo systemctl enable /etc/systemd/user/netmusicplayer.service
 ```
 
-Once a service has been installed using `systemctl enable`, the system will run it the next time the system boots. To run the service immediately, start it using `systemctl start` - see the following section.
+Once a service has been enabled using `systemctl enable`, the system will run it the next time the system boots. To run the service immediately, start it using `systemctl start` - see the following section.
+
+To disable a service, use the `systemctl disable` command:
+
+```
+sudo systemctl disable <service name>
+```
+
+For example:
+
+```
+sudo systemctl disable netmusicplayer
+```
 
 ## Start and stop a service
 To start a service, use the `systemctl start` command:
@@ -89,6 +101,8 @@ For example:
 ```
 sudo systemctl start netmusicplayer
 ```
+
+Similarly, use the `systemctl 
 
 To stop a service, use the `systemctl stop` command:
 

--- a/linux/usage/systemd.md
+++ b/linux/usage/systemd.md
@@ -2,8 +2,8 @@
 
 Raspberry Pi OS uses [`systemd`](https://www.freedesktop.org/wiki/Software/systemd/) to manage the running of services, including controlling what starts when Linux boots.
 
-## `rc.local` under `systemd`
-Unlike on older versions of Linux, `systemd` starts services based on their dependencies: services are no longer started in a predefined order. This means it is no longer guaranteed that `rc.local` will run after all other services have started. You should therefore not use `rc.local` to start programs at boot.
+## `rc.local` and service dependencies
+Unlike on older versions of Linux, `systemd` starts services based on their dependencies: services are no longer started in a predefined order. This means it is no longer guaranteed that `rc.local` will run after all other services have started. You should therefore not use `rc.local` to start programs at boot: instead, create a `systemd` service, specifying which other services it depends on.
 
 ## Service definitions
 `Systemd` defines each service in a separate file. Under `systemd` services are a type of 'unit': units are system resources under the control of `systemd`. The basic format of a service definition is as follows:

--- a/linux/usage/systemd.md
+++ b/linux/usage/systemd.md
@@ -39,7 +39,7 @@ ExecStart=/home/pi/myprogram.sh
 WantedBy=multi-user.target graphical.target
 ```
 
-Let's say the above file is `/etc/systemd/user/myprogram.service`: this defines a new one-shot service named `myprogram`. The `myprogram` service will wait until `local-fs.target` and `network-online.target` have been reached, then run `/home/pi/myprogram.sh`.
+Let's say the above file is `/etc/systemd/user/myprogram.service`: this defines a new one-shot service named `myprogram`. The `myprogram` service will wait until `network-online.target` have been reached, then run `/home/pi/myprogram.sh`.
 
 ### Example - simple service
 A simple service runs continuously for as long as its dependencies are met. We define `/etc/systemd/user/netmusicplayer.service` as follows:

--- a/linux/usage/systemd.md
+++ b/linux/usage/systemd.md
@@ -6,7 +6,7 @@ Raspberry Pi OS uses [`systemd`](https://www.freedesktop.org/wiki/Software/syste
 Unlike on older versions of Linux, `systemd` starts services based on their dependencies: services are no longer started in a predefined order. This means it is no longer guaranteed that `rc.local` will run once all other services have started. You should therefore not use `rc.local` to start programs at boot.
 
 ## Service definitions
-`Systemd` defines each service in a separate file. Under `systemd` services are a type of 'unit'. Units are system resources under the control of `systemd`. The basic format of a service definition is as follows:
+`Systemd` defines each service in a separate file. Under `systemd` services are a type of 'unit': units are system resources under the control of `systemd`. The basic format of a service definition is as follows:
 
 ```
 [Unit]

--- a/linux/usage/systemd.md
+++ b/linux/usage/systemd.md
@@ -20,7 +20,7 @@ Description=...
 ...
 ```
 
-User services should be placed in `/etc/systemd/user`: the filename dictates the service name. For example, a file named `monitoring.service` would define the service named `monitoring`.
+User services should be placed in `/etc/systemd/user`: the filename dictates the service name. For example, a file named `monitoring.service` would define a service named `monitoring`.
 
 ### Example - one-time service
 One-time services are used when you wish to run a program which does some work, then exits: this is in contrast to a service which stays running all the time. Consider the following service definition:
@@ -75,7 +75,7 @@ For example:
 sudo systemctl enable /etc/systemd/user/netmusicplayer.service
 ```
 
-Once a service has been enabled using `systemctl enable`, the system will run it the next time the system boots. To run the service immediately, start it using `systemctl start` - see the following section.
+Once a service has been enabled, it will run the next time the system boots. To run the service immediately, start it using `systemctl start` - see the following section.
 
 To disable a service, use the `systemctl disable` command:
 
@@ -101,8 +101,6 @@ For example:
 ```
 sudo systemctl start netmusicplayer
 ```
-
-Similarly, use the `systemctl 
 
 To stop a service, use the `systemctl stop` command:
 


### PR DESCRIPTION
The `rc.local` file does not behave as it did under sysv init. In particular, it can no longer be guaranteed that all system services have started up before `rc.local` runs. This means if users insert code into `rc.local`, it may not work as they expect.

The solution is to leave `rc.local` undocumented, and point users to `systemd` instead. Also, fix up the `systemd` page so services a user create based on that page have the desired effect.