### PR TITLE
Update security.md to clarify that a warning by deluser is not a problem

### DIFF
--- a/configuration/security.md
+++ b/configuration/security.md
@@ -73,7 +73,7 @@ This command will delete the `pi` user but will leave the `/home/pi` folder. If 
 ```bash
 sudo deluser -remove-home pi
 ```
-This command will result in a warning that the group `pi` has now more members. This group is, however, removed along with the `pi` user itself by the deluser command, so that the warning can be ignored.
+This command will result in a warning that the group `pi` has no more members. This group is, however, removed along with the `pi` user itself by the deluser command, so that the warning can be ignored.
 
 
 ## Make `sudo` require a password

--- a/configuration/security.md
+++ b/configuration/security.md
@@ -73,6 +73,8 @@ This command will delete the `pi` user but will leave the `/home/pi` folder. If 
 ```bash
 sudo deluser -remove-home pi
 ```
+This command will result in a warning that the group `pi` has now more members. This group is, however, removed along with the `pi` user itself by the deluser command, so that the warning can be ignored.
+
 
 ## Make `sudo` require a password
 

--- a/configuration/security.md
+++ b/configuration/security.md
@@ -73,7 +73,7 @@ This command will delete the `pi` user but will leave the `/home/pi` folder. If 
 ```bash
 sudo deluser -remove-home pi
 ```
-This command will result in a warning that the group `pi` has no more members. This group is, however, removed along with the `pi` user itself by the deluser command, so that the warning can be ignored.
+This command will result in a warning that the group `pi` has no more members. The `deluser` command removes both the `pi` user and the `pi` group though, so the warning can be safely ignored.
 
 
 ## Make `sudo` require a password


### PR DESCRIPTION
I found the warning that the group `pi` has no more members a bit puzzling. It might be useful to clarify that this is not a problem.