### PR TITLE
Add a caveat when using CCache in a CI environment

### DIFF
--- a/linux/kernel/building.md
+++ b/linux/kernel/building.md
@@ -125,8 +125,8 @@ If you are using a 32-bit operating system (for example, our Raspberry Pi Deskto
 
 `sudo apt install zlib1g-dev:amd64`
 
-If you are using CCache and a CI environment, instruct CCache to not use the compiler's mtime for cache ID calculations.
-This is because Git intentionally doesn't save file timestamps, so each time you clone the toolchain its file mtimes are different, invalidating CCache's cache when default settings are used.
+If you are using Ccache and a CI environment, instruct Ccache to not use the compiler's mtime for cache ID calculations.
+This is because Git intentionally doesn't save file timestamps, so each time you clone the toolchain its file mtimes are different, invalidating Ccache's cache when default settings are used.
 
 `ccache --set-config=compiler_check=content`
 

--- a/linux/kernel/building.md
+++ b/linux/kernel/building.md
@@ -125,8 +125,8 @@ If you are using a 32-bit operating system (for example, our Raspberry Pi Deskto
 
 `sudo apt install zlib1g-dev:amd64`
 
-If you are using CCache and a CI environment, instruct it to not use compiler's mtime for cache ID calculations.
-This is because Git intentionally doesn't save file timestamps, so each time you clone the toolchain, its file mtimes are different, invalidating CCache's cache with default settings.
+If you are using CCache and a CI environment, instruct CCache to not use the compiler's mtime for cache ID calculations.
+This is because Git intentionally doesn't save file timestamps, so each time you clone the toolchain its file mtimes are different, invalidating CCache's cache when default settings are used.
 
 `ccache --set-config=compiler_check=content`
 

--- a/linux/kernel/building.md
+++ b/linux/kernel/building.md
@@ -125,6 +125,11 @@ If you are using a 32-bit operating system (for example, our Raspberry Pi Deskto
 
 `sudo apt install zlib1g-dev:amd64`
 
+If you are using CCache and a CI environment, instruct it to not use compiler's mtime for cache ID calculations.
+This is because Git intentionally doesn't save file timestamps, so each time you clone the toolchain, its file mtimes are different, invalidating CCache's cache with default settings.
+
+`ccache --set-config=compiler_check=content`
+
 ### Get sources
 
 To download the minimal source tree for the current branch, run:


### PR DESCRIPTION
Since the toolchain is `git clone`'d rather than extracted from a tarball, mtimes of its executables are different each time, invalidating CCache's cache if used in a CI environment.
See e.g. https://travis-ci.community/t/bad-cache-hit-rate-ccache/9400 for an example of this problem.