### PR TITLE
Update linux.md

### DIFF
--- a/installation/installing-images/linux.md
+++ b/installation/installing-images/linux.md
@@ -20,7 +20,7 @@
 - In a terminal window, write the image to the card with the command below, making sure you replace the input file `if=` argument with the path to your `.img` file, and the `/dev/sdX` in the output file `of=` argument with the correct device name. **This is very important, as you will lose all the data on the hard drive if you provide the wrong device name.** Make sure the device name is the name of the whole SD card as described above, not just a partition. For example: `sdd`, not `sdds1` or `sddp1`; `mmcblk0`, not `mmcblk0p1`.
 
     ```bash
-    dd bs=4M if=2020-02-13-raspios-buster.img of=/dev/sdX conv=fsync
+    dd bs=4M if=2020-02-13-raspios-buster.img of=/dev/sdX conv=fsync; sync
     ```
 
 - Please note that block size set to `4M` will work most of the time. If not,  try `1M`, although this will take considerably longer.
@@ -42,7 +42,7 @@ unzip -p 2020-02-13-raspios-buster.zip | sudo dd of=/dev/sdX bs=4M conv=fsync
 
 - To see the progress of the copy operation, you can run the dd command with the status option.
    ```
-    dd bs=4M if=2020-02-13-raspios-buster.img of=/dev/sdX status=progress conv=fsync
+    dd bs=4M if=2020-02-13-raspios-buster.img of=/dev/sdX status=progress conv=fsync; sync
    ```
 - If you are using an older version of `dd`, the status option may not be available. You may be able to use the `dcfldd` command instead, which will give a progress report showing how much has been written. Another method is to send a USR1 signal to `dd`, which will let it print status information. Find out the PID of `dd` by using `pgrep -l dd` or `ps a | grep dd`. Then use `kill -USR1 PID` to send the USR1 signal to `dd`.
 


### PR DESCRIPTION
Added sync as part of the dd write commands. Logically, sync should be executed at the end of the dd writes to the SD card. Organizationally, this page has the sync separated from the dd command by at least half a page, separated by a section on verification, and formatted as text, rather than as the essential command that it is.