### PR TITLE
Explicitly call-out Vendor Class identifier for PXE

### DIFF
--- a/hardware/raspberrypi/bootmodes/net.md
+++ b/hardware/raspberrypi/bootmodes/net.md
@@ -6,7 +6,7 @@ We also have a [tutorial about setting up a network boot system](net_tutorial.md
 To network boot, the boot ROM does the following:
 
 * Initialise on-board Ethernet device (Microchip LAN9500 or LAN7500)
-* Send DHCP request
+* Send DHCP request (with Vendor Class identifier DHCP option 60 set to 'PXEClient:Arch:00000:UNDI:002001')
 * Receive DHCP reply
 * (optional) Receive DHCP proxy reply
 * ARP to tftpboot server


### PR DESCRIPTION
Vendor Class identifier was buried in some tcpdump parsed output further down in the page. Explicitly calling it out up-top, in some environments this is used as an initial pass filter by the DHCP server to determine which set of responses / behavior to use when interacting with the PXE Client system.