### PR TITLE
docs: vcgencmd get_throttled: add hex values

### DIFF
--- a/raspbian/applications/vcgencmd.md
+++ b/raspbian/applications/vcgencmd.md
@@ -32,16 +32,16 @@ Displays the enabled and detected state of the official camera. 1 means yes, 0 m
 
 Returns the throttled state of the system. This is a bit pattern - a bit being set indicates the following meanings:
 
-| Bit | Meaning |
-|:---:|---------|
-| 0   | Under-voltage detected |
-| 1   | Arm frequency capped |
-| 2   | Currently throttled |
-| 3   | Soft temperature limit active |
-| 16  | Under-voltage has occurred |
-| 17  | Arm frequency capping has occurred |
-| 18  | Throttling has occurred |
-| 19  | Soft temperature limit has occurred |
+| Bit | Hex value | Meaning |
+|:---:|-----------|---------|
+| 0   | 1 | Under-voltage detected |
+| 1   | 2 | Arm frequency capped |
+| 2   | 4 | Currently throttled |
+| 3   | 8 | Soft temperature limit active |
+| 16  | 10000 | Under-voltage has occurred |
+| 17  | 20000 | Arm frequency capping has occurred |
+| 18  | 40000 | Throttling has occurred |
+| 19  | 80000 | Soft temperature limit has occurred |
 
 A value of zero indicates that none of the above conditions is true.
 

--- a/raspbian/applications/vcgencmd.md
+++ b/raspbian/applications/vcgencmd.md
@@ -58,6 +58,10 @@ Adding the bit numbers along the top we get:
 
 From this we can see that bits 18 and 16 are set, indicating that the Pi has previously been throttled due to under-voltage, but is not currently throttled for any reason.
 
+Alternately, the values can be derived using the hex values above, by successively subtracting the largest value:
+
+``0x50000 = 40000 + 10000``
+
 #### measure_temp
 
 Returns the temperature of the SoC as measured by the on-board temperature sensor.


### PR DESCRIPTION
since the 0th bit is actually value 1, I find it's easier to decompose get_throttled by pulling out the hex values rather than converting to binary. Hopefully this is instructive to others.