### PR TITLE
Indicate that RESTART (0xf) was added later

### DIFF
--- a/hardware/raspberrypi/bcm2711_bootloader_config.md
+++ b/hardware/raspberrypi/bcm2711_bootloader_config.md
@@ -81,7 +81,7 @@ The BOOT_ORDER property defines the sequence for the different boot modes. It is
 * 0x2 - NETWORK  
 * 0x3 - USB device boot [usbboot](https://github.com/raspberrypi/usbboot) - Compute Module only.
 * 0x4 - USB mass storage boot
-* 0xf - RESTART (loop) - start again with the first boot order field.
+* 0xf - RESTART (loop) - start again with the first boot order field (added in pieeprom-2020-06-15.bin).
 
 Default: 0x1  
 Version: pieeprom-2020-04-16.bin  


### PR DESCRIPTION
Bootloader pieeprom-2020-04-16 added the `BOOT_ORDER` setting but it didn't include the 0xf option. Using 0xf in that version will cause the following error:

Unknown boot mode 0xf 0x0

This option is present in the pieeprom-2020-06-15.bin, which is the same version that added the related setting `MAX_RESTARTS`.