### PR TITLE
Use distro cross-compilers in kernel build

### DIFF
--- a/linux/kernel/building.md
+++ b/linux/kernel/building.md
@@ -114,11 +114,6 @@ Use the following command to install the cross-arch compiler onto your machine:
 sudo apt install crossbuild-essential-armhf
 ```
 
-If you are using Ccache and a CI environment, instruct Ccache to not use the compiler's mtime for cache ID calculations.
-This is because Git intentionally doesn't save file timestamps, so each time you clone the toolchain its file mtimes are different, invalidating Ccache's cache when default settings are used.
-
-`ccache --set-config=compiler_check=content`
-
 ### Get sources
 
 To download the minimal source tree for the current branch, run:

--- a/linux/kernel/building.md
+++ b/linux/kernel/building.md
@@ -99,20 +99,13 @@ also a Debian distribution, it means many aspects are similar, such as the comma
 
 You can either do this using VirtualBox (or VMWare) on Windows, or install it directly onto your computer. For reference, you can follow instructions online [at Wikihow](http://www.wikihow.com/Install-Ubuntu-on-VirtualBox).
 
-### Install required dependencies
+### Install required dependencies and toolchain
 
 To build the sources for cross-compilation, make sure you have the dependencies needed on your machine by executing:
 ```bash
-sudo apt install git bc bison flex libssl-dev make libc6-dev libncurses5-dev
+sudo apt install git bc bison flex libssl-dev make libc6-dev libncurses5-dev crossbuild-essential-armhf
 ```
 If you find you need other things, please submit a pull request to change the documentation.
-
-### Install toolchain
-
-Use the following command to install the cross-arch compiler onto your machine:
-```bash
-sudo apt install crossbuild-essential-armhf
-```
 
 ### Get sources
 

--- a/linux/kernel/building.md
+++ b/linux/kernel/building.md
@@ -109,18 +109,11 @@ If you find you need other things, please submit a pull request to change the do
 
 ### Install toolchain
 
-Use the following command to download the toolchain to the home folder:
-
+Use the following command to install the cross-arch compiler onto your machine:
 ```bash
-git clone https://github.com/raspberrypi/tools ~/tools
+sudo apt install binutils-arm-linux-gnueabihf crossbuild-essential-armhf
 ```
 
-Updating the $PATH environment variable makes the system aware of file locations needed for cross-compilation. 
-
-```bash
-echo PATH=\$PATH:~/tools/arm-bcm2708/arm-linux-gnueabihf/bin >> ~/.bashrc
-source ~/.bashrc
-```
 If you are using a 32-bit operating system (for example, our Raspberry Pi Desktop for PC), then you may need to install an additional set of libraries:
 
 `sudo apt install zlib1g-dev:amd64`

--- a/linux/kernel/building.md
+++ b/linux/kernel/building.md
@@ -103,7 +103,7 @@ You can either do this using VirtualBox (or VMWare) on Windows, or install it di
 
 To build the sources for cross-compilation, make sure you have the dependencies needed on your machine by executing:
 ```bash
-sudo apt install git bc bison flex libssl-dev make libc6-dev libncurses5-dev
+sudo apt install git bc libssl-dev libncurses5-dev
 ```
 If you find you need other things, please submit a pull request to change the documentation.
 
@@ -111,7 +111,7 @@ If you find you need other things, please submit a pull request to change the do
 
 Use the following command to install the cross-arch compiler onto your machine:
 ```bash
-sudo apt install crossbuild-essential-armhf
+sudo apt install --install-recommends crossbuild-essential-armhf
 ```
 
 If you are using Ccache and a CI environment, instruct Ccache to not use the compiler's mtime for cache ID calculations.

--- a/linux/kernel/building.md
+++ b/linux/kernel/building.md
@@ -103,7 +103,7 @@ You can either do this using VirtualBox (or VMWare) on Windows, or install it di
 
 To build the sources for cross-compilation, make sure you have the dependencies needed on your machine by executing:
 ```bash
-sudo apt install git bc libssl-dev libncurses5-dev
+sudo apt install git bc bison flex libssl-dev make libc6-dev libncurses5-dev
 ```
 If you find you need other things, please submit a pull request to change the documentation.
 
@@ -111,7 +111,7 @@ If you find you need other things, please submit a pull request to change the do
 
 Use the following command to install the cross-arch compiler onto your machine:
 ```bash
-sudo apt install --install-recommends crossbuild-essential-armhf
+sudo apt install crossbuild-essential-armhf
 ```
 
 If you are using Ccache and a CI environment, instruct Ccache to not use the compiler's mtime for cache ID calculations.

--- a/linux/kernel/building.md
+++ b/linux/kernel/building.md
@@ -111,7 +111,7 @@ If you find you need other things, please submit a pull request to change the do
 
 Use the following command to install the cross-arch compiler onto your machine:
 ```bash
-sudo apt install binutils-arm-linux-gnueabihf crossbuild-essential-armhf
+sudo apt install crossbuild-essential-armhf
 ```
 
 If you are using a 32-bit operating system (for example, our Raspberry Pi Desktop for PC), then you may need to install an additional set of libraries:

--- a/linux/kernel/building.md
+++ b/linux/kernel/building.md
@@ -114,10 +114,6 @@ Use the following command to install the cross-arch compiler onto your machine:
 sudo apt install crossbuild-essential-armhf
 ```
 
-If you are using a 32-bit operating system (for example, our Raspberry Pi Desktop for PC), then you may need to install an additional set of libraries:
-
-`sudo apt install zlib1g-dev:amd64`
-
 If you are using Ccache and a CI environment, instruct Ccache to not use the compiler's mtime for cache ID calculations.
 This is because Git intentionally doesn't save file timestamps, so each time you clone the toolchain its file mtimes are different, invalidating Ccache's cache when default settings are used.
 


### PR DESCRIPTION
The compiler given in the [raspberrypi/tools](https://github.com/raspberrypi/tools/tree/master/arm-bcm2708/arm-rpi-4.9.3-linux-gnueabihf) are fairly old and all the supported versions of Ubuntu and Debian have either the supported version or newer of the compiler offered before.

This can be seen at [here for Ubuntu 16.04](https://packages.ubuntu.com/xenial/gcc-arm-linux-gnueabihf) and [here for Debian Stretch](https://packages.debian.org/stretch/gcc-arm-linux-gnueabihf). Both of which is the oldest supported versions of their respective distro.

While this is not essential, I think that this will help get users setup quicker as it already has the proper paths set.