### PR TITLE
GPIO permissions information

### DIFF
--- a/usage/gpio/README.md
+++ b/usage/gpio/README.md
@@ -62,3 +62,7 @@ It is possible to control GPIO pins using a number of programming languages and 
 - [GPIO with Processing3](https://processing.org/reference/libraries/io/GPIO.html)
 
 **Warning: while connecting up simple components to the GPIO pins is perfectly safe, it's important to be careful how you wire things up. LEDs should have resistors to limit the current passing through them. Do not use 5V for 3V3 components. Do not connect motors directly to the GPIO pins, instead use an [H-bridge circuit or a motor controller board](https://projects.raspberrypi.org/en/projects/physical-computing/16).**
+
+## Permissions
+
+In order to use the GPIO ports your user must be a member of the `gpio` group. The `pi` user is a member by default, other users need to be added manually.

--- a/usage/gpio/README.md
+++ b/usage/gpio/README.md
@@ -66,3 +66,7 @@ It is possible to control GPIO pins using a number of programming languages and 
 ## Permissions
 
 In order to use the GPIO ports your user must be a member of the `gpio` group. The `pi` user is a member by default, other users need to be added manually.
+
+```bash
+sudo usermod -a -G gpio <username>
+```


### PR DESCRIPTION
When adding a new user they will not be able to program gpio unless they are part of the `gpio` group.