### PR TITLE
RPi 2 default sdram_freq equals 450 MHz

### DIFF
--- a/configuration/config-txt/overclocking.md
+++ b/configuration/config-txt/overclocking.md
@@ -25,29 +25,29 @@ Overclocking and overvoltage will be disabled at runtime when the SoC reaches 85
 | over_voltage_sdram_p | SDRAM phy voltage adjustment. [-16,8] equates to [0.8V,1.4V] with 0.025V steps. |
 | force_turbo | Forces turbo mode frequencies even when the ARM cores are not busy. Enabling this may set the warranty bit if `over_voltage_*` is also set. |
 | initial_turbo | Enables turbo mode from boot for the given value in seconds, or until cpufreq sets a frequency. For more information [see here](https://www.raspberrypi.org/forums/viewtopic.php?f=29&t=6201&start=425#p180099). The maximum value is `60`. |
-| arm_freq_min | Minimum value of arm_freq used for dynamic frequency clocking. |
+| arm_freq_min | Minimum value of `arm_freq` used for dynamic frequency clocking. |
 | core_freq_min | Minimum value of `core_freq` used for dynamic frequency clocking. |
-| gpu_freq_min | Minimum value of `gpu_freq` used for dynamic frequency clocking.|
-| h264_freq_min | Minimum value of `h264_freq` used for dynamic frequency clocking.|
-| isp_freq_min | Minimum value of `isp_freq` used for dynamic frequency clocking.|
-| v3d_freq_min | Minimum value of `v3d_freq` used for dynamic frequency clocking.|
-| hevc_freq_min | Minimum value of `hevc_freq` used for dynamic frequency clocking.|
-| sdram_freq_min | Minimum value of `sdram_freq` used for dynamic frequency clocking.|
-| over_voltage_min | Minimum value of `over_voltage` used for dynamic frequency clocking.|
-| temp_limit | Overheat protection. This sets the clocks and voltages to default when the SoC reaches this value in Celsius. Values over 85 are clamped to 85.|
-| temp_soft_limit | **3A+/3B+ only**. CPU speed throttle control. This sets the temperature at which the CPU clock speed throttling system activates. At this temperature, the clock speed is reduced from 1400Mhz to 1200Mhz.  Defaults to `60`, can be raised to a maximum of `70`, but this may cause instability. |
+| gpu_freq_min | Minimum value of `gpu_freq` used for dynamic frequency clocking. |
+| h264_freq_min | Minimum value of `h264_freq` used for dynamic frequency clocking. |
+| isp_freq_min | Minimum value of `isp_freq` used for dynamic frequency clocking. |
+| v3d_freq_min | Minimum value of `v3d_freq` used for dynamic frequency clocking. |
+| hevc_freq_min | Minimum value of `hevc_freq` used for dynamic frequency clocking. |
+| sdram_freq_min | Minimum value of `sdram_freq` used for dynamic frequency clocking. |
+| over_voltage_min | Minimum value of `over_voltage` used for dynamic frequency clocking. |
+| temp_limit | Overheat protection. This sets the clocks and voltages to default when the SoC reaches this value in Celsius. Values over 85 are clamped to 85. |
+| temp_soft_limit | **3A+/3B+ only**. CPU speed throttle control. This sets the temperature at which the CPU clock speed throttling system activates. At this temperature, the clock speed is reduced from 1400MHz to 1200MHz.  Defaults to `60`, can be raised to a maximum of `70`, but this may cause instability. |
 
 This table gives the default values for the options on various Raspberry Pi Models, all frequencies are stated in MHz.
 
 | Option       | Pi 0/W | Pi1 | Pi2 | Pi3   | Pi3A+/Pi3B+ | Pi4  |
-| ---          | :---:    | :---: | :---: | :----:  | :-----: | :----: | 
+| ---          | :---:  | :---: | :---: | :----:  | :-----: | :----: |
 | arm_freq     | 1000   | 700 | 900 | 1200  | 1400  | 1500 |
 | core_freq    | 400    | 250 | 250 | 400   | 400   | 500/550/360 |
 | h264_freq    | 300    | 250 | 250 | 400   | 400   | 500/550/360 |
 | isp_freq     | 300    | 250 | 250 | 400   | 400   | 500/550/360 |
 | v3d_freq     | 300    | 250 | 250 | 400   | 400   | 500/550/360 |
 | hevc_freq    | N/A    | N/A | N/A | N/A   | N/A   | 500/550/360 |
-| sdram_freq   | 450    | 400 | 400 | 450   | 500   | 3200 |
+| sdram_freq   | 450    | 400 | 450 | 450   | 500   | 3200 |
 | arm_freq_min | 700    | 700 | 600 | 600   | 600   | 600  |
 | core_freq_min| 250    | 250 | 250 | 250   | 250   | 250/275 |
 | gpu_freq_min | 250    | 250 | 250 | 250   | 250   | 500  |
@@ -63,32 +63,32 @@ This table gives defaults for options that are the same across all models.
 | initial_turbo        | 0       |
 | overvoltage_min      | 0       |
 | temp_limit           | 85      |
-| over_voltage_sdram_c | 0 (1.2v) |
-| over_voltage_sdram_i | 0 (1.2v) |
-| over_voltage_sdram_p | 0 (1.2v) |
+| over_voltage_sdram_c | 0 (1.2V) |
+| over_voltage_sdram_i | 0 (1.2V) |
+| over_voltage_sdram_p | 0 (1.2V) |
 
-This table describes the overvoltage settings for the various Pi models. The firmware uses Adaptive Voltage Scaling (AVS) to determine the optimum voltage to set. Note that for each integer rise in over_voltage, the voltage will be 25mV higher.
+This table lists the default `over_voltage` settings for the various Pi models. The firmware uses Adaptive Voltage Scaling (AVS) to determine the optimum voltage to set. Note that for each integer rise in `over_voltage`, the voltage will be 25mV higher.
 
-| Version | Default overvoltage | Setting |
+| Model | Default | Resulting voltage |
 | --- | --- | --- |
-| Pi 1 | 1.2V | 0 |
-| Pi 2 | 1.2-1.3125V | 0 |
-| Pi 3 | 1.2-1.3125V | 0 |
-| Pi Zero | 1.35V | 6 |
+| Pi 1 | 0 | 1.2V |
+| Pi 2 | 0 | 1.2-1.3125V |
+| Pi 3 | 0 | 1.2-1.3125V |
+| Pi Zero | 6 | 1.35V |
 
 #### Specific to Pi 4B
 
 The `core_freq` of the Raspberry Pi 4 can change from the default if either `hdmi_enable_4kp60` or `enable_tvout` are used, due to relationship between internal clocks and the particular requirements of the requested display modes.
 
-|Display option | Frequency |
-|---------------|-----------|
-| Default        | 500 |     
+| Display option | Frequency |
+| -------------- | --------: |
+| Default        | 500 |
 | enable_tvout | 360 |
 | hdmi_enable_4kp60 | 550 |
 
 Changing `core_freq` in `config.txt` is not supported on the Pi 4, any change from the default will almost certainly cause a failure to boot.
 
-It is recommended when overclocking to use the individual frequency settings (`isp_freq`, `v3d_freq` etc) rather than `gpu_freq`, as since it attempts to set `core_freq` (which cannot be changed on the Pi 4), it is not likely to have the desired effect. 
+It is recommended when overclocking to use the individual frequency settings (`isp_freq`, `v3d_freq` etc) rather than `gpu_freq`, as since it attempts to set `core_freq` (which cannot be changed on the Pi 4), it is not likely to have the desired effect.
 
 ### force_turbo
 
@@ -108,7 +108,7 @@ On Pi 2/Pi 3, setting this flag will disable the GPU from moving into turbo mode
 
 The GPU core, CPU, SDRAM and GPU each have their own PLLs and can have unrelated frequencies. The h264, v3d and ISP blocks share a PLL. For more information [see here](https://www.raspberrypi.org/forums/viewtopic.php?f=29&t=6201&start=275#p168042).
 
-To view the Pi's current frequency, type: `cat /sys/devices/system/cpu/cpu0/cpufreq/scaling_cur_freq`. Divide the result by 1000 to find the value in MHz. Note that this frequency is the kernel *requested* frequency, and it is possible that any throttling (for example at high temperatures) may mean the CPU is actually running more slowly than reported. An instantaneous measurement of the actual ARM CPU frequency can be retrieved using the vcgencmd `vcgencmd measure_clock arm`. This is displayed in Hertz.
+To view the Pi's current frequency in KHz, type: `cat /sys/devices/system/cpu/cpu0/cpufreq/scaling_cur_freq`. Divide the result by 1000 to find the value in MHz. Note that this frequency is the kernel *requested* frequency, and it is possible that any throttling (for example at high temperatures) may mean the CPU is actually running more slowly than reported. An instantaneous measurement of the actual ARM CPU frequency can be retrieved using the vcgencmd `vcgencmd measure_clock arm`. This is displayed in Hertz.
 
 ## Monitoring core temperature
 
@@ -118,17 +118,17 @@ Whilst hitting the temperature limit is not harmful to the SoC, it will cause CP
 
 With firmware from 12th September 2016 or later, when the core temperature is between 80'C and 85'C, a warning icon showing a red half-filled thermometer will be displayed, and the ARM cores will be throttled back. If the temperature exceeds 85'C, an icon showing a fully-filled thermometer will be displayed, and both the ARM cores and the GPU will be throttled back.
 
-For the Raspberry Pi 3 Model B+, the PCB technology has been changed to provide better heat dissipation and increased thermal mass. In addition, a soft temperature limit has been introduced, with the goal of maximising the time for which a device can "sprint" before reaching the hard limit at 85°C. When the soft limit is reached, the clock speed is reduced from 1.4GHz to 1.2GHz, and the operating voltage is reduced slightly. This reduces the rate of temperature increase: we trade a short period at 1.4GHz for a longer period at 1.2GHz. By default, the soft limit is 60°C, and this can be changed via the temp_soft_limit setting in config.txt.
+For the Raspberry Pi 3 Model B+, the PCB technology has been changed to provide better heat dissipation and increased thermal mass. In addition, a soft temperature limit has been introduced, with the goal of maximising the time for which a device can "sprint" before reaching the hard limit at 85°C. When the soft limit is reached, the clock speed is reduced from 1.4GHz to 1.2GHz, and the operating voltage is reduced slightly. This reduces the rate of temperature increase: we trade a short period at 1.4GHz for a longer period at 1.2GHz. By default, the soft limit is 60°C, and this can be changed via the `temp_soft_limit` setting in config.txt.
 
 See the page on [warning icons](../warning-icons.md) for more details.
 
 ## Monitoring voltage
 
-It is essential to keep the supply voltage above 4.8V for reliable performance. Note that the voltage from some USB chargers/power supplies can fall as low as 4.2V. This is because they are usually designed to charge a 3.7V LiPo battery, not to supply 5V to a computer. 
+It is essential to keep the supply voltage above 4.8V for reliable performance. Note that the voltage from some USB chargers/power supplies can fall as low as 4.2V. This is because they are usually designed to charge a 3.7V LiPo battery, not to supply 5V to a computer.
 
 To monitor the Pi's PSU voltage, you will need to use a multimeter to measure between the VCC and GND pins on the GPIO. More information is available in [power](../../hardware/raspberrypi/power/README.md).
 
-If the voltage drops below 4.63v (+-5%), recent versions of the firmware will show a yellow lightning bolt symbol on the display to indicate a lack of power, and a message indicating the low voltage state will be added to the kernel log.
+If the voltage drops below 4.63V (+-5%), recent versions of the firmware will show a yellow lightning bolt symbol on the display to indicate a lack of power, and a message indicating the low voltage state will be added to the kernel log.
 
 See the page on [warning icons](../warning-icons.md) for more details.
 


### PR DESCRIPTION
Fix the default `sdram_freq` frequency in the table for RPi 2.

Consequently wrap `config.txt` settings into code quotes.

Fix some unit symbol capitalization: `[Hz]` `[V]`

In the `over_voltage` table, clarify which is the default integer value and the resulting voltage (range). Enhance the wording slightly.

_________________

I found out about the default `sdram_freq` by chance while testing a few other things. So take this part of the PR as both, contribution and verification 😉:
```
2020-10-14 12:19:27 root@micha:/var/log# vcgencmd get_config sdram_freq
sdram_freq=450
2020-10-14 12:38:38 root@micha:/var/log# uname -a
Linux micha 5.4.68-v7+ #1343 SMP Mon Sep 28 12:38:29 BST 2020 armv7l GNU/Linux
2020-10-14 12:38:43 root@micha:/var/log# cat /proc/device-tree/model
Raspberry Pi 2 Model B Rev 1.1
2020-10-14 12:38:57 root@micha:/var/log# grep sdram_freq /boot/config.txt
#sdram_freq=450
#sdram_freq_min=150
```
A reboot has been done, so no previous settings are loaded. Note that it is the BCM2709 model, just in case it matters.

I added the few little format and wording changes while reading through it, hope that's fine.