### PR TITLE
Update bcm2711_bootloader_config.md

### DIFF
--- a/hardware/raspberrypi/bcm2711_bootloader_config.md
+++ b/hardware/raspberrypi/bcm2711_bootloader_config.md
@@ -1,40 +1,15 @@
-# Pi 4 Bootloader Configuration
+# Raspberry Pi 4 Bootloader Configuration
 
-You can display the currently-active configuration using
-```
-vcgencmd bootloader_config
-```
+## Editing the configuration
+Before editing the bootloader configuration [update your system](../../raspbian/updating.md) to get the latest version of the `rpi-eeprom` package.
 
-To change these bootloader configuration items, you need to extract the configuration segment, make changes, re-insert it, then reprogram the EEPROM with the new bootloader. The Raspberry Pi will need to be rebooted for changes to take effect.
+To view the current EEPROM configuration:
+`rpi-eeprom-config`
 
-```
-# Copy the EEPROM image of interest from /lib/firmware/raspberrypi/bootloader/ to pieeprom.bin
-rpi-eeprom-config pieeprom.bin > bootconf.txt
+To edit it and apply the updates to latest EEPROM release:
+`sudo -E rpi-eeprom-config --edit`
 
-# Edit the configuration using a text editor e.g. nano bootconf.txt
-
-# Example change. If you have a UART cable then setting BOOT_UART=1 will help debug boot issues
-BOOT_UART=1
-
-# Save the new configuration and exit editor
-
-# Apply the configuration change to the EEPROM image file
-rpi-eeprom-config --out pieeprom-new.bin --config bootconf.txt pieeprom.bin
-```
-
-To update the bootloader EEPROM with the edited bootloader:
-
-```
-# Flash the bootloader EEPROM
-# Run 'rpi-eeprom-update -h' for more information
-sudo rpi-eeprom-update -d -f ./pieeprom-new.bin
-sudo reboot
-```
-
-### Subsequent Bootloader Updates
-
-If you update your bootloader via apt, then any configuration changes made using the process described here will be migrated to the updated bootloader.
-
+Please see the [boot EEPROM](booteeprom.md) page for more information about the EEPROM update process.
 
 ## Configuration Properties
 This section describes all the configuration items available in the bootloader. The syntax is the same as [config.txt](../../configuration/config-txt/) but the properties are specific to the bootloader. [Conditional filters](../../configuration/config-txt/conditional.md) are also supported except for EDID.
@@ -43,89 +18,92 @@ This section describes all the configuration items available in the bootloader. 
 
 If 1 then enable UART debug output on GPIO 14 and 15. Configure the receiving debug terminal at 115200bps, 8 bits, no parity bits, 1 stop bit.
 
-Default: 0  
+Default: `0`  
 Version: All  
 
 ### WAKE_ON_GPIO
 
 If 1 then 'sudo halt' will run in a lower power mode until either GPIO3 or GLOBAL_EN are shorted to ground.
 
-Default: 1 (0 in original version of bootloader 2019-05-10)  
+Default: `1` (`0` in original version of bootloader 2019-05-10)  
 Version: All  
 
 ### POWER_OFF_ON_HALT
 
 If 1 and WAKE_ON_GPIO=0 then switch off all PMIC outputs in halt. This is lowest possible power state for halt but may cause problems with some HATs because 5V will still be on. GLOBAL_EN must be shorted to ground to boot.
 
-Default: 0  
+Default: `0`  
 Version: 2019-07-15  
 
 ### BOOT_ORDER
 The BOOT_ORDER setting allows flexible configuration for the priority of different bootmodes. It is represented as 32bit unsigned integer where each nibble represents a bootmode. The bootmodes are attempted in lowest significant nibble to highest significant nibble order.
 
-E.g. 0x21 means try SD first followed by network boot then stop. Whereas 0x2 would mean try network boot and then stop without trying to boot from the SD card.
+E.g. `0x21` means try SD first followed by network boot then stop. Whereas 0x2 would mean try network boot and then stop without trying to boot from the SD card.
 
 The retry counters are reset when switching to the next boot mode.
 
-BOOT_ORDER fields  
+`BOOT_ORDER` fields  
 The BOOT_ORDER property defines the sequence for the different boot modes. It is read right to left and up to 8 digits may be defined.
 
-* 0x0 - NONE (stop with error pattern)
-* 0x1 - SD CARD
-* 0x2 - NETWORK
-* 0x3 - USB device boot - Reserved - Compute Module only.
-* 0x4 - USB mass storage boot (since 2020-09-03)
-* 0xf - RESTART (loop) - start again with the first boot order field. (since 2020-09-03)
+| Value | Mode      | Description                                                              |
+|-------|-----------|--------------------------------------------------------------------------|
+|  0x0  |  NONE     |  Stop and display error pattern                                          |
+|  0x1  |  SD CARD  |  SD card (or EMMC on Compute Module 4)                                   |
+|  0x2  |  NETWORK  |  Network boot                                                            |
+|  0x3  |  USB DEV  |  USB device boot - See [usbboot](https://github.com/raspberrypi/usbboot) |
+|  0x4  |  USB MSD  |  USB mass storage boot (since 2020-09-03)                                |
+|  0xf  |  RESTART  |  Start again with the first boot order field. (since 2020-09-03)         |
 
-Default: 0xf41 (0x1 in versions prior to 2020-09-03)  
+Default: `0xf41` (`0x1` in versions prior to 2020-09-03)  
 Version: 2020-04-16  
 
 * Boot mode `0x0` will retry the SD boot if the SD card detect pin indicates that the card has been inserted or replaced.
 * The default boot order is `0xf41` which means continuously try SD then USB mass storage.
+* USB device boot is intended for use with Compute Module 4 to load a debug image e.g. a Linux RAM disk. This should be the last boot option because it does not currently support timeouts or retries.
 
 ### MAX_RESTARTS
 If the RESTART (`0xf`) boot mode is encountered more than MAX_RESTARTS times then a watchdog reset is triggered. This isn't recommended for general use but may be useful for test or remote systems where a full reset is needed to resolve issues with hardware or network interfaces.
 
-Default: -1 (infinite)  
+Default: `-1` (infinite)  
 Version: 2020-09-03  
 
 ### SD_BOOT_MAX_RETRIES
 The number of times that SD boot will be retried after failure before moving to the next boot mode defined by `BOOT_ORDER`.  
 -1 means infinite retries.
 
-Default: 0  
+Default: `0`  
 Version: 2020-04-16  
 
 ### NET_BOOT_MAX_RETRIES
 The number of times that network boot will be retried after failure before moving to the next boot mode defined by `BOOT_ORDER`.  
 -1 means infinite retries.
 
-Default: 0  
+Default: `0`  
 Version: 2020-04-16  
 
 ### DHCP_TIMEOUT
 The timeout in milliseconds for the entire DHCP sequence before failing the current iteration.
 
-Minimum: 5000  
-Default: 45000  
+Minimum: `5000`  
+Default: `45000` 
 Version: 2020-04-16  
 
 ### DHCP_REQ_TIMEOUT
 The timeout in milliseconds before retrying DHCP DISCOVER or DHCP REQ.
 
-Minimum: 500  
-Default: 4000  
+Minimum: `500`  
+Default: `4000`  
 Version: 2020-04-16  
 
 ### TFTP_FILE_TIMEOUT
 The timeout in milliseconds for an individual file download via TFTP.
 
-Minimum: 5000  
-Default: 30000  
+Minimum: `5000`  
+Default: `30000`  
 Version: 2020-04-16  
 
 ### TFTP_IP
-Optional dotted decimal ip address (e.g. "192.168.1.99") for the TFTP server which overrides the server-ip from the DHCP request.  
+Optional dotted decimal ip address (e.g. `192.168.1.99`) for the TFTP server which overrides the server-ip from the DHCP request.  
 This may be useful on home networks because tftpd-hpa can be used instead of dnsmasq where broadband router is the DHCP server.
 
 Default: ""  
@@ -135,9 +113,11 @@ Version: 2020-04-16
 In order to support unique TFTP boot directories for each Pi the bootloader prefixes the filenames with a device specific directory. If neither start4.elf nor start.elf are found in the prefixed directory then the prefix is cleared.
 On earlier models the serial number is used as the prefix, however, on Pi 4 the MAC address is no longer generated from the serial number making it difficult to automatically create tftpboot directories on the server by inspecting DHCPDISCOVER packets. To support this the TFTP_PREFIX may be customized to either be the MAC address, a fixed value or the serial number (default).
 
-* 0 - Use the serial number e.g. "9ffefdef/"
-* 1 - Use the string specified by TFTP_PREFIX_STR
-* 2 - Use the MAC address e.g. "dc-a6-32-01-36-c2/"
+| Value | Description                                   |
+|-------|-----------------------------------------------|
+| 0     | Use the serial number e.g. `9ffefdef/`        |
+| 1     | Use the string specified by TFTP_PREFIX_STR   |
+| 2     | Use the MAC address e.g. `dc-a6-32-01-36-c2/` |
 
 Default: 0  
 Version: 2020-04-16  
@@ -152,7 +132,7 @@ Version: 2020-04-16
 ### PXE_OPTION43
 Overrides the PXE Option43 match string with a different string. It's normally better to apply customisations to the DHCP server than change the client behaviour but this option is provided in case that's not possible.
 
-Default: "Raspberry Pi Boot"  
+Default: `Raspberry Pi Boot`  
 Version: 2020-04-16  
 
 ### DHCP_OPTION97
@@ -162,40 +142,40 @@ This is intended to be unique but also provide structured information to the DHC
 
 Specify DHCP_OPTION97=0 to revert the the old behaviour or a non-zero hex-value to specify a custom 4-byte prefix.
 
-Default: 0x34695052  
+Default: `0x34695052`  
 Version: 2020-04-16  
 
 ### Static IP address configuration
 If TFTP_IP and the following options are set then DHCP is skipped and the static IP configuration is applied. If the TFTP server is on the same subnet as the client then GATEWAY may be omitted.
 
 #### CLIENT_IP
-The IP address of the client e.g. "192.168.0.32"
+The IP address of the client e.g. `192.168.0.32`
 
 Default: ""  
 Version: 2020-04-16  
 
 #### SUBNET
-The subnet address mask e.g. "255.255.255.0"
+The subnet address mask e.g. `255.255.255.0`
 
 Default: ""  
 Version: 2020-04-16  
 
 #### GATEWAY
-The gateway address to use if the TFTP server is on a differenet subnet e.g. "192.168.0.1"
+The gateway address to use if the TFTP server is on a differenet subnet e.g. `192.168.0.1`
 
 Default: ""  
 Version: 2020-04-16  
 
 #### MAC_ADDRESS
-Overrides the Ethernet MAC address with the given value. e.g. dc:a6:32:01:36:c2
+Overrides the Ethernet MAC address with the given value. e.g. `dc:a6:32:01:36:c2`
 
 Default: ""  
 Version: 2020-04-16  
 
 ### DISABLE_HDMI
-The [HDMI boot diagnostics](./boot_diagnostics.md) display is disabled if DISABLE_HDMI=1. Other non-zero values are reserved for future use.
+The [HDMI boot diagnostics](./boot_diagnostics.md) display is disabled if `DISABLE_HDMI=1`. Other non-zero values are reserved for future use.
 
-Default: 0  
+Default: `0`  
 Version: 2020-04-16  
 
 From version 2020-09-03 the `disable_splash` property in `config.txt` is no longer checked because the HDMI diagnostics screen is started before `config.txt` is read.
@@ -210,7 +190,7 @@ Notes:-
 * Before self-update can be used the bootloader must have already been updated to a version which supports self update. The recommended approach would be to use the Raspberry Pi Imager and a spare SD card to update to pieeprom-2020-09-03 then use self-update for subsequent updates.
 * For network boot make sure that the TFTP `boot` directory can be mounted via NFS and that `rpi-eeprom-update` can write to it.
 
-Default: 1 (0 in versions prior to 2020-09-03)  
+Default: `1` (`0` in versions prior to 2020-09-03)  
 Version: 2020-04-16  
 
 ### FREEZE_VERSION
@@ -218,7 +198,7 @@ Previously this property was only checked by the `rpi-eeprom-update` script. How
 
 **Custom EEPROM update scripts must also check this flag.**
 
-Default: 0  
+Default: `0`  
 Version: All  
 
 ### NETCONSOLE - advanced logging
@@ -260,31 +240,31 @@ This is intended to allow problematic (e.g. very slow to enumerate) devices to b
 The format is a comma-separated list of hexadecimal values with the VID as most significant nibble. Spaces are not allowed.
 E.g. `034700a0,a4231234`
 
-Default: “”  
+Default: ""  
 Version: 2020-09-03  
 
 ### USB_MSD_DISCOVER_TIMEOUT
 If no USB mass storage devices are found within this timeout then USB-MSD is stopped and the next boot mode is selected
 
-Default: 20000 (20 seconds)  
+Default: `20000` (20 seconds)  
 Version: 2020-09-03  
 
 ### USB_MSD_LUN_TIMEOUT
 How long to wait in milliseconds before advancing to the next LUN e.g. a multi-slot SD-CARD reader. This is still being tweaked but may help speed up boot if old/slow devices are connected as well as a fast USB-MSD device containing the OS.
 
-Default: 2000 (2 seconds)  
+Default: `2000` (2 seconds)  
 Version: 2020-09-03  
 
 ### USB_MSD_PWR_OFF_TIME
 During USB mass storage boot, power to the USB ports is switched off for a short time to ensure the correct operation of USB mass storage devices. Most devices work correctly using the default setting: change this only if you have problems booting from a particular device. Setting `USB_MSD_PWR_OFF_TIME=0` will prevent power to the USB ports being switched off during USB mass storage boot.
 
-Minimum: 250  
-Maximum: 5000  
-Default: 1000 (1 second)  
+Minimum: `250`  
+Maximum: `5000`  
+Default: `1000` (1 second)  
 Version: 2020-09-03  
 
 ### XHCI_DEBUG
-This property controls the verbosity of USB debug messages for mass storage boot mode. Enabling all of these messages generates a huge amount of log data which will slow down booting and may even cause boot to fail. For verbose logs it's best to use `NETCONSOLE`.
+This property is a bit field controls the verbosity of USB debug messages for mass storage boot mode. Enabling all of these messages generates a huge amount of log data which will slow down booting and may even cause boot to fail. For verbose logs it's best to use `NETCONSOLE`.
 
 | Value | Log                                       |
 |-------|-------------------------------------------|
@@ -296,16 +276,13 @@ This property controls the verbosity of USB debug messages for mass storage boot
 |  0x20 | All xHCI TRBs (VERY VERBOSE)              |
 |  0x40 | All xHCI events (VERY VERBOSE)            |
 
-To combine values, add them together.
-
-(`0x` means these numbers are in hexadecimal. If you're not sure how to add these up, simply type the sum into Google, e.g. `=0x2+0x4`).
-
+To combine values, add them together. For example: 
 ```
-# Example: Enable mass storage and USB descriptor logging
+# Enable mass storage and USB descriptor logging
 XHCI_DEBUG=0x3
 ```
 
-Default: 0x0 (no USB debug messages enabled)  
+Default: `0x0` (no USB debug messages enabled)  
 Version: 2020-09-03  
 
 ## config.txt - configuration properties
@@ -314,7 +291,7 @@ Experimental property for custom firmware (bare metal).
 
 Bit 0 (0x1) indicates that the .elf file is custom firmware. This disables any compatiblity checks (e.g. is USB MSD boot supported) and resets PCIe before starting the executable.
 
-Default: 0x0  
+Default: `0x0`  
 Version: 2020-09-03  
 
 ### uart_2ndstage
@@ -322,7 +299,7 @@ If set to 0x1 then enable debug logging to the UART. In newer firmware versions 
 
 The `BOOT_UART` property also enables bootloader UART logging but does not enable UART logging in `start.elf` unless `uart_2ndstage=1` is also set.
 
-Default: 0x0  
+Default: `0`    
 Version: 2020-09-03  
 
 ### eeprom_write_protect
@@ -336,13 +313,13 @@ See: [Winbond W25x40cl datasheet](https://www.winbond.com/resource-files/w25x40c
 * 0 - Clears write protect regions
 * -1 - Do nothing.
 
-Default: -1  
+Default: `-1`  
 Version: 2020-09-03  
 
 ### bootloader_update
 This option may be set to 0 to block self-update without requiring the EEPROM configuration to be updated. This is sometimes useful when updating multiple Pis via network boot because this option can be controlled per Raspberry Pi (e.g. via a serial number filter in config.txt).
 
-Default: 1 (0 in versions prior to 2020-09-03)  
+Default: `1` (`0` in versions prior to 2020-09-03)  
 Version: 2020-04-16  
 
 ## Advanced boot modes - Network / USB mass storage boot.


### PR DESCRIPTION
* Use backticks to format values which are likely to be copied and pasted to avoid people copying the double quotes as well
* Simplify the editing section at the start to remove information duplicated on the booteeprom page. Just present the simple '--edit' option
* Tablify some enums and link to usbboot repo for CM4