### PR TITLE
Update README.md

### DIFF
--- a/hardware/raspberrypi/spi/README.md
+++ b/hardware/raspberrypi/spi/README.md
@@ -160,7 +160,7 @@ Setup and Hold times related to the automatic assertion and de-assertion of the 
 
 The default Linux driver is now the standard spi-bcm2835.
 
-SPI0 is disabled by default. To enable it, use [raspi-config](../../../configuration/raspi-config.md), or ensure the line `dtparam=spi=on` isn't commented out in `/boot/config.txt`. By default it uses 2 chip select lines, but this can be reduced to 1 using `dtoverlay=spi0-1cs`. `dtoverlay=spi0-2cs` also exists, and without any parameters it is equivalent to `dtparam=spi=on`.
+SPI0 is disabled by default. To enable it, use [raspi-config](../../../configuration/raspi-config.md), or ensure the line `dtparam=spi=on` isn't commented out in `/boot/config.txt`. By default it uses 2 chip select lines.
 
 To enable SPI1, you can use 1, 2 or 3 chip select lines, adding in each case:
 <pre>


### PR DESCRIPTION
There is no overlay spi0-1cs or spi0-2cs (anymore?). On all systems I checked, dtoverlay -a only lists spi0-cs and spi0-hw-cs.

For spi1 and higher the spi<n>-1cs and similar are listed