### PR TITLE
Hardware index page: clarify display product

### DIFF
--- a/hardware/README.md
+++ b/hardware/README.md
@@ -10,6 +10,6 @@ Technical information about Raspberry Pi hardware, including official add-ons an
 - [General HAT information](https://github.com/raspberrypi/hats/blob/master/README.md) (Links to our HAT github repository)
 - [Sense HAT](sense-hat/README.md)
 - [TV HAT](tv-hat/README.md)
-- [Display](display/README.md)
+- [Touch Display](display/README.md)
 - [Mouse and Keyboard](keyboard_mouse/README.md)
 - [Industrial use](industrial/README.md)


### PR DESCRIPTION
The official name of the product is Raspberry Pi Touch Display. Since other products don't specify `Raspberry Pi` on this index page, list the product as `Touch Display`. (Currently says `Display`).