### PR TITLE
Add note about changing the hostapd hw_mode

### DIFF
--- a/configuration/wireless/access-point-bridged.md
+++ b/configuration/wireless/access-point-bridged.md
@@ -7,24 +7,24 @@ If you wish to create a standalone wireless network, consider instead setting up
 
 ```
                                          +- RPi -------+
-                                     +---+ Bridge      |
-                                     |   | WLAN AP     +-)))
-                                     |   | 192.168.1.2 |         +- Laptop ----+
-                                     |   +-------------+     (((-+ WLAN Client |
-                 +- Router ----+     |                           | 192.168.1.5 |
-                 | Firewall    |     |   +- PC#2 ------+         +-------------+
-(Internet)---WAN-+ DHCP server +-LAN-+---+ 192.168.1.3 |
-                 | 192.168.1.1 |     |   +-------------+
+                                     +---+ 10.10.0.2   |          +- Laptop ----+
+                                     |   |     WLAN AP +-)))  (((-+ WLAN Client |
+                                     |   |  Bridge     |          | 10.10.0.5   |
+                                     |   +-------------+          +-------------+
+                 +- Router ----+     |
+                 | Firewall    |     |   +- PC#2 ------+
+(Internet)---WAN-+ DHCP server +-LAN-+---+ 10.10.0.3   |
+                 |   10.10.0.1 |     |   +-------------+
                  +-------------+     |
                                      |   +- PC#1 ------+
-                                     +---+ 192.168.1.4 |
+                                     +---+ 10.10.0.4   |
                                          +-------------+
 ```
 
-A bridged wireless access point can be created using the inbuilt wireless features of the Raspberry Pi 4, Raspberry Pi 3B, Raspberry Pi 3A+/3B+ or Raspberry Pi Zero W/WH, or by using a suitable USB wireless dongle that supports access point mode.
+A bridged wireless access point can be created using the inbuilt wireless features of the Raspberry Pi 4, Raspberry Pi 3 or Raspberry Pi Zero W, or by using a suitable USB wireless dongle that supports access point mode.
 It is possible that some USB dongles may need slight changes to their settings. If you are having trouble with a USB wireless dongle, please check the [forums](https://www.raspberrypi.org/forums/).
 
-This documentation was tested on a Raspberry Pi 3B running a fresh installation of Raspberry Pi OS Buster. 
+This documentation was tested on a Raspberry Pi 3B running a fresh installation of Raspberry Pi OS Buster.
 
 <a name="intro"></a>
 ## Before you start
@@ -33,7 +33,7 @@ This documentation was tested on a Raspberry Pi 3B running a fresh installation 
 
   **Note:** If installing remotely via SSH,
     * Connect to your Raspberry Pi **by name**, e.g. `ssh pi@raspberrypi.local`. The IP address of your Raspberry Pi on the network **will probably change** after installation.
-    * Be ready to add screen and keyboard in case you lose contact with your Raspberry Pi after installation. 
+    * Be ready to add screen and keyboard in case you lose contact with your Raspberry Pi after installation.
 * Connect your Raspberry Pi to the Ethernet network and boot the Raspberry Pi OS.
 * Ensure the Raspberry Pi OS on your Raspberry Pi is [up-to-date](../../raspbian/updating.md) and reboot if packages were installed in the process.
 * Have a wireless client (laptop, smartphone, ...) ready to test your new access point.
@@ -139,7 +139,7 @@ This setting will be automatically restored at boot time. We will define an appr
 <a name="ap-config"></a>
 ## Configure the access point software
 
-Create the `hostapd` configuration file, located at `/etc/hostapd/hostapd.conf`, to add the various parameters for your new wireless network. 
+Create the `hostapd` configuration file, located at `/etc/hostapd/hostapd.conf`, to add the various parameters for your new wireless network.
 
 ```
 sudo nano /etc/hostapd/hostapd.conf
@@ -171,7 +171,9 @@ To use the 5 GHz band, you can change the operations mode from `hw_mode=g` to `h
  - a = IEEE 802.11a (5 GHz) (Raspberry Pi 3B+ onwards)
  - b = IEEE 802.11b (2.4 GHz)
  - g = IEEE 802.11g (2.4 GHz)
- 
+
+Note that when changing the `hw_mode`, you may need to also change the `channel` - see [Wikipedia](https://en.wikipedia.org/wiki/List_of_WLAN_channels) for a list of allowed combinations.
+
 <a name="conclusion"></a>
 ## Run your new wireless access point
 

--- a/configuration/wireless/access-point-routed.md
+++ b/configuration/wireless/access-point-routed.md
@@ -22,7 +22,7 @@ If you wish to extend an existing Ethernet network to wireless clients, consider
 A routed wireless access point can be created using the inbuilt wireless features of the Raspberry Pi 4, Raspberry Pi 3 or Raspberry Pi Zero W, or by using a suitable USB wireless dongle that supports access point mode.
 It is possible that some USB dongles may need slight changes to their settings. If you are having trouble with a USB wireless dongle, please check the [forums](https://www.raspberrypi.org/forums/).
 
-This documentation was tested on a Raspberry Pi 3B running a fresh installation of Raspberry Pi OS Buster. 
+This documentation was tested on a Raspberry Pi 3B running a fresh installation of Raspberry Pi OS Buster.
 
 <a name="intro"></a>
 ## Before you start
@@ -30,9 +30,10 @@ This documentation was tested on a Raspberry Pi 3B running a fresh installation 
 * Ensure you have administrative access to your Raspberry Pi. The network setup will be modified as part of the installation: local access, with screen and keyboard connected to your Raspberry Pi, is recommended.
 * Connect your Raspberry Pi to the Ethernet network and boot the Raspberry Pi OS.
 * Ensure the Raspberry Pi OS on your Raspberry Pi is [up to date](../../raspbian/updating.md) and reboot if packages were installed in the process.
-* Take note of the IP configuration of the Ethernet network the Raspberry Pi is connected to: 
+* Take note of the IP configuration of the Ethernet network the Raspberry Pi is connected to:
     * In this document, we assume IP network `10.10.0.0/24` is configured on the Ethernet LAN, and the Raspberry Pi is going to manage IP network `192.168.4.0/24` for wireless clients.
     * Please select another IP network for wireless, e.g. `192.168.10.0/24`, if IP network `192.168.4.0/24` is already in use by your Ethernet LAN.
+* Ensure the Raspberry Pi OS on your Raspberry Pi is [up-to-date](../../raspbian/updating.md) and reboot if packages were installed in the process.
 * Have a wireless client (laptop, smartphone, ...) ready to test your new access point.
 
 <a name="software-install"></a>
@@ -65,11 +66,11 @@ Software installation is complete. We will configure the software packages later
 <a name="routing"></a>
 ## Set up the network router
 
-The Raspberry Pi will run and manage a standalone wireless network. It will also route between the wireless and Ethernet networks, providing internet access to wireless clients. If you prefer, you can choose to skip the routing by skipping the section "Enable routing and IP masquerading" below, and run the wireless network in complete isolation. 
+The Raspberry Pi will run and manage a standalone wireless network. It will also route between the wireless and Ethernet networks, providing internet access to wireless clients. If you prefer, you can choose to skip the routing by skipping the section "Enable routing and IP masquerading" below, and run the wireless network in complete isolation.
 
 ### Define the wireless interface IP configuration
 
-The Raspberry Pi runs a DHCP server for the wireless network; this requires static IP configuration for the wireless interface (`wlan0`) in the Raspberry Pi. 
+The Raspberry Pi runs a DHCP server for the wireless network; this requires static IP configuration for the wireless interface (`wlan0`) in the Raspberry Pi.
 The Raspberry Pi also acts as the router on the wireless network, and as is customary, we will give it the first IP address in the network: `192.168.4.1`.
 
 To configure the static IP address, edit the configuration file for `dhcpcd` with:
@@ -89,7 +90,7 @@ interface wlan0
 ### Enable routing and IP masquerading
 
 This section configures the Raspberry Pi to let wireless clients access computers on the main (Ethernet) network, and from there the internet.
-**NOTE:** If you wish to block wireless clients from accessing the Ethernet network and the internet, skip this section. 
+**NOTE:** If you wish to block wireless clients from accessing the Ethernet network and the internet, skip this section.
 
 To enable routing, i.e. to allow traffic to flow from one network to the other in the Raspberry Pi, create a file using the following command, with the contents below:
 ```
@@ -118,7 +119,7 @@ Filtering rules are saved to the directory `/etc/iptables/`. If in the future yo
 
 ### Configure the DHCP and DNS services for the wireless network
 
-The DHCP and DNS services are provided by `dnsmasq`. The default configuration file serves as a template for all possible configuration options, whereas we only need a few. It is easier to start from an empty file. 
+The DHCP and DNS services are provided by `dnsmasq`. The default configuration file serves as a template for all possible configuration options, whereas we only need a few. It is easier to start from an empty file.
 
 Rename the default configuration file and edit a new one:
 
@@ -144,7 +145,8 @@ There are many more options for `dnsmasq`; see the default configuration file (`
 <a name="wifi-cc-rfkill"></a>
 ## Ensure wireless operation
 
-Countries around the world regulate the use of telecommunication radio frequency bands to ensure interference-free operation. The Linux OS helps users [comply](https://wireless.wiki.kernel.org/en/developers/regulatory/statement) with these rules by allowing applications to be configured with a two-letter "WiFi country code", e.g. `US` for a computer used in the United States.
+Countries around the world regulate the use of telecommunication radio frequency bands to ensure interference-free operation.
+The Linux OS helps users [comply](https://wireless.wiki.kernel.org/en/developers/regulatory/statement) with these rules by allowing applications to be configured with a two-letter "WiFi country code", e.g. `US` for a computer used in the United States.
 
 In the Raspberry Pi OS, 5 GHz wireless networking is disabled until a WiFi country code has been configured by the user, usually as part of the initial installation process (see wireless configuration pages in this [section](README.md) for details.)
 
@@ -159,7 +161,7 @@ This setting will be automatically restored at boot time. We will define an appr
 <a name="ap-config"></a>
 ## Configure the access point software
 
-Create the `hostapd` configuration file, located at `/etc/hostapd/hostapd.conf`, to add the various parameters for your wireless network. 
+Create the `hostapd` configuration file, located at `/etc/hostapd/hostapd.conf`, to add the various parameters for your new wireless network.
 
 ```
 sudo nano /etc/hostapd/hostapd.conf
@@ -186,10 +188,9 @@ rsn_pairwise=CCMP
 Note the line `country_code=GB`: it configures the computer to use the correct wireless frequencies in the United Kingdom. **Adapt this line** and specify the two-letter ISO code of your country. See [Wikipedia](https://en.wikipedia.org/wiki/ISO_3166-1) for a list of two-letter ISO 3166-1 country codes.
 
 To use the 5 GHz band, you can change the operations mode from `hw_mode=g` to `hw_mode=a`. Possible values for `hw_mode` are:
- - a = IEEE 802.11a (5 GHz)
+ - a = IEEE 802.11a (5 GHz) (Raspberry Pi 3B+ onwards)
  - b = IEEE 802.11b (2.4 GHz)
  - g = IEEE 802.11g (2.4 GHz)
- - ad = IEEE 802.11ad (60 GHz)
 
 Note that when changing the `hw_mode`, you may need to also change the `channel` - see [Wikipedia](https://en.wikipedia.org/wiki/List_of_WLAN_channels) for a list of allowed combinations.
 
@@ -205,6 +206,6 @@ Once your Raspberry Pi has restarted, search for wireless networks with your wir
 
 If SSH is enabled on the Raspberry Pi, it should be possible to connect to it from your wireless client as follows, assuming the `pi` account is present: `ssh pi@192.168.4.1` or `ssh pi@gw.wlan`
 
-If your wireless client has access to your Raspberry Pi (and the internet), congratulations on your new access point!
+If your wireless client has access to your Raspberry Pi (and the internet, if you set up routing), congratulations on setting up your new access point!
 
 If you encounter difficulties, contact the [forums](https://www.raspberrypi.org/forums/) for assistance. Please refer to this page in your message.

--- a/configuration/wireless/access-point-routed.md
+++ b/configuration/wireless/access-point-routed.md
@@ -29,11 +29,10 @@ This documentation was tested on a Raspberry Pi 3B running a fresh installation 
 
 * Ensure you have administrative access to your Raspberry Pi. The network setup will be modified as part of the installation: local access, with screen and keyboard connected to your Raspberry Pi, is recommended.
 * Connect your Raspberry Pi to the Ethernet network and boot the Raspberry Pi OS.
-* Ensure the Raspberry Pi OS on your Raspberry Pi is [up to date](../../raspbian/updating.md) and reboot if packages were installed in the process.
+* Ensure the Raspberry Pi OS on your Raspberry Pi is [up-to-date](../../raspbian/updating.md) and reboot if packages were installed in the process.
 * Take note of the IP configuration of the Ethernet network the Raspberry Pi is connected to:
     * In this document, we assume IP network `10.10.0.0/24` is configured on the Ethernet LAN, and the Raspberry Pi is going to manage IP network `192.168.4.0/24` for wireless clients.
     * Please select another IP network for wireless, e.g. `192.168.10.0/24`, if IP network `192.168.4.0/24` is already in use by your Ethernet LAN.
-* Ensure the Raspberry Pi OS on your Raspberry Pi is [up-to-date](../../raspbian/updating.md) and reboot if packages were installed in the process.
 * Have a wireless client (laptop, smartphone, ...) ready to test your new access point.
 
 <a name="software-install"></a>

--- a/configuration/wireless/access-point-routed.md
+++ b/configuration/wireless/access-point-routed.md
@@ -190,8 +190,10 @@ To use the 5 GHz band, you can change the operations mode from `hw_mode=g` to `h
  - b = IEEE 802.11b (2.4 GHz)
  - g = IEEE 802.11g (2.4 GHz)
  - ad = IEEE 802.11ad (60 GHz)
-<a name="conclusion"></a>
 
+Note that when changing the `hw_mode`, you may need to also change the `channel` - see [Wikipedia](https://en.wikipedia.org/wiki/List_of_WLAN_channels) for a list of allowed combinations.
+
+<a name="conclusion"></a>
 ## Run your new wireless access point
 
 Now restart your Raspberry Pi and verify that the wireless access point becomes automatically available.


### PR DESCRIPTION
If I left `channel` set to `7` when changing the `hw_mode` to `a`, hostapd wouldn't start and reported an error about an invalid channel selection. (it later worked when I changed the channel to 36)

However I dunno much about wireless networks, and even less about access points, so pinging @epoch1970 for confirmation.