### PR TITLE
Update bcm2711_bootloader_config.md

### DIFF
--- a/hardware/raspberrypi/bcm2711_bootloader_config.md
+++ b/hardware/raspberrypi/bcm2711_bootloader_config.md
@@ -48,7 +48,7 @@ The BOOT_ORDER property defines the sequence for the different boot modes. It is
 |-------|-----------|---------------------------------------------------------------------------------------------------|
 |  0x1  |  SD CARD  |  SD card (or eMMC on Compute Module 4)                                                            |
 |  0x2  |  NETWORK  |  Network boot                                                                                     |
-|  0x3  |  USB DEV  |  USB device boot - See [usbboot](https://github.com/raspberrypi/usbboot)  (since 2020-09-03)      |
+|  0x3  |  RPIBOOT  |  RPIBOOT -  See [usbboot](https://github.com/raspberrypi/usbboot)  (since 2020-09-03)             |
 |  0x4  |  USB MSD  |  USB mass storage boot (since 2020-09-03)                                                         |
 |  0xe  |  STOP     |  Stop and display error pattern (since 2020-09-03). A power cycle is required to exit this state. |
 |  0xf  |  RESTART  |  Start again with the first boot order field. (since 2020-09-03)                                  |


### PR DESCRIPTION
Rename USB-DEV to RPIBOOT because that's the name of the protocol, even if the repo is called usbboot