### PR TITLE
Additional / better example for supplicant file.

### DIFF
--- a/configuration/wireless/headless.md
+++ b/configuration/wireless/headless.md
@@ -20,7 +20,26 @@ network={
 }
 ```
 
-Note that some older wireless dongles don't support 5GHz networks.
+Here is a more elaborate example that should work for most typical wpa2 personal networks. This template below works for 2.4ghz/5ghz hidden or not networks. The utilization of quotes around the ssid - psk can help avoid any oddities if your network ssid or password has special chars (! @ # $ etc)
+
+```ctrl_interface=DIR=/var/run/wpa_supplicant GROUP=netdev
+update_config=1
+country=<Insert 2 letter ISO 3166-1 country code here>
+
+
+
+network={
+        scan_ssid=1
+        ssid="<Name of your wireless LAN>"
+        psk="<Password for your wireless LAN>"
+        proto=RSN
+        key_mgmt=WPA-PSK
+        pairwise=CCMP
+        auth_alg=OPEN
+}
+```
+
+Note that some older pi's (zerow or 3b) or usb wireless dongles don't support 5GHz networks.
 
 More information on the `wpa_supplicant.conf` file can be found [here](wireless-cli.md). See [Wikipedia](https://en.wikipedia.org/wiki/ISO_3166-1) for a list of 2 letter ISO 3166-1 country codes.
 


### PR DESCRIPTION
Just an edit of the headless setup to provide a more elaborate - working wpa_supplicant.conf file for most typical consumer wpa2 personal networks hidden ssid or not. 

This config has been proven and tested to work personally and has always been referred to in our discord community with thousands of users who love Raspberry Pi when the basic template provided on the site doesn't cut it or work for those not willing to learn proper usage of wpa_supplicant.conf entries.

If this change - edit is not acceptable I do apologize. I appreciate the hard work the foundation has done and thank you for your time - consideration viewing this (perhaps slightly niched) request. 

More often than not I'm linked the headless guide in our server and told the light example for them doesn't work because they haven't bothered to read further into wpa_supplicant. I figured at least providing a more concise example or secondary example like mine would hopefully remedy this.





Happy holidays - new years otherwise. Stay healthy - safe all!.