### PR TITLE
Installation: deprecate NOOBS, tweak page links

### DIFF
--- a/installation/README.md
+++ b/installation/README.md
@@ -4,7 +4,6 @@ We recommend using [Raspberry Pi Imager](https://www.raspberrypi.org/software/) 
 
 * You can find detailed help with installing OS images [here](installing-images/). For further assistance, check out our [forums](https://www.raspberrypi.org/forums/).
 
-* [Further information about SD cards](sd-cards.md)
+* [Further information about SD cards](sd-cards.md).
 
-
-**Note:** [NOOBS](noobs.md) is still available, but is no longer recommended for new installations.
+* [NOOBS](noobs.md) is still available, but is no longer recommended for new installations.

--- a/installation/README.md
+++ b/installation/README.md
@@ -1,6 +1,6 @@
 # Installation
 
-We recommend using [Raspberry Pi Imager](https://www.raspberrypi.org/software/) to install an operating system on your Raspberry Pi. As well as Raspberry Pi OS, you can use it to install other operating systems such as Ubuntu, and LibreELEC (Kodi media centre).
+We recommend using [Raspberry Pi Imager](https://www.raspberrypi.org/software/) to install an operating system on your Raspberry Pi. As well as Raspberry Pi OS, you can use it to install other operating systems such as Ubuntu or LibreELEC (Kodi media centre).
 
 * You can find detailed help with installing OS images [here](installing-images/). For further assistance, check out our [forums](https://www.raspberrypi.org/forums/).
 

--- a/installation/README.md
+++ b/installation/README.md
@@ -6,4 +6,5 @@ We recommend using [Raspberry Pi Imager](https://www.raspberrypi.org/software/) 
 
 * [Further information about SD cards](sd-cards.md)
 
-[NOOBS](noobs.md) is still available, but is no longer recommended for new installations.
+
+*Note:* [NOOBS](noobs.md) is still available, but is no longer recommended for new installations.

--- a/installation/README.md
+++ b/installation/README.md
@@ -7,4 +7,4 @@ We recommend using [Raspberry Pi Imager](https://www.raspberrypi.org/software/) 
 * [Further information about SD cards](sd-cards.md)
 
 
-*Note:* [NOOBS](noobs.md) is still available, but is no longer recommended for new installations.
+**Note:** [NOOBS](noobs.md) is still available, but is no longer recommended for new installations.

--- a/installation/README.md
+++ b/installation/README.md
@@ -6,4 +6,4 @@ We recommend using [Raspberry Pi Imager](https://www.raspberrypi.org/software/) 
 
 * [Further information about SD cards](sd-cards.md).
 
-* [NOOBS](noobs.md) is still available, but is no longer recommended for new installations.
+* [NOOBS](noobs.md)

--- a/installation/README.md
+++ b/installation/README.md
@@ -1,11 +1,9 @@
 # Installation
 
-Some simple guides to setting up the software on your Raspberry Pi.
+We recommend using [Raspberry Pi Imager](https://www.raspberrypi.org/software/) to install an operating system on your Raspberry Pi. As well as Raspberry Pi OS, you can use it to install other operating systems such as Ubuntu, and LibreELEC (Kodi media centre).
 
-Beginners should start with [NOOBS](noobs.md), which gives the user a choice of operating system from the standard distributions. The recommended distribution for normal use is Raspberry Pi OS. Alternatives are available, such as LibreELEC (Kodi media centre) or Arch Linux.
+* You can find detailed help with installing OS images [here](installing-images/). For further assistance, check out our [forums](https://www.raspberrypi.org/forums/).
 
-## Contents
+* [Further information about SD cards](sdcards.md)
 
-- [NOOBS](noobs.md)
-- [Installing images](installing-images/README.md)
-- [SD Cards](sd-cards.md)
+[NOOBS](noobs.md) is still available, but is no longer recommended for new installations.

--- a/installation/README.md
+++ b/installation/README.md
@@ -4,6 +4,6 @@ We recommend using [Raspberry Pi Imager](https://www.raspberrypi.org/software/) 
 
 * You can find detailed help with installing OS images [here](installing-images/). For further assistance, check out our [forums](https://www.raspberrypi.org/forums/).
 
-* [Further information about SD cards](sdcards.md)
+* [Further information about SD cards](sd-cards.md)
 
 [NOOBS](noobs.md) is still available, but is no longer recommended for new installations.

--- a/installation/noobs.md
+++ b/installation/noobs.md
@@ -1,6 +1,6 @@
 # NOOBS
 
-**Note:** We now recommend that you use [Raspberry Pi Imager](https://www.raspberrypi.org/software/) to install an operating system, instead of using NOOBS. If you are buying an SD card with software pre-installed on it, then we do still recommend buying one with NOOBS on it.
+**Note: We now recommend that you use [Raspberry Pi Imager](https://www.raspberrypi.org/software/) to install an operating system, instead of using NOOBS. If you are buying an SD card with software pre-installed on it, then we do still recommend buying one with NOOBS on it.**
 
 **New Out Of Box Software (NOOBS)** is an operating system installation manager for the Raspberry Pi.
 

--- a/installation/noobs.md
+++ b/installation/noobs.md
@@ -14,7 +14,7 @@ SD cards with NOOBS pre-installed are available from many of our distributors an
 
 ## What's included in NOOBS
 
-NOOBS includes Raspberry Pi OS. It can also be used to install other operating systems: this requires that the Pi has a working internet connection to download the OS.
+NOOBS includes Raspberry Pi OS, and LibreELEC which is a Kodi media player system. It can also be used to install other operating systems: this requires that the Pi has a working internet connection to download the OS.
 
 ## NOOBS development
 

--- a/installation/noobs.md
+++ b/installation/noobs.md
@@ -1,6 +1,8 @@
 # NOOBS
 
-**New Out Of Box Software (NOOBS)** is an easy operating system installation manager for the Raspberry Pi.
+**Note:** We now recommend that you use [Raspberry Pi Imager](https://www.raspberrypi.org/software/) to install an operating system, instead of using NOOBS. If you are buying an SD card with software pre-installed on it, then we do still recommend buying one with NOOBS on it.
+
+**New Out Of Box Software (NOOBS)** is an operating system installation manager for the Raspberry Pi.
 
 ![NOOBS OS selection](images/noobs.png)
 
@@ -10,41 +12,9 @@
 
 SD cards with NOOBS preinstalled are available from many of our distributors and independent retailers, including [Pimoroni](https://shop.pimoroni.com/products/noobs-8gb-sd-card), [Adafruit](https://www.adafruit.com/products/1583), and [Pi Hut](http://thepihut.com/collections/raspberry-pi-sd-cards-and-adapters/products/noobs-preinstalled-sd-card).
 
-### Download
-
-Alternatively, NOOBS is available for download on the Raspberry Pi website: [raspberrypi.org/downloads](https://www.raspberrypi.org/downloads/)
-
-#### How to install NOOBS on an SD card
-
-Once you've downloaded the NOOBS zip file, you'll need to copy the contents to a formatted SD card on your computer.
-
-To set up a blank SD card with NOOBS:
-
-- Format an SD card as FAT. See the instructions given below.
-  - Your SD card will need to be at least 16GB for Full Raspberry Pi OS, or at least 8GB for all other installs. 
-- Download and extract the files from the NOOBS zip file.
-- Copy the extracted files onto the SD card that you just formatted, so that these files are at the root directory of the SD card. Please note that in some cases it may extract the files into a folder; if this is the case, then please copy across the files from inside the folder rather than the folder itself.
-- On first boot, the "RECOVERY" FAT partition will be automatically resized to a minimum, and a list of OSes that are available to install will be displayed.
-
-#### How to format an SD card as FAT
-
-**Note:** If you're formatting an SD (or micro SD) card that has a capacity over 32GB (i.e. 64GB and above), then see the separate [SDXC formatting](sdxc_formatting.md) instructions.
-
-##### Windows
-
-If you are a Windows user, we recommend formatting your SD card using the SD Association's Formatting Tool, which can be downloaded from [sdcard.org](https://www.sdcard.org/downloads/formatter_4/). Instructions for using the tool are available on the same site.
-
-##### Mac OS
-
-The [SD Association's Formatting Tool](https://www.sdcard.org/downloads/formatter_4/) is also available for Mac users, although the default OS X Disk Utility is also capable of formatting the entire disk. To do this, select the SD card volume and choose `Erase` with `MS-DOS` format.
-
-##### Linux
-
-For Linux users we recommend `gparted` (or the command line version `parted`). Norman Dunbar has written up [instructions](http://qdosmsq.dunbar-it.co.uk/blog/2013/06/noobs-for-raspberry-pi/) for Linux users.
-
 ## What's included in NOOBS
 
-The following operating systems are currently included in NOOBS:
+The following operating systems are currently included in NOOBS. Note that only Raspberry Pi OS is supplied on the SD card - all other choices require that you have an internet connection to download the operating system.
 
 - [Raspberry Pi OS](https://www.raspberrypi.org)
 - [LibreELEC](https://libreelec.tv/)
@@ -56,23 +26,11 @@ The following operating systems are currently included in NOOBS:
 - [Windows 10 IoT Core](https://developer.microsoft.com/en-us/windows/iot)
 - [TLXOS](https://thinlinx.com/)
 
-As of NOOBS v1.3.10 (September 2014), only Raspberry Pi OS is installed by default in NOOBS. The others can be installed with a network connection.
-
-## NOOBS and NOOBS Lite
-
-NOOBS is available in two forms: offline and network install, or network install only.
-
-The full version has Raspberry Pi OS included, so it can be installed from the SD card while offline, whereas using NOOBS Lite or installing any other operating system requires an internet connection.
-
-Note that the operating system image on the full version can be outdated if a new version of the OS is released, but if connected to the internet you will be shown the option of downloading the latest version if there is a newer one available.
-
 ## NOOBS development
 
 ### Latest NOOBS release
 
 The latest NOOBS release is **v3.5.1**, released on **4th December 2020**.
-
-(From NOOBS v1.4.0 onwards, NOOBS Lite only shares the first two digits of the version number, i.e. v1.4)
 
 ### NOOBS documentation
 

--- a/installation/noobs.md
+++ b/installation/noobs.md
@@ -10,7 +10,7 @@
 
 ### Buy a pre-installed SD card
 
-SD cards with NOOBS preinstalled are available from many of our distributors and independent retailers, including [Pimoroni](https://shop.pimoroni.com/products/noobs-8gb-sd-card), [Adafruit](https://www.adafruit.com/products/1583), and [Pi Hut](http://thepihut.com/collections/raspberry-pi-sd-cards-and-adapters/products/noobs-preinstalled-sd-card).
+SD cards with NOOBS pre-installed are available from many of our distributors and independent retailers, including [Pimoroni](https://shop.pimoroni.com/products/noobs-8gb-sd-card), [Adafruit](https://www.adafruit.com/products/1583), and [Pi Hut](http://thepihut.com/collections/raspberry-pi-sd-cards-and-adapters/products/noobs-preinstalled-sd-card).
 
 ## What's included in NOOBS
 

--- a/installation/noobs.md
+++ b/installation/noobs.md
@@ -1,6 +1,6 @@
 # NOOBS
 
-**Note: We now recommend that you use [Raspberry Pi Imager](https://www.raspberrypi.org/software/) to install an operating system, instead of using NOOBS. If you are buying an SD card with software pre-installed on it, then we do still recommend buying one with NOOBS on it.**
+**Note: We now recommend that you use [Raspberry Pi Imager](https://www.raspberrypi.org/software/) to install an operating system, instead of using NOOBS. If you are buying an SD card with software pre-installed on it, then we recommend buying one with NOOBS on it.**
 
 **New Out Of Box Software (NOOBS)** is an operating system installation manager for the Raspberry Pi.
 

--- a/installation/noobs.md
+++ b/installation/noobs.md
@@ -14,23 +14,13 @@ SD cards with NOOBS pre-installed are available from many of our distributors an
 
 ## What's included in NOOBS
 
-The following operating systems are currently included in NOOBS. Note that only Raspberry Pi OS is supplied on the SD card - all other choices require that you have an internet connection to download the operating system.
-
-- [Raspberry Pi OS](https://www.raspberrypi.org)
-- [LibreELEC](https://libreelec.tv/)
-- [OSMC](https://osmc.tv/)
-- [Recalbox](https://www.recalbox.com/)
-- [Lakka](http://www.lakka.tv/)
-- [RISC OS](https://www.riscosopen.org/wiki/documentation/show/Welcome%20to%20RISC%20OS%20Pi)
-- [Screenly OSE](https://www.screenly.io/ose/)
-- [Windows 10 IoT Core](https://developer.microsoft.com/en-us/windows/iot)
-- [TLXOS](https://thinlinx.com/)
+NOOBS includes Raspberry Pi OS. It can also be used to install other operating systems: this requires that the Pi has a working internet connection to download the OS.
 
 ## NOOBS development
 
 ### Latest NOOBS release
 
-The latest NOOBS release is **v3.5.1**, released on **4th December 2020**.
+The latest NOOBS release is **v3.5.2**, released on **12th January 2021**.
 
 ### NOOBS documentation
 


### PR DESCRIPTION
Just noticed this page is still recommending NOOBS, so this change aims to update it to point folk to Raspberry Pi Imager instead. I've also made some attempt to make use of the new Foundation-provided content, which somewhat supercedes what is in the installation section of the docs.

The new Foundation-provided page at https://www.raspberrypi.org/software/ is simpler than anything in this repo, so I've linked straight to that for Raspberry Pi Imager. It also has a handy video, which should explain the (fairly obvious) process in enough detail for most users.

I've tweaked the links to the 3 sub-pages as follows:

1. `NOOBS` - still linked, but added a note that it is now deprecated.
2. `Installing Images` - I've added a bit of blurb pointing folk to that page if they need some extra help, as in most cases raspberrypi.org/software/ should be all folk need. I've also pointed folk to the forums for extra help as well.
3. `SD cards` - I've labelled this "further info about SD cards", since in most cases the info on this page should not really be needed, but it's there if folk require it.