### PR TITLE
change example to put file in /lib/systemd/system

### DIFF
--- a/linux/usage/systemd.md
+++ b/linux/usage/systemd.md
@@ -23,12 +23,13 @@ User=pi
 
 [Install]
 WantedBy=multi-user.target
+Alias=ms.service
 ```
 So in this instance, the service would run Python 3 from our working directory `/home/pi/myscript` which contains our python program to run `main.py`. But you are not limited to Python programs: simply change the ExecStart line to be the command to start any program/script that you want running from booting.
 
-Copy this file into `/etc/systemd/system` as root, for example:
+Copy this file into `/lib/systemd/system` as root, for example:
 ```
-sudo cp myscript.service /etc/systemd/system/myscript.service
+sudo cp myscript.service /lib/systemd/system/myscript.service
 ```
 
 Once this has been copied, you can attempt to start the service using the following command:
@@ -44,6 +45,17 @@ When you are happy that this starts and stops your app, you can have it start au
 ```
 sudo systemctl enable myscript.service
 ```
+
+With the alias in the service file you can alias alternative names, in this case `ms` - this works after a service is enabled, so in this case you can use
+```
+sudo systemctl start ms
+```
+and
+```
+sudo systemctl stop ms
+```
+This can then allow you to have a more descriptive long filename if you prefer.
+
 
 The `systemctl` command can also be used to restart the service or disable it from boot up!
 

--- a/linux/usage/systemd.md
+++ b/linux/usage/systemd.md
@@ -46,7 +46,7 @@ When you are happy that this starts and stops your app, you can have it start au
 sudo systemctl enable myscript.service
 ```
 
-With the alias in the service file you can alias alternative names, in this case `ms` - this works after a service is enabled, so in this case you can use
+With the alias in the service file you can alias alternative names, in this case `ms` - this only works after a service is enabled using the full filename.  In this exaple you can use:
 ```
 sudo systemctl start ms
 ```


### PR DESCRIPTION
Some changes for consideration. It seems better practice to put the .service file in /lib/systemd/system and let system d create the symlinks when enable is used.

But i defer to others if this is silly for some reason.

I also added an example of using alias - super useful when you want a longer descriptive .service filename but you want the stop and start name to be shorter.

I know both of these about preference not right/wrong so accept / reject PR as you see fit :-). 