### PR TITLE
Update net_tutorial.md to allow DNS server to be used for internal systems. 

### DIFF
--- a/hardware/raspberrypi/bootmodes/net_tutorial.md
+++ b/hardware/raspberrypi/bootmodes/net_tutorial.md
@@ -170,6 +170,7 @@ sudo nano /etc/dnsmasq.conf
 Then replace the contents of `dnsmasq.conf` with:
 
 ```
+# Note: comment out port if you want DNS services for systems on the network. 
 port=0
 dhcp-range=10.42.0.255,proxy
 log-dhcp


### PR DESCRIPTION
Specifying Port=0 is not required and will actually cause problems if you are using this for other systems on the network needing DNS services. It should be omitted allowing the default port to be used. I assume this is probably originally put in here to prevent users from making a DNS server that is a security risk but there should at least be a comment about it as I have added here.