### PR TITLE
Clarified and corrected example

### DIFF
--- a/linux/usage/cron.md
+++ b/linux/usage/cron.md
@@ -39,10 +39,10 @@ The layout for a cron entry is made up of six components: minute, hour, day of m
 For example:
 
 ```
-0 0 * * *  /home/pi/backup.sh
+15 0 * * *  sh /home/pi/backup.sh
 ```
 
-This cron entry would run the `backup.sh` script every day at midnight.
+This cron entry would run the `backup.sh` script, located in /home/pi/backup, every day at 15 minutes past midnight.
 
 ### View scheduled tasks
 


### PR DESCRIPTION
I used this guide to add some actions to the su cron, but they didn't run. I made some mistakes, and based on these mistakesm I propose updating the example as follows:

1.  added "sh" to shell script command in cron. Without this the shell script doesn't run
2. Clarified the example to make clear distinction between minutes and hours in the crontab file. Common sense would expect the first input to be hours, the second to be minutes. This is not the case in crontab. Altough the documentation was correct, the example was set at midnight (00:00), which did not highlight the pitfall.
