### PR TITLE
reorder arguments in all `dd` commands to match

### DIFF
--- a/installation/installing-images/linux.md
+++ b/installation/installing-images/linux.md
@@ -20,7 +20,7 @@
 - In a terminal window, write the image to the card with the command below, making sure you replace the input file `if=` argument with the path to your `.img` file, and the `/dev/sdX` in the output file `of=` argument with the correct device name. **This is very important, as you will lose all the data on the hard drive if you provide the wrong device name.** Make sure the device name is the name of the whole SD card as described above, not just a partition. For example: `sdd`, not `sdds1` or `sddp1`; `mmcblk0`, not `mmcblk0p1`.
 
     ```bash
-    dd bs=4M if=2021-01-11-raspios-buster-armhf.img of=/dev/sdX conv=fsync
+    dd if=2021-01-11-raspios-buster-armhf.img of=/dev/sdX bs=4M conv=fsync
     ```
 
 - Please note that block size set to `4M` will work most of the time. If not,  try `1M`, although this will take considerably longer.
@@ -42,7 +42,7 @@ unzip -p 2021-01-11-raspios-buster-armhf.zip | sudo dd of=/dev/sdX bs=4M conv=fs
 
 - To see the progress of the copy operation, you can run the dd command with the status option.
    ```
-    dd bs=4M if=2021-01-11-raspios-buster-armhf.img of=/dev/sdX status=progress conv=fsync
+    dd if=2021-01-11-raspios-buster-armhf.img of=/dev/sdX bs=4M conv=fsync status=progress
    ```
 - If you are using an older version of `dd`, the status option may not be available. You may be able to use the `dcfldd` command instead, which will give a progress report showing how much has been written. Another method is to send a USR1 signal to `dd`, which will let it print status information. Find out the PID of `dd` by using `pgrep -l dd` or `ps a | grep dd`. Then use `kill -USR1 PID` to send the USR1 signal to `dd`.
 
@@ -60,7 +60,7 @@ We need the number `xxx`, which is the block count. We can ignore the `yyy` numb
 
 - Copy the SD card content to an image on your hard drive using `dd` again:
     ```bash
-    dd bs=4M if=/dev/sdX of=from-sd-card.img count=xxx
+    dd if=/dev/sdX of=from-sd-card.img bs=4M count=xxx
     ```
 `if` is the input file (i.e. the SD card device), `of` is the output file to which the SD card content is to be copied (called `from-sd-card.img` in this example), and `xxx` is the number of blocks written by the original `dd` operation.
 


### PR DESCRIPTION
for easier visual comparison of various `dd` incantations (for sticklers, etc.)