### PR TITLE
Update bcm2711_bootloader_config.md

### DIFF
--- a/hardware/raspberrypi/bcm2711_bootloader_config.md
+++ b/hardware/raspberrypi/bcm2711_bootloader_config.md
@@ -1,7 +1,7 @@
 # Raspberry Pi 4 bootloader configuration
 
 ## Editing the configuration
-Before editing the bootloader configuration, [update your system](../../raspbian/updating.md) to get the latest version of the `rpi-eeprom` package.
+Before editing the bootloader configuration, [update your system](../../raspbian/updating.md) to get the latest version of the `rpi-eeprom` package.  Releases prior to the 2020-09-03 default/critical release will not support all features listed here.
 
 To view the current EEPROM configuration:  
 `rpi-eeprom-config`
@@ -19,14 +19,12 @@ This section describes all the configuration items available in the bootloader. 
 If `1` then enable UART debug output on GPIO 14 and 15. Configure the receiving debug terminal at 115200bps, 8 bits, no parity bits, 1 stop bit.
 
 Default: `0`  
-Version: All  
 
 ### WAKE_ON_GPIO
 
 If `1` then `sudo halt` will run in a lower power mode until either GPIO3 or GLOBAL_EN are shorted to ground.
 
 Default: `1` (`0` in original version of bootloader 2019-05-10)  
-Version: All  
 
 ### POWER_OFF_ON_HALT
 
@@ -35,7 +33,6 @@ If `1` and `WAKE_ON_GPIO=0` then `sudo halt` will switch off all PMIC outputs. T
 Pi 400 has a dedicated power button which operates even if the processor is switched off. This behaviour is enabled by default, however, `WAKE_ON_GPIO=2` may be set to use an external GPIO power button instead of the dedicated power button.
 
 Default: `0`  
-Version: 2019-07-15  
 
 ### BOOT_ORDER
 The `BOOT_ORDER` setting allows flexible configuration for the priority of different bootmodes. It is represented as 32bit unsigned integer where each nibble represents a bootmode. The bootmodes are attempted in lowest significant nibble to highest significant nibble order.
@@ -58,8 +55,7 @@ The BOOT_ORDER property defines the sequence for the different boot modes. It is
 
 After trying each non-zero boot mode the bootloader stops. However, from 2020-09-03 the bootloader will monitor the SD card detect pin and try SD boot if a new SD card is inserted.
 
-Default: `0xf41` (`0x1` in versions prior to 2020-09-03)  
-Version: 2020-04-16  
+Default: `0xf41`  
 
 * Boot mode `0x0` will retry the SD boot if the SD card detect pin indicates that the card has been inserted or replaced.
 * The default boot order is `0xf41` which means continuously try SD then USB mass storage.
@@ -70,49 +66,42 @@ Version: 2020-04-16
 If the RESTART (`0xf`) boot mode is encountered more than MAX_RESTARTS times then a watchdog reset is triggered. This isn't recommended for general use but may be useful for test or remote systems where a full reset is needed to resolve issues with hardware or network interfaces.
 
 Default: `-1` (infinite)  
-Version: 2020-09-03  
 
 ### SD_BOOT_MAX_RETRIES
 The number of times that SD boot will be retried after failure before moving to the next boot mode defined by `BOOT_ORDER`.  
 `-1` means infinite retries.
 
 Default: `0`  
-Version: 2020-04-16  
 
 ### NET_BOOT_MAX_RETRIES
 The number of times that network boot will be retried after failure before moving to the next boot mode defined by `BOOT_ORDER`.  
 `-1` means infinite retries.
 
 Default: `0`  
-Version: 2020-04-16  
 
 ### DHCP_TIMEOUT
 The timeout in milliseconds for the entire DHCP sequence before failing the current iteration.
 
 Minimum: `5000`  
 Default: `45000`  
-Version: 2020-04-16  
 
 ### DHCP_REQ_TIMEOUT
 The timeout in milliseconds before retrying DHCP DISCOVER or DHCP REQ.
 
 Minimum: `500`  
 Default: `4000`  
-Version: 2020-04-16  
 
 ### TFTP_FILE_TIMEOUT
 The timeout in milliseconds for an individual file download via TFTP.
 
 Minimum: `5000`  
 Default: `30000`  
-Version: 2020-04-16  
 
 ### TFTP_IP
 Optional dotted decimal ip address (e.g. `192.168.1.99`) for the TFTP server which overrides the server-ip from the DHCP request.  
 This may be useful on home networks because tftpd-hpa can be used instead of dnsmasq where broadband router is the DHCP server.
 
 Default: ""  
-Version: 2020-04-16  
 
 ### TFTP_PREFIX
 In order to support unique TFTP boot directories for each Pi the bootloader prefixes the filenames with a device specific directory. If neither start4.elf nor start.elf are found in the prefixed directory then the prefix is cleared.
@@ -125,20 +114,17 @@ On earlier models the serial number is used as the prefix, however, on Pi 4 the 
 | 2     | Use the MAC address e.g. `dc-a6-32-01-36-c2/` |
 
 Default: 0  
-Version: 2020-04-16  
 
 ### TFTP_PREFIX_STR
 Specify the custom directory prefix string used when `TFTP_PREFIX` is set to 1. For example:- `TFTP_PREFIX_STR=tftp_test/`
 
 Default: ""  
 Max length: 32 characters  
-Version: 2020-04-16  
 
 ### PXE_OPTION43
 Overrides the PXE Option43 match string with a different string. It's normally better to apply customisations to the DHCP server than change the client behaviour but this option is provided in case that's not possible.
 
 Default: `Raspberry Pi Boot`  
-Version: 2020-04-16  
 
 ### DHCP_OPTION97
 In earlier releases the client GUID (Option97) was just the serial number repeated 4 times. By default, the new GUID format is
@@ -148,7 +134,6 @@ This is intended to be unique but also provide structured information to the DHC
 Specify DHCP_OPTION97=0 to revert the the old behaviour or a non-zero hex-value to specify a custom 4-byte prefix.
 
 Default: `0x34695052`  
-Version: 2020-04-16  
 
 ### Static IP address configuration
 If TFTP_IP and the following options are set then DHCP is skipped and the static IP configuration is applied. If the TFTP server is on the same subnet as the client then GATEWAY may be omitted.
@@ -157,37 +142,31 @@ If TFTP_IP and the following options are set then DHCP is skipped and the static
 The IP address of the client e.g. `192.168.0.32`
 
 Default: ""  
-Version: 2020-04-16  
 
 #### SUBNET
 The subnet address mask e.g. `255.255.255.0`
 
 Default: ""  
-Version: 2020-04-16  
 
 #### GATEWAY
 The gateway address to use if the TFTP server is on a differenet subnet e.g. `192.168.0.1`
 
 Default: ""  
-Version: 2020-04-16  
 
 #### MAC_ADDRESS
 Overrides the Ethernet MAC address with the given value. e.g. `dc:a6:32:01:36:c2`
 
 Default: ""  
-Version: 2020-04-16  
 
 ### DISABLE_HDMI
 The [HDMI boot diagnostics](./boot_diagnostics.md) display is disabled if `DISABLE_HDMI=1`. Other non-zero values are reserved for future use.
 
 Default: `0`  
-Version: 2020-04-16  
 
 ### HDMI_DELAY
 Skip rendering of the HDMI diagnostics display for up to N seconds (default 5) unless a fatal error occurs. The default behaviour is designed to avoid the bootloader diagnostics screen from briefly appearing during a normal SD / USB boot.
 
 Default: `5`  
-Version: 2020-12-14   
 
 ### ENABLE_SELF_UPDATE
 Enables the bootloader to update itself from a TFTP or USB mass storage device (MSD) boot filesystem.
@@ -200,7 +179,6 @@ Notes:-
 * For network boot make sure that the TFTP `boot` directory can be mounted via NFS and that `rpi-eeprom-update` can write to it.
 
 Default: `1` (`0` in versions prior to 2020-09-03)  
-Version: 2020-04-16  
 
 ### FREEZE_VERSION
 Previously this property was only checked by the `rpi-eeprom-update` script. However, now that self-update is enabled the bootloader will also check this property. If set to 1, this overrides `ENABLE_SELF_UPDATE` to stop automatic updates. To disable `FREEZE_VERSION` you will have to use an SD card boot with recovery.bin.
@@ -208,7 +186,6 @@ Previously this property was only checked by the `rpi-eeprom-update` script. How
 **Custom EEPROM update scripts must also check this flag.**
 
 Default: `0`  
-Version: All  
 
 ### NETCONSOLE - advanced logging
 `NETCONSOLE` duplicates debug messages to the network interface. The IP addresses and ports are defined by the `NETCONSOLE` string.
@@ -240,7 +217,6 @@ NETCONSOLE=6665@169.254.1.1/,6666@/
 
 Default: ""  (not enabled)  
 Max length: 32 characters  
-Version: 2020-09-03  
 
 ### USB_MSD_EXCLUDE_VID_PID
 A list of up to 4 VID/PID pairs specifying devices which the bootloader should ignore. If this matches a HUB then the HUB won’t be enumerated, causing all downstream devices to be excluded.
@@ -250,7 +226,6 @@ The format is a comma-separated list of hexadecimal values with the VID as most 
 E.g. `034700a0,a4231234`
 
 Default: ""  
-Version: 2020-09-03  
 
 ### USB_MSD_DISCOVER_TIMEOUT
 If no USB mass storage devices are found within this timeout then USB-MSD is stopped and the next boot mode is selected
@@ -262,7 +237,6 @@ Version: 2020-09-03
 How long to wait in milliseconds before advancing to the next LUN e.g. a multi-slot SD-CARD reader. This is still being tweaked but may help speed up boot if old/slow devices are connected as well as a fast USB-MSD device containing the OS.
 
 Default: `2000` (2 seconds)  
-Version: 2020-09-03  
 
 ### USB_MSD_PWR_OFF_TIME
 During USB mass storage boot, power to the USB ports is switched off for a short time to ensure the correct operation of USB mass storage devices. Most devices work correctly using the default setting: change this only if you have problems booting from a particular device. Setting `USB_MSD_PWR_OFF_TIME=0` will prevent power to the USB ports being switched off during USB mass storage boot.
@@ -270,7 +244,6 @@ During USB mass storage boot, power to the USB ports is switched off for a short
 Minimum: `250`  
 Maximum: `5000`  
 Default: `1000` (1 second)  
-Version: 2020-09-03  
 
 ### XHCI_DEBUG
 This property is a bit field which controls the verbosity of USB debug messages for mass storage boot mode. Enabling all of these messages generates a huge amount of log data which will slow down booting and may even cause boot to fail. For verbose logs it's best to use `NETCONSOLE`.
@@ -292,7 +265,6 @@ XHCI_DEBUG=0x3
 ```
 
 Default: `0x0` (no USB debug messages enabled)  
-Version: 2020-09-03  
 
 ## config.txt - configuration properties
 ### boot_load_flags
@@ -301,7 +273,6 @@ Experimental property for custom firmware (bare metal).
 Bit 0 (0x1) indicates that the .elf file is custom firmware. This disables any compatiblity checks (e.g. is USB MSD boot supported) and resets PCIe before starting the executable.
 
 Default: `0x0`  
-Version: 2020-09-03  
 
 ### uart_2ndstage
 If set to 0x1 then enable debug logging to the UART. In newer firmware versions (Raspberry Pi OS 2020-08-20 and later) UART logging is also automatically enabled in start.elf. This is also described on the [Boot options](../../configuration/config-txt/boot.md) page.
@@ -309,7 +280,6 @@ If set to 0x1 then enable debug logging to the UART. In newer firmware versions 
 The `BOOT_UART` property also enables bootloader UART logging but does not enable UART logging in `start.elf` unless `uart_2ndstage=1` is also set.
 
 Default: `0`    
-Version: 2020-09-03  
 
 ### eeprom_write_protect
 Controls whether the bootloader and VLI EEPROMs are marked as write protected.
@@ -325,13 +295,11 @@ See: [Winbond W25x40cl datasheet](https://www.winbond.com/resource-files/w25x40c
 | -1    | Do nothing.                                                      |
 
 Default: `-1`  
-Version: 2020-09-03  
 
 ### bootloader_update
 This option may be set to 0 to block self-update without requiring the EEPROM configuration to be updated. This is sometimes useful when updating multiple Pis via network boot because this option can be controlled per Raspberry Pi (e.g. via a serial number filter in config.txt).
 
 Default: `1` (`0` in versions prior to 2020-09-03)  
-Version: 2020-04-16  
 
 ## Advanced boot modes - Network / USB mass storage boot.
 For network or USB mass storage boot we recommend updating to bootloader version 2020-09-03 and Raspberry Pi OS 2020-08-20 or newer.


### PR DESCRIPTION
The 2020-09-03 release has been the default automatic upgrade for a long time now and is the baseline for USB boot. Remove the version tags for this and all prior releases to make the documentation easier to read.

When the next critical update is released then the version field would be used for significant features which require the upgrade.

More detailed information is already available via the release-notes file which tracks the beta release where a change was made.