### PR TITLE
Increase NFS rsize/wsize for netboot tutorial

### DIFF
--- a/hardware/raspberrypi/bootmodes/net_tutorial.md
+++ b/hardware/raspberrypi/bootmodes/net_tutorial.md
@@ -239,7 +239,7 @@ sudo systemctl restart nfs-kernel-server
 Edit `/tftpboot/cmdline.txt` and from `root=` onwards, and replace it with:
 
 ```
-root=/dev/nfs nfsroot=10.42.0.211:/nfs/client1,vers=4.1,proto=tcp rw ip=dhcp rootwait elevator=deadline
+root=/dev/nfs nfsroot=10.42.0.211:/nfs/client1,vers=4.1,proto=tcp,rsize=1048576,wsize=1048576 rw ip=dhcp rootwait elevator=deadline
 ```
 
 You should substitute the IP address here with the IP address you have noted down. Also remove any part of the command line starting with init=.


### PR DESCRIPTION
rsize and wsize normally default to 1048576 (1MB) for NFS mounts, but for an NFS root device they default to 4096 (4KB).  This can lead to a significant performance degradation if the user expects the normal defaults.