### PR TITLE
Setup: remove reference to NOOBS

### DIFF
--- a/setup/README.md
+++ b/setup/README.md
@@ -1,10 +1,10 @@
 # Setup
 
-A guide to setting up your Raspberry Pi
+A guide to setting up your Raspberry Pi.
 
 ## What you will need
 
-### Essential (for general use)
+### Essential
 
 - [SD card](../installation/sd-cards.md)
     - We recommend a minimum of 8GB micro SD card, and using [Raspberry Pi Imager](https://www.raspberrypi.org/software/) to install an operating system onto it.
@@ -16,20 +16,18 @@ A guide to setting up your Raspberry Pi
     - For keyboard layout configuration options see [raspi-config](../configuration/raspi-config.md).
 - [Power supply](../hardware/raspberrypi/power/README.md)
     - The Pi is powered via a micro USB connector, except the Pi 4B and Pi 400 which use a USB type C connector.
-    - You need a good quality power supply that can supply at least 3A at 5V for the Pi 4B, 2A at 5V for the Pi 3B and 3B+, or 700mA at 5V for the earlier, lower-powered Pi models. We recommend using the [official Raspberry Pi power supply](https://www.raspberrypi.org/products/raspberry-pi-universal-power-supply/), which is designed specifically for Raspberry Pi.
-    - Low-current (~700mA) power supplies will work for basic usage, but are likely to cause the Pi to reboot if it draws too much power. They are not suitable for use with the Pi 3 or 4.
+    - You need a good quality power supply - see [here](../hardware/raspberrypi/power/README.md) for information on the power requirements of each model of Raspberry Pi. We recommend using an official Raspberry Pi power supply - for the Pi 4B and 400 use the type C power supply; for all other models use the micro USB power supply(https://www.raspberrypi.org/products/raspberry-pi-universal-power-supply/).
 
 ### Optional
 
-- Ethernet (network) cable [Model B/B+/2B/3B/3B+/4B only]
-    - An Ethernet cable is used to connect your Pi to a local network and the internet.
+- Network cable (not Pi Zero)
+    - A network cable is used to connect your Pi to a local network and the internet.
 - [USB wireless network dongle](../configuration/wireless/README.md)
     - Only required if you need wireless network connectivity and are using a model without built-in wireless functionality.
-- Audio lead
-    - Audio can be played through speakers or headphones using a standard 3.5mm jack.
-    - Without an HDMI cable, an audio lead is necessary to produce sound.
-    - No separate audio lead is necessary if you're using an HDMI cable to connect to a monitor with speakers, as audio can be played directly through the display; but it is possible to connect one if you prefer to have the audio played through other speakers - this requires [configuration](../configuration/audio-config.md).
-
+- Sound hardware
+    - If your display uses an HDMI connection and has built-in speakers, you can use it to output sound.
+    - Audio can also be played through speakers or headphones by connecting them to the AV jack. Speakers must have their own amplification, since the output from the Pi is not powerful enough to drive speakers directly.
+   
 ## Troubleshooting
 
-For any issues during setup, search [the forums](https://www.raspberrypi.org/forums/) for a solution. If you cannot find one, please post your problem, providing as much detail as possible.
+You can get help with setting up your Pi on our [forums](https://www.raspberrypi.org/forums/).

--- a/setup/README.md
+++ b/setup/README.md
@@ -15,8 +15,7 @@ A guide to setting up your Raspberry Pi.
     - Wireless keyboards and mice will work if already paired.
     - For keyboard layout configuration options see [raspi-config](../configuration/raspi-config.md).
 - [Power supply](../hardware/raspberrypi/power/README.md)
-    - The Pi is powered via a micro USB connector, except the Pi 4B and Pi 400 which use a USB type C connector.
-    - You need a good quality power supply - see [here](../hardware/raspberrypi/power/README.md) for information on the power requirements of each model of Raspberry Pi. We recommend using an official Raspberry Pi power supply - for the Pi 4B and 400 use the type C power supply; for all other models use the micro USB power supply(https://www.raspberrypi.org/products/raspberry-pi-universal-power-supply/).
+    - You need a good quality power supply - see [here](../hardware/raspberrypi/power/README.md) for information on the power requirements of each model of Raspberry Pi. We recommend using an official Raspberry Pi power supply - for the Pi 4B and 400 use the [type C power supply](https://www.raspberrypi.org/products/type-c-power-supply/); for all other models use the [micro USB power supply](https://www.raspberrypi.org/products/raspberry-pi-universal-power-supply/).
 
 ### Optional
 

--- a/setup/README.md
+++ b/setup/README.md
@@ -7,7 +7,7 @@ A guide to setting up your Raspberry Pi
 ### Essential (for general use)
 
 - [SD card](../installation/sd-cards.md)
-    - We recommend a minimum of 8GB class 4 or class 10 microSD card. To save time, you can get a card that is pre-installed with [NOOBS](../installation/noobs.md) or [Raspberry Pi OS](../installation/installing-images/README.md), although setting up your own card is easy.
+    - We recommend a minimum of 8GB micro SD card, and using [Raspberry Pi Imager](https://www.raspberrypi.org/software/) to install an operating system onto it.
 - [Display and connectivity cable](monitor-connection.md)
     - Any HDMI/DVI monitor or TV should work as a display for the Pi. For best results, use a display with HDMI input; other types of connection for older devices are also available.
 - Keyboard and mouse
@@ -15,16 +15,16 @@ A guide to setting up your Raspberry Pi
     - Wireless keyboards and mice will work if already paired.
     - For keyboard layout configuration options see [raspi-config](../configuration/raspi-config.md).
 - [Power supply](../hardware/raspberrypi/power/README.md)
-    - The Pi is powered by a USB Micro [models pre 4B] or USB Type-C [model 4B] power supply (like most standard mobile phone chargers).
-    - You need a good-quality power supply that can supply at least 3A at 5V for the Model 4B, 2A at 5V for the Model 3B and 3B+, or 700mA at 5V for the earlier, lower-powered Pi models. We recommend using the [official Raspberry Pi power supply](https://www.raspberrypi.org/products/raspberry-pi-universal-power-supply/), which is designed specifically for Raspberry Pi.
+    - The Pi is powered via a micro USB connector, except the Pi 4B and Pi 400 which use a USB type C connector.
+    - You need a good quality power supply that can supply at least 3A at 5V for the Pi 4B, 2A at 5V for the Pi 3B and 3B+, or 700mA at 5V for the earlier, lower-powered Pi models. We recommend using the [official Raspberry Pi power supply](https://www.raspberrypi.org/products/raspberry-pi-universal-power-supply/), which is designed specifically for Raspberry Pi.
     - Low-current (~700mA) power supplies will work for basic usage, but are likely to cause the Pi to reboot if it draws too much power. They are not suitable for use with the Pi 3 or 4.
 
 ### Optional
 
 - Ethernet (network) cable [Model B/B+/2B/3B/3B+/4B only]
     - An Ethernet cable is used to connect your Pi to a local network and the internet.
-- [USB wireless dongle](../configuration/wireless/README.md)
-    - Only required if you need wireless connectivity and are using an older model without built-in wireless functionality.
+- [USB wireless network dongle](../configuration/wireless/README.md)
+    - Only required if you need wireless network connectivity and are using a model without built-in wireless functionality.
 - Audio lead
     - Audio can be played through speakers or headphones using a standard 3.5mm jack.
     - Without an HDMI cable, an audio lead is necessary to produce sound.


### PR DESCRIPTION
Since NOOBS is now deprecated for end-user installs, remove reference to it from the setup guide.

Also, some other minor fixups to the page, including removing reference to use raspi-config to set the keyboard layout - we've got a GUI setup tool now, and the first run wizard prompts the user for a keyboard layout as well.