### PR TITLE
Remove "users" option from fstab

### DIFF
--- a/configuration/external-storage.md
+++ b/configuration/external-storage.md
@@ -68,10 +68,9 @@ You can modify the `fstab` file to define the location where the storage device 
 4. Add the following line in the `fstab` file:
 
     ```
-    UUID=5C24-1453 /mnt/mydisk fstype defaults,user,nofail 0 0
+    UUID=5C24-1453 /mnt/mydisk fstype defaults,nofail 0 0
     ```
    Replace `fstype` with the type of your file system, which you found in step 2 of 'Mounting a storage device' above, for example: `ntfs`.
-   The `user` option allows any user on the system to mount the disk while the system is running.
    
 5. If the filesystem type is FAT or NTFS, add `,umask=000` immediately after `nofail` - this will allow all users full read/write access to every file on the storage device.
 

--- a/configuration/external-storage.md
+++ b/configuration/external-storage.md
@@ -68,9 +68,10 @@ You can modify the `fstab` file to define the location where the storage device 
 4. Add the following line in the `fstab` file:
 
     ```
-    UUID=5C24-1453 /mnt/mydisk fstype defaults,auto,users,rw,nofail 0 0
+    UUID=5C24-1453 /mnt/mydisk fstype defaults,user,nofail 0 0
     ```
    Replace `fstype` with the type of your file system, which you found in step 2 of 'Mounting a storage device' above, for example: `ntfs`.
+   The `user` option allows any user on the system to mount the disk while the system is running.
    
 5. If the filesystem type is FAT or NTFS, add `,umask=000` immediately after `nofail` - this will allow all users full read/write access to every file on the storage device.
 


### PR DESCRIPTION
I haven't found a "users" option; it's normally "user", but I don't think that's a good default anyway. "auto" and "rw" are also already included in "defaults," so I removed those.