### PR TITLE
bootloader: Simplify EEPROM write protect documentation

### DIFF
--- a/hardware/raspberrypi/bcm2711_bootloader_config.md
+++ b/hardware/raspberrypi/bcm2711_bootloader_config.md
@@ -282,17 +282,21 @@ The `BOOT_UART` property also enables bootloader UART logging but does not enabl
 Default: `0`    
 
 ### eeprom_write_protect
-Controls whether the bootloader and VLI EEPROMs are marked as write protected.
+The `2020-09-03` `recovery.bin` EEPROM updater provides a feature to configure the EEPROM `Write Status Register`. This can be set to either mark the entire EEPROM as write-protected or clear write-protection.
 
-**This has no effect unless the EEPROM `/WP` pin is pulled low (TP5). Similarly, `/WP` low only write protects the EEPROM status register so if EEPROM write protect was not previously defined then the EEPROM would not actually be write protected**
+This option must be used in conjunction with the EEPROM `/WP` pin which controls updates to the EEPROM `Write Status Register`.  Pulling `/WP` low (CM4 `EEPROM_nEP` or Pi4B `TP5`) does NOT write-protect the EEPROM unless the `Write Status Register` has also been configured.
 
 See: [Winbond W25x40cl datasheet](https://www.winbond.com/resource-files/w25x40cl_f%2020140325.pdf)
+
+`eeprom_write_protect` settings in `config.txt` for `recovery.bin`.
 
 | Value | Description                                                      |
 |-------|------------------------------------------------------------------|
 |  1    | Configures the write protect regions to cover the entire EEPROM. |
-|  0    | Clears the write protect regions.                                |  
+|  0    | Clears the write protect regions.                                |
 | -1    | Do nothing.                                                      |
+
+N.B `flashrom` does not support clearing of the write-protect regions and will fail to update the EEPROM if write-protect regions are defined.
 
 Default: `-1`  
 

--- a/hardware/raspberrypi/booteeprom.md
+++ b/hardware/raspberrypi/booteeprom.md
@@ -148,21 +148,7 @@ sudo systemctl unmask rpi-eeprom-update
 The `FREEZE_VERSION` option in the [EEPROM config file](bcm2711_bootloader_config.md) may be used to indicate to the `rpi-eeprom-update` service that the EEPROM should not be updated on this board. 
 
 ### EEPROM write protect
-Write protecting the EEPROMs on the Raspberry Pi 4 Model B requires both a software change and a small board modification. 
-
-**This is only recommended for advanced users or industrial customers.**
-
-By default, neither the bootloader nor the VL805 SPI EEPROMs are write-protected. 
-
-If `eeprom_write_protect=1` is defined in `config.txt` then `recovery.bin` will define the write protect regions such that all of both EEPROMS are write-protected. The write-protect region configuration is then made read-only when the write-protect (`/WP`) pin is pulled low. If `eeprom_write_protect=0` is defined then the write-protect regions are cleared. If `eeprom_write_protect` is not defined then the write-protect bits are not modified.
-
-* The `eeprom_write_protect` property requires the `recovery.bin` from the `2020-07-16` bootloader release or newer.
-* The `/WP` pin on these EEPROMs only prevents writes to the non-volatile bits of the status register. Therefore, the write regions must be defined in addition to `/WP` being pulled low.
-* The `/WP` pin must not be pulled low whilst attempting to change the write-protect status.
-* The `/WP` pin for the EEPROMs may be pulled low by connecting test point 5 (`TP5`) to ground.
-* The bootloader self-update mechanism also supports the `eeprom_write_protect` property. However, the bootloader must have already have been upgraded to `2020-07-16` or newer before the `eeprom_write_protect` property will be recognised.
-
-N.B `flashrom` does not support clearing of the write-protect regions and will fail to update the EEPROM if write-protect regions are defined.
+Both the bootloader and VLI SPI EEPROMs support hardware write-protection.  See the [eeprom_write_protect](bcm2711_bootloader_config.md) option for more information about how to enabled this when flashing the EEPROMs.
 
 ## Release Notes
 * [Release notes](https://github.com/raspberrypi/rpi-eeprom/blob/master/firmware/release-notes.md) for bootloader EEPROMs.


### PR DESCRIPTION
This is a standard feature now that CM4 is released. Remove duplication
of settings and make the description of the confusing internaction
between /WP and the Write Status Register less long winded.