### PR TITLE
Update BCM2711 bootflow

### DIFF
--- a/hardware/raspberrypi/bootmodes/bootflow_2711.md
+++ b/hardware/raspberrypi/bootmodes/bootflow_2711.md
@@ -6,8 +6,8 @@ The bootflow for the ROM (first stage) is as follows:-
 
 * BCM2711 SoC powers up
 * Read OTP to determine if the `nRPIBOOT` GPIO is configured
-* If nRPIBOOT GPIO is high or OTP does NOT define `nRPIBOOT` GPIO 
-   * Check OTP to see if recovery.bin can be loaded from SD/EMMC
+* If `nRPIBOOT` GPIO is high or OTP does NOT define `nRPIBOOT` GPIO 
+   * Check OTP to see if `recovery.bin` can be loaded from SD/EMMC
       * If SD recovery.bin is enabled then check primary SD/EMMC for `recovery.bin`
          * Success - run `recovery.bin` and update the SPI EEPROM
          * Fail - continue
@@ -37,8 +37,8 @@ Please see the [bootloader configuration](../bcm2711_bootloader_config.md) page 
    * If `POWER_OFF_ON_HALT` is `1` and `WAKE_ON_GPIO` is `0` then
       * Use PMIC to power off system
    * else
-      * While GPIO3 is high OR `WAKE_ON_GPIO` is 1
-         Sleep
+      * While GPIO3 is high OR `WAKE_ON_GPIO` is `1`
+         * sleep
 * While True
    * Read the next boot-mode from the BOOT_ORDER parameter in the EEPROM config file.
    * If boot-mode == `RESTART`
@@ -68,7 +68,7 @@ Please see the [bootloader configuration](../bcm2711_bootloader_config.md) page 
             * Failure - continue            
    * else if boot-mode == `RPIBOOT` then
       * Attempt to load firmware using USB device mode from the USB OTG port- see [usbboot](https://github.com/raspberrypi/usbboot).
-        There is no timeout for RPIBOOT mode.
+        There is no timeout for `RPIBOOT` mode.
          
 ## Bootloader updates
 The bootloader may also be updated before the firmware is started if a `pieeprom.upd` file is found. Please see the [bootloader eeprom](../booteeprom.md) page for more information about bootloader updates.

--- a/hardware/raspberrypi/bootmodes/bootflow_2711.md
+++ b/hardware/raspberrypi/bootmodes/bootflow_2711.md
@@ -37,7 +37,7 @@ Please see the [bootloader configuration](../bcm2711_bootloader_config.md) page 
    * If `POWER_OFF_ON_HALT` is `1` and `WAKE_ON_GPIO` is `0` then
       * Use PMIC to power off system
    * else
-      * While GPIO3 is high OR `WAKE_ON_GPIO` is `1`
+      * While GPIO3 is high OR `WAKE_ON_GPIO` is `0`
          * sleep
 * While True
    * Read the next boot-mode from the BOOT_ORDER parameter in the EEPROM config file.

--- a/hardware/raspberrypi/bootmodes/bootflow_2711.md
+++ b/hardware/raspberrypi/bootmodes/bootflow_2711.md
@@ -1,42 +1,63 @@
 # Raspberry Pi4, Pi400 and CM4 bootflow
 
-This page describes the bootflow for BCM2711 based products. The main difference betweeen this and previous products is that the second stage bootloader (bootcode.bin) is loaded for an SPI flash [EEPROM](../booteeprom.md) instead of bootable media. Consequently, settings which previously could only be configured with a one off OTP update may now be modified later on by reflashing the EEPROM.
+This page describes the bootflow for BCM2711 based products. The main difference betweeen this and previous products is that the second stage bootloader (bootcode.bin) is loaded from an SPI flash [EEPROM](../booteeprom.md). 
 
-The bootflow is as follows:-
+The bootflow for the ROM (first stage) is as follows:-
 
 * BCM2711 SoC powers up
 * Read OTP to determine GPIO configuration for second stage loading.
-* If nRPIBOOT pin is not defined in OTP or nRPIBOOT GPIO is high
+* If nRPIBOOT GPIO is high or OTP does not define nRPIBOOT GPIO (only defined for CM4)
    * Check primary SD/EMMC for recovery.bin
-      * Success - run recovery.bin
+      * Success - run `recovery.bin`
       * Fail - continue
    * Check SPI EEPROM for second stage loader
       * Success - run second stage bootloader 
       * Fail - continue
 * While True
    * Attempt to load recovery.bin from [USB device boot](../computemodule/cm-emmc-flashing.md)
-      * Success - run recovery.bin
-      * Fail - continue
+      * Success - run `recovery.bin`
+      * Fail - retry USB device boot
 
 ## recovery.bin
-Recovery.bin is a cutdown version of the bootloader which has just enough functionality to reflash the full bootloader in SPI EEPROM.
+`recovery.bin` is a minimal second stage program used to reflash the bootloader SPI EEPROM image.
 
 # Second stage bootloader 
 
-Bootfloat after ROM has loaded the second stage bootloader into the VPU L2 cache:-
+This section describes the high-level flow of the second stage bootloader.
+
+Please see the [bootloader configuration](bcm2711_bootloader_config.md) page for more information about each boot-mode and the [boot folder](../../configuration/boot_folder.md) page for a description of the GPU firmware files loaded by this stage.
 
 * Initialise clocks and SDRAM
-* Read EEPROM configuration file
+* Check PM_RSTS register to determine if HALT is requested
+   * If POWER_OFF_ON_HALT = 1 and WAKE_ON_GPIO = 0 then
+      * Use PMIC to power off system
+   * else
+      * While GPIO3 is high OR WAKE_ON_GPIO = 1
+         Sleep
+* Read the EEPROM configuration file 
 * While True
-   * Read the next boot-mode from the BOOT_ORDER field
-   * If boot-mode i== SD CARD
+   * Read the next boot-mode from the BOOT_ORDER parameter in the EEPROM config file.
+   * If boot-mode == RESTART
+      * Jump back to the first boot-mode in the BOOT_ORDER field
+   * else if boot-mode == STOP
+      * Display start.elf not found [error pattern](../../configuration/led_blink_warnings.md) and wait forever.
+   * else if boot-mode == SD CARD
       * Attempt to load firmware from the SD card
          * Success - run firmware
          * Failure - continue
-   * else if boot-mode == 
-
-
-## BOOT_ORDER
-
-The `BOOT_ORDER` configuration item is embedded inside the bootloader code in the EEPROM. See the [Pi4 Bootloader Configuration](../bcm2711_bootloader_config.md) page for details on how to change the bootloader configuration.
-
+   * else if boot-mode == NETWORK
+      * If boot-mode == NETWORK then 
+         * Used DHCP to request IP address
+         * Load firmware from TFTP server
+         * If the firmware is not found or a timeout or network error occurs then continue
+   * else if boot-mode == USB-MSD or boot-mode == USB-BCM-MSD then
+      * While USB discover has not timed out 
+         * Check for USB mass storage devices
+         * If a new mass storage device is found then
+            * For each drive (LUN)
+               * Attempt to load firmware
+                  * Success - run firmware
+                  * Failed - advance to next LUN
+   * else if boot-mode == RPIBOOT then
+      * Attempt to load firmware using USB device mode from the USB OTG port- see [usbboot](https://github.com/raspberrypi/usbboot) There is no timeout for RPIBOOT mode.
+         

--- a/hardware/raspberrypi/bootmodes/bootflow_2711.md
+++ b/hardware/raspberrypi/bootmodes/bootflow_2711.md
@@ -36,9 +36,9 @@ Please see the [bootloader configuration](../bcm2711_bootloader_config.md) page 
    * Check `POWER_OFF_ON_HALT` and `WAKE_ON_GPIO` EEPROM configuration settings.
    * If `POWER_OFF_ON_HALT` is `1` and `WAKE_ON_GPIO` is `0` then
       * Use PMIC to power off system
-   * else
-      * While GPIO3 is high OR `WAKE_ON_GPIO` is `0`
-         * sleep
+   * else if `WAKE_ON_GPIO` is `1`
+      * Enable fall-edge interrupts on GPIO3 to wake-up if GPIO3 is pulled low   
+   * sleep
 * While True
    * Read the next boot-mode from the BOOT_ORDER parameter in the EEPROM config file.
    * If boot-mode == `RESTART`

--- a/hardware/raspberrypi/bootmodes/bootflow_2711.md
+++ b/hardware/raspberrypi/bootmodes/bootflow_2711.md
@@ -9,14 +9,14 @@ The bootflow for the ROM (first stage) is as follows:-
 * If nRPIBOOT GPIO is high or OTP does NOT define `nRPIBOOT` GPIO 
    * Check OTP to see if recovery.bin can be loaded from SD/EMMC
       * If SD recovery.bin is enabled then check primary SD/EMMC for `recovery.bin`
-         * Success - run `recovery.bin`
+         * Success - run `recovery.bin` and update the SPI EEPROM
          * Fail - continue
    * Check SPI EEPROM for second stage loader
       * Success - run second stage bootloader 
       * Fail - continue
 * While True
    * Attempt to load recovery.bin from [USB device boot](../../computemodule/cm-emmc-flashing.md)
-      * Success - run `recovery.bin`
+      * Success - run `recovery.bin` and update the SPI EEPROM or switch to USB mass storage device mode
       * Fail - retry USB device boot
 
 N.B. Currently only CM4 reserves a GPIO for `nRPIBOOT`
@@ -62,7 +62,7 @@ Please see the [bootloader configuration](../bcm2711_bootloader_config.md) page 
                   * Success - run the firmware
                   * Failed - advance to next LUN
    * else if boot-mode == `NVME` then
-      * Scan PCI for an NVMe device and if found
+      * Scan PCIe for an NVMe device and if found
          * Attempt to load firmware from the NVMe device
             * Success - run the firmware
             * Failure - continue            
@@ -70,5 +70,5 @@ Please see the [bootloader configuration](../bcm2711_bootloader_config.md) page 
       * Attempt to load firmware using USB device mode from the USB OTG port- see [usbboot](https://github.com/raspberrypi/usbboot).
         There is no timeout for RPIBOOT mode.
          
-## Bootloader self-update
-Since the ROM can only load `recovery.bin` from the SD/EMMC the second stage bootloader has the ability to update the EEPROM itself. This is enabled for USB, Network and NVMe boot modes unless `ENABLE_SELF_UPDATE=0` in the [bootloader configuration](../bcm2711_bootloader_config.md).
+## Bootloader updates
+The bootloader may also be updated before the firmware is started if a `pieeprom.upd` file is found. Please see the [bootloader eeprom](../booteeprom.md) page for more information about bootloader updates.

--- a/hardware/raspberrypi/bootmodes/bootflow_2711.md
+++ b/hardware/raspberrypi/bootmodes/bootflow_2711.md
@@ -5,8 +5,8 @@ This page describes the bootflow for BCM2711 based products. The main difference
 The bootflow for the ROM (first stage) is as follows:-
 
 * BCM2711 SoC powers up
-* Read OTP to determine GPIO configuration for second stage loading.
-* If nRPIBOOT GPIO is high or OTP does not define `nRPIBOOT` GPIO (only defined for CM4)
+* Read OTP to determine if board model defined `nRPIBOOT` GPIO
+* If nRPIBOOT GPIO is high or OTP does NOT define `nRPIBOOT` GPIO 
    * Check primary SD/EMMC for `recovery.bin`
       * Success - run `recovery.bin`
       * Fail - continue
@@ -17,6 +17,8 @@ The bootflow for the ROM (first stage) is as follows:-
    * Attempt to load recovery.bin from [USB device boot](../computemodule/cm-emmc-flashing.md)
       * Success - run `recovery.bin`
       * Fail - retry USB device boot
+
+N.B. Currently only CM4 reserves a GPIO for `nRPIBOOT`
 
 ## recovery.bin
 `recovery.bin` is a minimal second stage program used to reflash the bootloader SPI EEPROM image.
@@ -44,7 +46,7 @@ Please see the [bootloader configuration](../bcm2711_bootloader_config.md) page 
       * Display start.elf not found [error pattern](../../../configuration/led_blink_warnings.md) and wait forever.
    * else if boot-mode == `SD CARD`
       * Attempt to load firmware from the SD card
-         * Success - run firmware
+         * Success - run the firmware
          * Failure - continue
    * else if boot-mode == `NETWORK`
       * If boot-mode == `NETWORK` then 
@@ -57,7 +59,7 @@ Please see the [bootloader configuration](../bcm2711_bootloader_config.md) page 
          * If a new mass storage device is found then
             * For each drive (LUN)
                * Attempt to load firmware
-                  * Success - run firmware
+                  * Success - run the firmware
                   * Failed - advance to next LUN
    * else if boot-mode == `RPIBOOT` then
       * Attempt to load firmware using USB device mode from the USB OTG port- see [usbboot](https://github.com/raspberrypi/usbboot).

--- a/hardware/raspberrypi/bootmodes/bootflow_2711.md
+++ b/hardware/raspberrypi/bootmodes/bootflow_2711.md
@@ -15,7 +15,7 @@ The bootflow for the ROM (first stage) is as follows:-
       * Success - run second stage bootloader 
       * Fail - continue
 * While True
-   * Attempt to load recovery.bin from [USB device boot](../computemodule/cm-emmc-flashing.md)
+   * Attempt to load recovery.bin from [USB device boot](../../computemodule/cm-emmc-flashing.md)
       * Success - run `recovery.bin`
       * Fail - retry USB device boot
 
@@ -49,11 +49,11 @@ Please see the [bootloader configuration](../bcm2711_bootloader_config.md) page 
       * Attempt to load firmware from the SD card
          * Success - run the firmware
          * Failure - continue   
-   * If boot-mode == `NETWORK` then 
+   * else if boot-mode == `NETWORK` then 
       * Use DHCP protocol to request IP address
       * Load firmware from the DHCP or statically defined TFTP server
       * If the firmware is not found or a timeout or network error occurs then continue
-   * else if boot-mode == `USB-MSD` or boot-mode == `USB-BCM-MSD` then
+   * else if boot-mode == `USB-MSD` or boot-mode == `BCM-USB-MSD` then
       * While USB discover has not timed out 
          * Check for USB mass storage devices
          * If a new mass storage device is found then
@@ -71,4 +71,4 @@ Please see the [bootloader configuration](../bcm2711_bootloader_config.md) page 
         There is no timeout for RPIBOOT mode.
          
 ## Bootloader self-update
-Since the ROM can only loader `recovery.bin` from the SD/EMMC the second stage bootloader has the ability to update the EEPROM itself. This is enabled for USB, Network and NVMe boot modes unless `ENABLE_SELF_UPDATE=0` in the [bootloader configuration](../bcm2711_bootloader_config.md).
+Since the ROM can only load `recovery.bin` from the SD/EMMC the second stage bootloader has the ability to update the EEPROM itself. This is enabled for USB, Network and NVMe boot modes unless `ENABLE_SELF_UPDATE=0` in the [bootloader configuration](../bcm2711_bootloader_config.md).

--- a/hardware/raspberrypi/bootmodes/bootflow_2711.md
+++ b/hardware/raspberrypi/bootmodes/bootflow_2711.md
@@ -6,8 +6,8 @@ The bootflow for the ROM (first stage) is as follows:-
 
 * BCM2711 SoC powers up
 * Read OTP to determine GPIO configuration for second stage loading.
-* If nRPIBOOT GPIO is high or OTP does not define nRPIBOOT GPIO (only defined for CM4)
-   * Check primary SD/EMMC for recovery.bin
+* If nRPIBOOT GPIO is high or OTP does not define `nRPIBOOT` GPIO (only defined for CM4)
+   * Check primary SD/EMMC for `recovery.bin`
       * Success - run `recovery.bin`
       * Fail - continue
    * Check SPI EEPROM for second stage loader
@@ -28,29 +28,30 @@ This section describes the high-level flow of the second stage bootloader.
 Please see the [bootloader configuration](../bcm2711_bootloader_config.md) page for more information about each boot-mode and the [boot folder](../../../configuration/boot_folder.md) page for a description of the GPU firmware files loaded by this stage.
 
 * Initialise clocks and SDRAM
-* Check PM_RSTS register to determine if HALT is requested
-   * If POWER_OFF_ON_HALT = 1 and WAKE_ON_GPIO = 0 then
+* Read the EEPROM configuration file
+* Check `PM_RSTS` register to determine if HALT is requested
+   * Check `POWER_OFF_ON_HALT` and `WAKE_ON_GPIO` EEPROM configuration settings.
+   * If `POWER_OFF_ON_HALT` is `1` and `WAKE_ON_GPIO` is `0` then
       * Use PMIC to power off system
    * else
-      * While GPIO3 is high OR WAKE_ON_GPIO = 1
+      * While GPIO3 is high OR `WAKE_ON_GPIO` is 1
          Sleep
-* Read the EEPROM configuration file 
 * While True
    * Read the next boot-mode from the BOOT_ORDER parameter in the EEPROM config file.
-   * If boot-mode == RESTART
-      * Jump back to the first boot-mode in the BOOT_ORDER field
-   * else if boot-mode == STOP
+   * If boot-mode == `RESTART`
+      * Jump back to the first boot-mode in the `BOOT_ORDER` field
+   * else if boot-mode == `STOP`
       * Display start.elf not found [error pattern](../../../configuration/led_blink_warnings.md) and wait forever.
-   * else if boot-mode == SD CARD
+   * else if boot-mode == `SD CARD`
       * Attempt to load firmware from the SD card
          * Success - run firmware
          * Failure - continue
-   * else if boot-mode == NETWORK
-      * If boot-mode == NETWORK then 
-         * Used DHCP to request IP address
-         * Load firmware from TFTP server
+   * else if boot-mode == `NETWORK`
+      * If boot-mode == `NETWORK` then 
+         * Use DHCP protocol to request IP address
+         * Load firmware from the DHCP or statically defined TFTP server
          * If the firmware is not found or a timeout or network error occurs then continue
-   * else if boot-mode == USB-MSD or boot-mode == USB-BCM-MSD then
+   * else if boot-mode == `USB-MSD` or boot-mode == `USB-BCM-MSD` then
       * While USB discover has not timed out 
          * Check for USB mass storage devices
          * If a new mass storage device is found then
@@ -58,6 +59,7 @@ Please see the [bootloader configuration](../bcm2711_bootloader_config.md) page 
                * Attempt to load firmware
                   * Success - run firmware
                   * Failed - advance to next LUN
-   * else if boot-mode == RPIBOOT then
-      * Attempt to load firmware using USB device mode from the USB OTG port- see [usbboot](https://github.com/raspberrypi/usbboot) There is no timeout for RPIBOOT mode.
+   * else if boot-mode == `RPIBOOT` then
+      * Attempt to load firmware using USB device mode from the USB OTG port- see [usbboot](https://github.com/raspberrypi/usbboot).
+        There is no timeout for RPIBOOT mode.
          

--- a/hardware/raspberrypi/bootmodes/bootflow_2711.md
+++ b/hardware/raspberrypi/bootmodes/bootflow_2711.md
@@ -25,7 +25,7 @@ The bootflow for the ROM (first stage) is as follows:-
 
 This section describes the high-level flow of the second stage bootloader.
 
-Please see the [bootloader configuration](bcm2711_bootloader_config.md) page for more information about each boot-mode and the [boot folder](../../configuration/boot_folder.md) page for a description of the GPU firmware files loaded by this stage.
+Please see the [bootloader configuration](../bcm2711_bootloader_config.md) page for more information about each boot-mode and the [boot folder](../../../configuration/boot_folder.md) page for a description of the GPU firmware files loaded by this stage.
 
 * Initialise clocks and SDRAM
 * Check PM_RSTS register to determine if HALT is requested
@@ -40,7 +40,7 @@ Please see the [bootloader configuration](bcm2711_bootloader_config.md) page for
    * If boot-mode == RESTART
       * Jump back to the first boot-mode in the BOOT_ORDER field
    * else if boot-mode == STOP
-      * Display start.elf not found [error pattern](../../configuration/led_blink_warnings.md) and wait forever.
+      * Display start.elf not found [error pattern](../../../configuration/led_blink_warnings.md) and wait forever.
    * else if boot-mode == SD CARD
       * Attempt to load firmware from the SD card
          * Success - run firmware


### PR DESCRIPTION
Updated for CM4 with nRPIBOOT and update the second stage boot flow to show the RESTART boot-order.

I've omitted SD_MAX_RETRIES because very few people need this in addition to the RESTART boot-mode and it made the pseudo code too big.

@lurch @JamesH65 What have I missed / is there is excessive detail that could be trimmed?