### PR TITLE
Major rewrite of UART documentation in response to issues/1754.

### DIFF
--- a/configuration/uart.md
+++ b/configuration/uart.md
@@ -55,7 +55,7 @@ dtoverlay=uart1,txd1_pin=32,rxd1_pin=33
 
 #### config.txt
 
-On most devices, adding `enable-uart=1` to `/boot/config.txt` should ensure that a UART is available on the GPIO header. On compute modules, you must also add a device-tree overlay eo enable the particular UART you want to use.
+On most devices, adding `enable-uart=1` to `/boot/config.txt` should ensure that a UART is available on the GPIO header. On compute modules, you must also add a device-tree overlay to enable the particular UART you want to use.
 
 See [config.txt](config-txt/README.md) for more information.
 
@@ -119,9 +119,9 @@ Alternatively, you can manually enable the UARTs and edit `/boot/cmdline.txt` to
 
 ## Relevant differences between PL011 and mini UART
 
-The mini UART measures time based on the CPU's core clock. If the core clock frequency is allowed to change, the mini UART's baud rate will change with it, and will not be what was intended.
+The mini UART measures time based on the VPU's core clock. If the core clock frequency is allowed to change, the mini UART's baud rate will change with it, and will not be what was intended.
 
-Therefore, using the mini UART requires configuring the Raspberry Pi to use a fixed CPU core clock frequency. There are several ways to fix the VPU core frequency. Either setting `enable_uart=1` or `core_freq=250` in `config.txt` will work.
+Therefore, using the mini UART requires configuring the Raspberry Pi to use a fixed VPU core clock frequency. There are several ways to fix the VPU core frequency. Either setting `enable_uart=1` or `core_freq=250` in `config.txt` will work.
 
 The mini UART also has smaller [FIFO buffers](https://en.wikipedia.org/wiki/Data_buffer#Telecommunication_buffer) than the PL011. Combined with the lack of flow control, this makes it more prone to losing characters at higher baud rates. It is also generally less capable than a PL011, mainly due to its baud rate link to the VPU clock speed.
 

--- a/configuration/uart.md
+++ b/configuration/uart.md
@@ -19,7 +19,7 @@ The naming and numbering of the UARTs can be confusing because they use differen
 
 Inside the Raspberry Pi, the UARTs are able to connect in several ways. UART0 and UART1 can connect to either the GPIO header, or the onboard Bluetooth module, if there is one. UARTs two through five can be enabled and disabled, but have no alternate connections.
 
-See the [Raspberry Pi 4 Model B Datasheet](https://www.raspberrypi.org/documentation/hardware/raspberrypi/bcm2711/rpi_DATA_2711_1p0_preliminary.pdf) section _5.1.2 GPIO Alternate Functions_, for pinout details. Earlier models are similar but with only the first two UARTs.
+See the [Raspberry Pi 4 Model B Datasheet](../hardware/raspberrypi/bcm2711/rpi_DATA_2711_1p0_preliminary.pdf) section _5.1.2 GPIO Alternate Functions_, for pinout details. Earlier models are similar but with only the first two UARTs.
 
 ### Voltages
 

--- a/configuration/uart.md
+++ b/configuration/uart.md
@@ -1,18 +1,14 @@
 # UART configuration
 
-A [UART](https://en.wikipedia.org/wiki/Universal_asynchronous_receiver-transmitter) is a serial communication device which uses one or more signal wires and a common ground to transmit and receive data between two devices. When computer people talk about 'serial ports', they usually mean UARTs. People from DOS/Windows background may know these as 'COM ports'.
-
 ## Hardware
 
-On all Raspberry Pi computers except microcontrollers, there are at least two UARTs built into the [SoC](https://en.wikipedia.org/wiki/System_on_a_chip). The Raspberry Pi 4 family has six UARTs.
+All Raspberry Pi computers have at least two UARTs. The Raspberry Pi 4 family (BCM2711) has six UARTs.
 
-There are also two different types of UART devices available on the Raspberry Pi:
-* [PL011](http://infocenter.arm.com/help/index.jsp?topic=/com.arm.doc.ddi0183g/index.html) part of the ARM spec and is patterned on the full-featured [16550 UART](https://en.wikipedia.org/wiki/16550_UART) chip.
-* mini UART is patterned on the slightly older and less full-featured [8250 UART](https://en.wikipedia.org/wiki/8250_UART) chip.
+There are two different types of UART devices available on the Raspberry Pi:
+* [PL011](http://infocenter.arm.com/help/index.jsp?topic=/com.arm.doc.ddi0183g/index.html), patterned on the [16550 UART](https://en.wikipedia.org/wiki/16550_UART) chip.
+* mini UART, patterned on the [8250 UART](https://en.wikipedia.org/wiki/8250_UART) chip.
 
-The naming/numbering of the UARTs can be confusing because they are listed one way in the Broadcom SoC documentation, and another way in Linux. Depending on the board features and configuration, either of the first two UARTs may appear on the same pins in the GPIO header, so you they aren't uniquely described by their locations either.
-
-Broadcom gives each UART a name and number in their SoC documentation, and this is a good starting point.
+The naming and numbering of the UARTs can be confusing because they use different names and numbers in different contexts. These names from Broadcom are authoritative:
 
 | SoC | UART0 | UART1 | UART2 | UART3 | UART4 | UART5 |
 | --- | --- | --- | --- | --- | --- | --- |
@@ -21,23 +17,21 @@ Broadcom gives each UART a name and number in their SoC documentation, and this 
 | BCM2837 | PL011 | mini UART |
 | BCM2711 | PL011 | mini UART | PL011 | PL011 | PL011 | PL011 |
 
- See the [Raspberry Pi 4 Model B Datasheet](https://www.raspberrypi.org/documentation/hardware/raspberrypi/bcm2711/rpi_DATA_2711_1p0_preliminary.pdf) section _5.1.2 GPIO Alternate Functions_, for details on exactly which UART can appear on which GPIO numbers. Earlier models are similar, but have only the first two UARTs. Take care to line up the numbers: TXD0 and RXD0 always belong to UART0, TXD1 to UART1 and so on. Also, remember that the GPIO numbering is on the CPU, and is different than the GPIO pin numbers on the 40-pin J8 header.
+Inside the Raspberry Pi, the UARTs are able to connect in several ways. UART0 and UART1 can connect to either the GPIO lines, or the onboard Bluetooth module, if there is one. UARTs two through five connect to the GPIO lines and nowhere else.
 
-Inside the Raspberry Pi, the UARTs are able to connect in several ways. UART0 and UART1 can connect to either the GPIO lines or the onboard Bluetooth module, if there is one. UARTs two through five connect to the GPIO lines and nowhere else.
+See the [Raspberry Pi 4 Model B Datasheet](https://www.raspberrypi.org/documentation/hardware/raspberrypi/bcm2711/rpi_DATA_2711_1p0_preliminary.pdf) section _5.1.2 GPIO Alternate Functions_, for pinout details. Earlier models are similar but with only the first two UARTs.
 
 ### Voltages
 
-All the onboard Raspberry Pi UARTs are 3.3V [logic level](https://en.wikipedia.org/wiki/Logic_level) only, sometimes called ['CMOS'](https://en.wikipedia.org/wiki/CMOS) level. Do not connect Raspberry Pi UARTs to 5V circuits, sometimes called ['TTL'](https://en.wikipedia.org/wiki/Transistor%E2%80%93transistor_logic) level, because the Raspberry Pi will be damaged. [RS-232](https://en.wikipedia.org/wiki/RS-232) uses +/- 12V signals, which are right out.
-
-There are chips called ['level shifters'](https://en.wikipedia.org/wiki/Level_shifter) which convert voltages between levels. You can find them either as individual ICs for using in your own designs, or integrated into other devices to make them compatible. They're inexpensive and readily available from third parties.
+All the onboard Raspberry Pi UARTs are 3.3V ([CMOS](https://en.wikipedia.org/wiki/CMOS) [logic level](https://en.wikipedia.org/wiki/Logic_level)). Do not connect Raspberry Pi UARTs to 5V ([TTL logic level](https://en.wikipedia.org/wiki/Transistor%E2%80%93transistor_logic)) circuits, because the Raspberry Pi will be damaged. [Level shifters](https://en.wikipedia.org/wiki/Level_shifter) are inexpensive and readily available.
 
 ## Software support
 
-Raspberry Pi OS has built-in drivers for the UARTs built into the SoC, and common external types as well.
+Raspberry Pi OS ships with drivers for the onboard UARTs.
 
-The PL011 devices will appear as [character devices](https://en.wikipedia.org/wiki/Device_file#Character_devices) with names like `/dev/ttyAMA*`. If there are multiple PL011s, they're in the same _order_ as the Broadcom documentation, but not necessarily the same _number_. The mini UART always appears as character device named `/dev/ttyS0`, and there is never more than one. If you want to be specific about which hardware type you're using, use the `/dev/ttyAMA*` and `/dev/ttyS0` names.
+PL011s appear as [character devices](https://en.wikipedia.org/wiki/Device_file#Character_devices) `/dev/ttyAMA*`. If there are multiple PL011s, they're in the same _order_ as the Broadcom documentation, but not necessarily the same _number_. The mini UART always appears as `/dev/ttyS0`. If you want to be specific about hardware types, use the `/dev/ttyAMA*` and `/dev/ttyS0` names.
 
-There are also be symbolic links with names like `/dev/serial*`. If a UART is enabled and configured to appear on pins 8 and 10 of the GPIO header, `/dev/serial0` will link to that UART. If a UART is enabled and configured to connect to the onboard Bluetooth module, `/dev/serial1` links to that one. If you want to be specific about where a UART is connected, use the `/dev/serial*` names.
+There are also be symbolic links: `/dev/serial*`. If a UART is enabled and connected to pins 8 and 10 of the GPIO header, `/dev/serial0` will link to that UART. If a UART is enabled and connected to the onboard Bluetooth module, `/dev/serial1` links to that one. If you want to be specific about a UART connection, use the `/dev/serial*` names.
 
 The Linux device management system chooses which hardware UARTs are connected to the GPIO pins and creates the `/dev/serial*` symlinks. By default, if there is an onboard Bluetooth module, it gets UART0 and the GPIO header gets UART1. If there is no Bluetooth, the GPIO header gets UART0. This behavior is configurable and can be changed with device tree overlays.
 
@@ -45,7 +39,11 @@ The Linux device management system chooses which hardware UARTs are connected to
 
 ### Configuring the hardware
 
-There are several ways to configure the UART hardware.
+On most devices, only UART0 is enabled by default. On compute modules, the UARTs are all disabled by default and must be explicitly enabled using a device tree overlay. You must also specify which GPIO pins to use for the interface, for example:
+
+```
+dtoverlay=uart1,txd1_pin=32,rxd1_pin=33
+```
 
 #### raspi-config
 
@@ -57,7 +55,7 @@ There are several ways to configure the UART hardware.
 
 #### config.txt
 
-Adding `enable-uart=1` to `/boot/config.txt` should be enough to enable the first two UART ports.
+On most devices, adding `enable-uart=1` to `/boot/config.txt` should be enough to enable the first two UART ports. On compute modules, you must also add a device-tree overlay eo enable the particular UART you want to use.
 
 See [config.txt](config-txt/README.md) for more information.
 
@@ -67,9 +65,7 @@ Device tree overlays are also typically added in `/boot/config.txt` with lines l
 ```
 dtoverlay=disable-bt
 ```
-However, device overlays are defined in the open-source [Linux source code](https://github.com/raspberrypi/linux). By contrast, the options available in config.txt are defined by the closed-source bootloader from Raspberry Pi and Broadcom. For full instructions on how to use Device Tree overlays see [this page](device-tree.md). Note that the `-overlay.dts` part of the filenames are removed.
-
-You can list the available device-tree overlays by running `dtoverlay -a`. Refer to `/boot/overlays/README` for details on Device Tree overlays, or run `dtoverlay -h overlay-name` for descriptions and usage information.
+However, device overlays are defined in the open-source [Linux source code](https://github.com/raspberrypi/linux). See [this page](device-tree.md). for further detail.
 
 These device-tree overlays are of interest:
 
@@ -77,8 +73,8 @@ These device-tree overlays are of interest:
 |---|---|
 | disable-bt | Disable onboard Bluetooth, making UART0 available. |
 | miniuart-bt | Switch the onboard Bluetooth to UART1, making UART0 available. |
-| uart0 | Change the pin usage of UART0 |
-| uart1 | Change the pin usage of UART1 |
+| uart0 | Enable and set the pin usage of UART0 |
+| uart1 | Enable and set the pin usage of UART1 |
 | uart2 | Enable UART2 |
 | uart3 | Enable UART3 |
 | uart4 | Enable UART4 |
@@ -86,9 +82,9 @@ These device-tree overlays are of interest:
 
 ### Serial console
 
-If configured, Raspberry Pi OS can present a login prompt and some system messages on `/dev/serial0` and the related GPIO header pins, 8 and 10. This arrangement is called a ['serial console'](https://en.wikipedia.org/wiki/System_console) and is a traditional way to access a computer that may not have its own human-interface hardware such as a keyboard, monitor, etc. For example, many network servers have serial consoles.
+Raspberry Pi OS can present a [serial console](https://en.wikipedia.org/wiki/System_console) on `/dev/serial0` and the related GPIO header pins, 8 and 10.
 
-The serial console can be enabled and disabled by answering "Yes" to raspi-config's prompt: `Would you like a login shell to be accessible over serial?`
+The serial console can be enabled by answering "Yes" to raspi-config's prompt: `Would you like a login shell to be accessible over serial?`
 
 #### Enabling early console (earlycon) for Linux
 
@@ -114,31 +110,16 @@ N.B. Selecting the wrong early console can prevent the Pi from booting.
 
 ### Raspberry Pi as terminal
 
-A device you use to login to a serial console is called a ['terminal'](https://en.wikipedia.org/wiki/Computer_terminal). A Raspberry Pi can also act as a terminal, so you can actually login from one Raspberry Pi to another with just a few wires and no network! You just need to connect the two devices' grounds together, and then connect one's TXD to the other's RXD, and vice versa. No resistors or other special hardware are required.
+A Raspberry Pi can also act as a serial terminal, which can be used to connect to another device's serial console. You'll need to disable the terminal's serial console so that the serial console and terminal program won't conflict with each other.
 
-Regardless of whether you're connecting to another Raspberry Pi or some other device, if you're going to use your Raspberry Pi as a terminal, you'll need to disable its serial console. Otherwise, your Raspberry Pi's own serial console will conflict with the terminal program.
+To use a Raspberry Pi as a serial terminal, you can use `sudo raspi-config`, answering 'No' to the question: `Would you like a login shell to be accessible over serial?` and 'Yes' to `Would you like the serial port hardware to be enabled?`
 
-`sudo raspi-config` disables the serial console but leaves the serial port enabled if you answer 'No' to the question: `Would you like a login shell to be accessible over serial?` and 'Yes' to `Would you like the serial port hardware to be enabled?`
+Alternatively, you can also manually enable the UARTs and edit `/boot/cmdline.txt` to remove the portion like `console=serial0,115200`.
 
-You can also manually edit `/boot/cmdline.txt` and remove the portion like `console=serial0,115200`. Don't mess with the part that says `console=tty1`－that says to output system messages to the video output.
-
-Regardless of which method you use, you will need to be root or use `sudo` to change the settings, and reboot to let the changes take effect.
-
-There are a few programs that can open the serial port for you. These are called  ['terminal emulators'](https://en.wikipedia.org/wiki/Computer_terminal#Emulation). A simple one is called 'screen'.
-
-To install screen, run:
-```shell
-sudo apt update
-sudo apt install screen
-```
-
-With screen installed, you can run `screen /dev/serial0` to open the serial port. `CTRL-C` doesn't kill the terminal program, as it does most other programs. If it did, when you tried to kill a program on the remote computer, you'd accidentally kill your connection instead. So screen passes `CTRL-C` on to the remote computer. To close the connection and quit screen, press `CTRL-A` and then `k` (for kill) and confirm with `y`. For help, press `CTRL-A ?`.
-
-N.B: screen and any other terminal emulator show only the data that comes in through the UART. Therefore, the screen will be blank if there's no one on the other end of the line, or if they haven't transmitted anything.
 
 ## Relevant differences between PL011 and mini UART
 
-UARTs work by raising and lowering voltages with very precise timing, called the 'baud rate'. The mini UART measures time based on the CPU's core clock. If the core clock frequency is allowed to change, the mini UART's baud rate will change with it, and will not be what was intended.
+The mini UART measures time based on the CPU's core clock. If the core clock frequency is allowed to change, the mini UART's baud rate will change with it, and will not be what was intended.
 
 Therefore, using the mini UART requires configuring the Raspberry Pi to use a fixed CPU core clock frequency. There are several ways to fix the VPU core frequency. Either setting `enable_uart=1` or `core_freq=250` in `config.txt` will work.
 


### PR DESCRIPTION
Like it says, this is a major rewrite of the UART documentation. Nominally, this is because of /https://github.com/raspberrypi/documentation/issues/1754. But also, I found this documentation confusing when I needed it a couple weeks ago, so I gave a shot at fixing the whole thing.

I got rid of the terminology of "primary" and "secondary" devices, which seemed to appear only in this doc, not in Broadcom's docs or others. Instead, I attempted to consistently refer to hardware devices by their canonical hardware names: UART0, etc. When discussing the serial port on the GPIO header, I referred to it as `/dev/serial0`, because that's how it will appear to the reader in Linux.

As you review this, please look first at the structure and clarity for the expected audience. Does this meet the reader's need? My intent was to give:
* a brief introduction to what a UART is in general, and relate it to other things they may know
* then to discuss the UARTs present in Raspberry Pi devices
* then to discuss applications and other how-to instructions

Once we've settled on the structure, I think we need to look at the accuracy of the information. This is a big change and it contains many assertions of fact. I've attempted to validate them against reality. You can see my methodology and data at https://github.com/michaelstoops/documentation/blob/1754-testing/configuration/uart-testing.md. It should be easy to reproduce if you have the appropriate tools.

Lastly, let's look at minor issues of style: formatting and the like. I had to decide which things to 'quote' and which to mark as `inline code`, which I don't think is quite clear in the style guide. I gave a reasonable attempt, but I also edited and re-edited a lot, so I'm not sure they're all consistent in the end.

Your feedback is welcome.