### PR TITLE
Update msd.md

### DIFF
--- a/hardware/raspberrypi/bootmodes/msd.md
+++ b/hardware/raspberrypi/bootmodes/msd.md
@@ -4,9 +4,9 @@
 
 This page explains how to boot your Raspberry Pi from a USB mass storage device such as a flash drive or a USB hard disk. When attaching USB devices, particularly hard disks and SSDs, be mindful of their power requirements. If you wish to attach more than one SSD or hard disk to the Pi, this normally requires external power - either a powered hard disk enclosure, or a powered USB hub. Note that models prior to the Pi 4B have known issues which prevent booting with some USB devices.
 
-<a name="pi400"></a><a name="pi4"></a><a name="cm4"></a>
+<a name="pi400"></a><a name="pi4"></a>
 ## Raspberry Pi 4B and Raspberry Pi 400
-The Raspberry Pi Pi 400 and newer Raspberry Pi 4B boards support USB boot by default. On earlier Pi4B boards, or to select alternate boot modes, the bootloader must be updated.
+The Raspberry Pi Pi 400 and newer Raspberry Pi 4B boards support USB boot by default. On earlier Raspberry Pi 4B boards, or to select alternate boot modes, the bootloader must be updated.
 
 ### Using Raspberry Pi Imager to update the bootloader (recommended)
 Raspberry Pi Imager provides a GUI for updating the bootloader
@@ -17,10 +17,10 @@ Raspberry Pi Imager provides a GUI for updating the bootloader
 4. Select `Misc utility images` under `Operating System`
 5. Select `Bootloader`
 6. Select `USB`
-7. Select `SD card` and then `Write`
+7. Select Store and then Write
 
 ### Using raspi-config to update the bootloader from within Raspberry Pi OS
-To change the boot-mode or bootloader version from within Raspberry Pi OS run [raspi-config](../../configuration/raspi-config.md)
+To change the boot-mode from within Raspberry Pi OS run [raspi-config](../../configuration/raspi-config.md)
 
 1. Run `sudo raspi-config`
 2. Select `Advanced Options`
@@ -32,6 +32,7 @@ See also:-
 * The [bootloader configuration](../bcm2711_bootloader_config.md) page for other boot configuration options
 * The [bootloader EEPROM](../booteeprom.md) page for more information 
 
+<a name="cm4"></a>
 ## Compute Module 4
 Please see the [Flashing the Compute Module eMMC](../../computemodule/cm-emmc-flashing.md) for bootloader update instructions.
 

--- a/hardware/raspberrypi/bootmodes/msd.md
+++ b/hardware/raspberrypi/bootmodes/msd.md
@@ -20,7 +20,7 @@ Raspberry Pi Imager provides a GUI for updating the bootloader
 7. Select Storage and then Write
 
 ### Using raspi-config to update the bootloader from within Raspberry Pi OS
-To change the boot-mode from within Raspberry Pi OS run [raspi-config](../../configuration/raspi-config.md)
+To change the boot-mode from within Raspberry Pi OS run [raspi-config](../../../configuration/raspi-config.md)
 
 1. Run `sudo raspi-config`
 2. Select `Advanced Options`

--- a/hardware/raspberrypi/bootmodes/msd.md
+++ b/hardware/raspberrypi/bootmodes/msd.md
@@ -4,35 +4,36 @@
 
 This page explains how to boot your Raspberry Pi from a USB mass storage device such as a flash drive or a USB hard disk. When attaching USB devices, particularly hard disks and SSDs, be mindful of their power requirements. If you wish to attach more than one SSD or hard disk to the Pi, this normally requires external power - either a powered hard disk enclosure, or a powered USB hub. Note that models prior to the Pi 4B have known issues which prevent booting with some USB devices.
 
-<a name="pi400"></a>
-## Raspberry Pi 400
-To boot the Pi 400 from a USB mass storage device, simply image the USB drive with Raspberry Pi OS 2020-08-20 or newer using the Raspberry Pi Imager utility: select the USB drive from the `SD Card` list in Raspberry Pi Imager.
+<a name="pi400"></a><a name="pi4"></a><a name="cm4"></a>
+## Raspberry Pi 4B and Raspberry Pi 400
+The Raspberry Pi Pi 400 and newer Raspberry Pi 4B boards support USB boot by default. On earlier Pi4B boards, or to select alternate boot modes, the bootloader must be updated.
 
-<a name="pi4"></a>
-## Raspberry Pi 4B
-Depending on when your Raspberry Pi 4B was manufactured, the bootloader EEPROM may need to be updated to enable booting from USB mass storage devices. 
+### Using Raspberry Pi Imager to update the bootloader (recommended)
+Raspberry Pi Imager provides a GUI for updating the bootloader
 
-### Check if your Pi 4B has the required bootloader EEPROM version
+1. Download [Raspberry Pi Imager](https://www.raspberrypi.org/downloads/)
+2. Select a spare SD card. The contents will get overwritten!
+3. Launch `Raspberry Pi Imager`
+4. Select `Misc utility images` under `Operating System`
+5. Select `Bootloader`
+6. Select `USB`
+7. Select `SD card` and then `Write`
 
-To check if your Pi 4B has the required bootloader EEPROM version, power it up with no SD card inserted and a display attached to one of the HDMI ports. The Pi 4B will display a diagnostic screen on the attached display, which includes the bootloader EEPROM version at the top of the screen. The bootloader must be dated `Sep 3 2020` or later to support USB mass storage boot. If the diagnostic screen reports a date earlier than `Sep 3 2020`, or there is no diagnostic screen shown, you will need to update the bootloader EEPROM first to enable USB mass storage boot.
+### Using raspi-config to update the bootloader from within Raspberry Pi OS
+To change the boot-mode or bootloader version from within Raspberry Pi OS run [raspi-config](../../configuration/raspi-config.md)
 
-USB mass storage boot on the Pi 4B requires Raspberry Pi OS 2020-08-20 or later.
+1. Run `sudo raspi-config`
+2. Select `Advanced Options`
+3. Select `Boot Order`
+4. Select `USB`
+5. Reboot
 
+See also:-
+* The [bootloader configuration](../bcm2711_bootloader_config.md) page for other boot configuration options
+* The [bootloader EEPROM](../booteeprom.md) page for more information 
 
-### Enable USB mass storage boot on a Pi 4B by updating the bootloader EEPROM
-If your Pi 4B requires an updated bootloader EEPROM in order to support USB mass storage boot, you can perform the update as follows:
-
-1. Use the "Misc Utility Images" option in [Raspberry Pi Imager](https://www.raspberrypi.org/downloads/) to create an SD card with the latest "Raspberry Pi 4 EEPROM boot recovery" image.
-1. Boot the Pi 4B using this SD card.
-1. The bootloader EEPROM will be updated to the latest factory version, then the Pi will flash its green ACT light rapidly, and display green on the HDMI outputs to indicate success.
-
-The Pi 4B can now be booted from a USB mass storage device.
-
-## Changing boot order on Pi 4B and Pi 400
-
-The [raspi-config](../../../configuration/raspi-config.md) utility can be used to choose between SD/USB (default) or SD/Network boot modes.
-
-The full set of boot mode options is documented on the [bootloader configuration](../bcm2711_bootloader_config.md) page.
+## Compute Module 4
+Please see the [Flashing the Compute Module eMMC](../../computemodule/cm-emmc-flashing.md) for bootloader update instructions.
 
 ## Raspberry Pi 3B+
 

--- a/hardware/raspberrypi/bootmodes/msd.md
+++ b/hardware/raspberrypi/bootmodes/msd.md
@@ -17,7 +17,7 @@ Raspberry Pi Imager provides a GUI for updating the bootloader
 4. Select `Misc utility images` under `Operating System`
 5. Select `Bootloader`
 6. Select `USB`
-7. Select Store and then Write
+7. Select Storage and then Write
 
 ### Using raspi-config to update the bootloader from within Raspberry Pi OS
 To change the boot-mode from within Raspberry Pi OS run [raspi-config](../../configuration/raspi-config.md)


### PR DESCRIPTION
The MSD boot page should describe the simplest approach for enabling USB boot. Replace the BCM2711 sections with a snippet from the simplified bootloader_config page and provide links to the full instructions.
The Raspberry Pi Imager approach will work regardless of the current EEPROM config, anyone who has manually tweaked the EEPROM config doesn't need this page.