### PR TITLE
Update mac.md

### DIFF
--- a/installation/installing-images/mac.md
+++ b/installation/installing-images/mac.md
@@ -61,7 +61,7 @@ If you specify the wrong device in the instructions, you could overwrite your pr
 - Copy the image
 
   ```bash
-  sudo dd bs=1m if=path_of_your_image.img of=/dev/rdiskN; sync
+  sudo dd bs=1m of=path_of_your_image.img if=/dev/rdiskN; sync
   ```
 
    Replace `N` with the number that you noted before. Note the ```rdisk``` ('raw disk')


### PR DESCRIPTION
The usage of "if" and "of" command line switches for dd utility command on MAC was listed backwards. I have corrected that.

 if=file  Read input from file instead of the standard input
of=file  Write output to file instead of the standard output.