### PR TITLE
Fix note about uncompressed arm64 images

### DIFF
--- a/configuration/config-txt/boot.md
+++ b/configuration/config-txt/boot.md
@@ -39,7 +39,7 @@ Set the `disable_commandline_tags` command to `1` to stop `start.elf` from filli
 
 ## arm_64bit
 
-If set to non-zero, forces the kernel loading system to assume a 64-bit kernel, starts the processors up in 64-bit mode, and sets `kernel8.img` to be the kernel image loaded, unless there is an explicit `kernel` option defined in which case that is used instead. Defaults to 0 on all platforms. **NOTE**: 64-bit kernels must be uncompressed image files.
+If set to non-zero, forces the kernel loading system to assume a 64-bit kernel, starts the processors up in 64-bit mode, and sets `kernel8.img` to be the kernel image loaded, unless there is an explicit `kernel` option defined in which case that is used instead. Defaults to 0 on all platforms. **NOTE**: 64-bit kernels may be uncompressed image files or a gzip archive of an image (which can still be called kernel8.img; the bootloader will recognize the archive from the signature bytes at the beginning).
 
 Note that the 64-bit kernel will only work on the Pi4, Pi3, and Pi2B rev1.2 boards with latest firmware.
 


### PR DESCRIPTION
The Pi's built-in bootloader gained the ability to unpack gzip'd kernel images in Dec 2020 (I think? Sometime around then anyway); in fact, this is what raspios is currently using for kernel8.img.