### PR TITLE
Restructure EEPROM documentation

### DIFF
--- a/hardware/raspberrypi/bcm2711_bootloader_config.md
+++ b/hardware/raspberrypi/bcm2711_bootloader_config.md
@@ -14,96 +14,109 @@ Please see the [boot EEPROM](booteeprom.md) page for more information about the 
 ## Configuration properties
 This section describes all the configuration items available in the bootloader. The syntax is the same as [config.txt](../../configuration/config-txt/) but the properties are specific to the bootloader. [Conditional filters](../../configuration/config-txt/conditional.md) are also supported except for EDID.
 
+<a name="BOOT_UART"></a>
 ### BOOT_UART
 
 If `1` then enable UART debug output on GPIO 14 and 15. Configure the receiving debug terminal at 115200bps, 8 bits, no parity bits, 1 stop bit.
 
 Default: `0`  
 
+<a name="WAKE_ON_GPIO"></a>
 ### WAKE_ON_GPIO
 
 If `1` then `sudo halt` will run in a lower power mode until either GPIO3 or GLOBAL_EN are shorted to ground.
 
 Default: `1` (`0` in original version of bootloader 2019-05-10)  
 
+<a name="POWER_OFF_ON_HALT"></a>
 ### POWER_OFF_ON_HALT
 
-If `1` and `WAKE_ON_GPIO=0` then `sudo halt` will switch off all PMIC outputs. This is lowest possible power state for halt but may cause problems with some HATs because 5V will still be on. GLOBAL_EN must be shorted to ground to boot.
+If `1` and `WAKE_ON_GPIO=0` then `sudo halt` will switch off all PMIC outputs. This is lowest possible power state for halt but may cause problems with some HATs because 5V will still be on. `GLOBAL_EN` must be shorted to ground to boot.
 
 Pi 400 has a dedicated power button which operates even if the processor is switched off. This behaviour is enabled by default, however, `WAKE_ON_GPIO=2` may be set to use an external GPIO power button instead of the dedicated power button.
 
 Default: `0`  
 
+<a name="BOOT_ORDER"></a>
 ### BOOT_ORDER
-The `BOOT_ORDER` setting allows flexible configuration for the priority of different bootmodes. It is represented as 32bit unsigned integer where each nibble represents a bootmode. The bootmodes are attempted in lowest significant nibble to highest significant nibble order.
+The `BOOT_ORDER` setting allows flexible configuration for the priority of different boot modes. It is represented as 32bit unsigned integer where each nibble represents a boot mode. The boot modes are attempted in lowest significant nibble to highest significant nibble order.
 
-E.g.`0xf41` means continuously trying SD card followed by USB mass storage. Whereas, `0xf12` means continuously trying network boot followed by SD card boot. 
-The retry counters are reset when switching to the next boot mode.
+The minimum supported bootloader version for custom boot modes is 2020-09-03.
 
-`BOOT_ORDER` fields  
+##### `BOOT_ORDER` fields
 The BOOT_ORDER property defines the sequence for the different boot modes. It is read right to left and up to 8 digits may be defined.
 
-| Value | Mode         | Description                                                                                       |
-|-------|--------------|---------------------------------------------------------------------------------------------------|
-|  0x1  |  SD CARD     |  SD card (or eMMC on Compute Module 4)                                                            |
-|  0x2  |  NETWORK     |  Network boot                                                                                     |
-|  0x3  |  RPIBOOT     |  RPIBOOT -  See [usbboot](https://github.com/raspberrypi/usbboot)  (since 2020-09-03)             |
-|  0x4  |  USB-MSD     |  USB mass storage boot (since 2020-09-03)                                                         |
-|  0x5  |  BCM-USB-MSD |  USB 2.0 boot from USB Type-C socket or USB Type-A socket on CM4 IO board.     (since 2020-12-14) |
-|  0x6  |  NVME        |  Boot from an NVMe SSD connected to the PCIe socket (CM4 only). See [NVMe boot](bootmodes/nvme.md) for more details
-|  0xe  |  STOP        |  Stop and display error pattern (since 2020-09-03). A power cycle is required to exit this state. |
-|  0xf  |  RESTART     |  Start again with the first boot order field. (since 2020-09-03)                                  |
+| Value | Mode            | Description                                                                                                              |
+|-------|-----------------|--------------------------------------------------------------------------------------------------------------------------|
+|  0x0  |  SD CARD DETECT |  Try SD then wait for card-detect to indicate that the card has changed - deprecated now that 0xf (RESTART) is available.|
+|  0x1  |  SD CARD        |  SD card (or eMMC on Compute Module 4).                                                                                  |
+|  0x2  |  NETWORK        |  Network boot - See [Network boot server tutorial](bootmodes/net_tutorial.md)                                            |
+|  0x3  |  RPIBOOT        |  RPIBOOT - See [usbboot](https://github.com/raspberrypi/usbboot)                                                         |
+|  0x4  |  USB-MSD        |  USB mass storage boot - See [USB mass storage boot](bootmodes/msd.md)                                                   |
+|  0x5  |  BCM-USB-MSD    |  USB 2.0 boot from USB Type-C socket or USB Type-A socket on CM4 IO board.     (since 2020-12-14)                        |
+|  0x6  |  NVME           |  Boot from an NVMe SSD connected to the PCIe socket (CM4 only). See [NVMe boot](bootmodes/nvme.md) for more details.     |
+|  0xe  |  STOP           |  Stop and display error pattern. A power cycle is required to exit this state.                                           |
+|  0xf  |  RESTART        |  Restart from the first boot-mode in the BOOT_ORDER field i.e. loop                                                      |
 
-After trying each non-zero boot mode the bootloader stops. However, from 2020-09-03 the bootloader will monitor the SD card detect pin and try SD boot if a new SD card is inserted.
+`RPIBOOT` is intended for use with Compute Module 4 to load a custom debug image (e.g. a Linux RAM-disk) instead of the normal boot. This should be the last boot option because it does not currently support timeouts or retries.
 
-Default: `0xf41`  
+##### `BOOT_ORDER` examples
 
-* Boot mode `0x0` will retry the SD boot if the SD card detect pin indicates that the card has been inserted or replaced.
-* The default boot order is `0xf41` which means continuously try SD then USB mass storage.
-* `RPIBOOT` is intended for use with Compute Module 4 to load a custom debug image (e.g. a Linux RAM-disk) instead of the normal boot. This should be the last boot option because it does not currently support timeouts or retries.
-* `BCM-USB-MSD` boot allows a Compute Module 4 to boot from USB without requiring an additional PCIe XHCI card. This USB controller does not support USB 3.0 and booting will be slower than `USB-MSD` boot on a Pi 4 or Pi 400.
+| BOOT_ORDER | Description                                                                    |
+| -----------|--------------------------------------------------------------------------------|
+| 0xf41      | Try SD first, followed by USB-MSD then repeat (default if BOOT_ORDER is empty) |
+| 0xf14      | Try USB first, followed by SD then repeat                                      |
+| 0xf21      | Try SD first, followed by NETWORK then repeat                                  |
 
+<a name="MAX_RESTARTS"></a>
 ### MAX_RESTARTS
 If the RESTART (`0xf`) boot mode is encountered more than MAX_RESTARTS times then a watchdog reset is triggered. This isn't recommended for general use but may be useful for test or remote systems where a full reset is needed to resolve issues with hardware or network interfaces.
 
 Default: `-1` (infinite)  
 
+<a name="SD_BOOT_MAX_RETRIES"></a>
 ### SD_BOOT_MAX_RETRIES
 The number of times that SD boot will be retried after failure before moving to the next boot mode defined by `BOOT_ORDER`.  
 `-1` means infinite retries.
 
 Default: `0`  
 
+<a name="NET_BOOT_MAX_RETRIES"></a>
 ### NET_BOOT_MAX_RETRIES
 The number of times that network boot will be retried after failure before moving to the next boot mode defined by `BOOT_ORDER`.  
 `-1` means infinite retries.
 
 Default: `0`  
 
+<a name="DHCP_TIMEOUT"></a>
 ### DHCP_TIMEOUT
 The timeout in milliseconds for the entire DHCP sequence before failing the current iteration.
 
 Minimum: `5000`  
 Default: `45000`  
 
+<a name="DHCP_REQ_TIMEOUT"></a>
 ### DHCP_REQ_TIMEOUT
 The timeout in milliseconds before retrying DHCP DISCOVER or DHCP REQ.
 
 Minimum: `500`  
 Default: `4000`  
 
+<a name="TFTP_FILE_TIMEOUT"></a>
 ### TFTP_FILE_TIMEOUT
 The timeout in milliseconds for an individual file download via TFTP.
 
 Minimum: `5000`  
 Default: `30000`  
 
+<a name="TFTP_IP"></a>
 ### TFTP_IP
 Optional dotted decimal ip address (e.g. `192.168.1.99`) for the TFTP server which overrides the server-ip from the DHCP request.  
 This may be useful on home networks because tftpd-hpa can be used instead of dnsmasq where broadband router is the DHCP server.
 
 Default: ""  
 
+<a name="TFTP_PREFIX"></a>
 ### TFTP_PREFIX
 In order to support unique TFTP boot directories for each Pi the bootloader prefixes the filenames with a device specific directory. If neither start4.elf nor start.elf are found in the prefixed directory then the prefix is cleared.
 On earlier models the serial number is used as the prefix, however, on Pi 4 the MAC address is no longer generated from the serial number making it difficult to automatically create tftpboot directories on the server by inspecting DHCPDISCOVER packets. To support this the TFTP_PREFIX may be customized to either be the MAC address, a fixed value or the serial number (default).
@@ -116,17 +129,20 @@ On earlier models the serial number is used as the prefix, however, on Pi 4 the 
 
 Default: 0  
 
+<a name="TFTP_PREFIX_STR"></a>
 ### TFTP_PREFIX_STR
 Specify the custom directory prefix string used when `TFTP_PREFIX` is set to 1. For example:- `TFTP_PREFIX_STR=tftp_test/`
 
 Default: ""  
 Max length: 32 characters  
 
+<a name="PXE_OPTION43"></a>
 ### PXE_OPTION43
 Overrides the PXE Option43 match string with a different string. It's normally better to apply customisations to the DHCP server than change the client behaviour but this option is provided in case that's not possible.
 
 Default: `Raspberry Pi Boot`  
 
+<a name="DHCP_OPTION97"></a>
 ### DHCP_OPTION97
 In earlier releases the client GUID (Option97) was just the serial number repeated 4 times. By default, the new GUID format is
 the concatenation of the fourcc for RPi4 (0x34695052 - little endian), the board revision (e.g. 0x00c03111) (4-bytes), the least significant 4 bytes of the mac address and the 4-byte serial number.
@@ -139,36 +155,43 @@ Default: `0x34695052`
 ### Static IP address configuration
 If TFTP_IP and the following options are set then DHCP is skipped and the static IP configuration is applied. If the TFTP server is on the same subnet as the client then GATEWAY may be omitted.
 
+<a name="CLIENT_IP"></a>
 #### CLIENT_IP
 The IP address of the client e.g. `192.168.0.32`
 
 Default: ""  
 
+<a name="SUBNET"></a>
 #### SUBNET
 The subnet address mask e.g. `255.255.255.0`
 
 Default: ""  
 
+<a name="GATEWAY"></a>
 #### GATEWAY
 The gateway address to use if the TFTP server is on a differenet subnet e.g. `192.168.0.1`
 
 Default: ""  
 
+<a name="MAC_ADDRESS"></a>
 #### MAC_ADDRESS
 Overrides the Ethernet MAC address with the given value. e.g. `dc:a6:32:01:36:c2`
 
 Default: ""  
 
+<a name="DISABLE_HDMI"></a>
 ### DISABLE_HDMI
 The [HDMI boot diagnostics](./boot_diagnostics.md) display is disabled if `DISABLE_HDMI=1`. Other non-zero values are reserved for future use.
 
 Default: `0`  
 
+<a name="HDMI_DELAY"></a>
 ### HDMI_DELAY
 Skip rendering of the HDMI diagnostics display for up to N seconds (default 5) unless a fatal error occurs. The default behaviour is designed to avoid the bootloader diagnostics screen from briefly appearing during a normal SD / USB boot.
 
 Default: `5`  
 
+<a name="ENABLE_SELF_UPDATE"></a>
 ### ENABLE_SELF_UPDATE
 Enables the bootloader to update itself from a TFTP or USB mass storage device (MSD) boot filesystem.
 
@@ -181,6 +204,7 @@ Notes:-
 
 Default: `1` (`0` in versions prior to 2020-09-03)  
 
+<a name="FREEZE_VERSION"></a>
 ### FREEZE_VERSION
 Previously this property was only checked by the `rpi-eeprom-update` script. However, now that self-update is enabled the bootloader will also check this property. If set to 1, this overrides `ENABLE_SELF_UPDATE` to stop automatic updates. To disable `FREEZE_VERSION` you will have to use an SD card boot with recovery.bin.
 
@@ -188,6 +212,7 @@ Previously this property was only checked by the `rpi-eeprom-update` script. How
 
 Default: `0`  
 
+<a name="NETCONSOLE"></a>
 ### NETCONSOLE - advanced logging
 `NETCONSOLE` duplicates debug messages to the network interface. The IP addresses and ports are defined by the `NETCONSOLE` string.
 
@@ -219,6 +244,7 @@ NETCONSOLE=6665@169.254.1.1/,6666@/
 Default: ""  (not enabled)  
 Max length: 32 characters  
 
+<a name="USB_MSD_EXCLUDE_VID_PID"></a>
 ### USB_MSD_EXCLUDE_VID_PID
 A list of up to 4 VID/PID pairs specifying devices which the bootloader should ignore. If this matches a HUB then the HUB won’t be enumerated, causing all downstream devices to be excluded.
 This is intended to allow problematic (e.g. very slow to enumerate) devices to be ignored during boot enumeration. This is specific to the bootloader and is not passed to the OS.
@@ -228,17 +254,20 @@ E.g. `034700a0,a4231234`
 
 Default: ""  
 
+<a name="USB_MSD_DISCOVER_TIMEOUT"></a>
 ### USB_MSD_DISCOVER_TIMEOUT
 If no USB mass storage devices are found within this timeout then USB-MSD is stopped and the next boot mode is selected
 
 Default: `20000` (20 seconds)  
 Version: 2020-09-03  
 
+<a name="USB_MSD_LUN_TIMEOUT"></a>
 ### USB_MSD_LUN_TIMEOUT
 How long to wait in milliseconds before advancing to the next LUN e.g. a multi-slot SD-CARD reader. This is still being tweaked but may help speed up boot if old/slow devices are connected as well as a fast USB-MSD device containing the OS.
 
 Default: `2000` (2 seconds)  
 
+<a name="USB_MSD_PWR_OFF_TIME"></a>
 ### USB_MSD_PWR_OFF_TIME
 During USB mass storage boot, power to the USB ports is switched off for a short time to ensure the correct operation of USB mass storage devices. Most devices work correctly using the default setting: change this only if you have problems booting from a particular device. Setting `USB_MSD_PWR_OFF_TIME=0` will prevent power to the USB ports being switched off during USB mass storage boot.
 
@@ -246,6 +275,7 @@ Minimum: `250`
 Maximum: `5000`  
 Default: `1000` (1 second)  
 
+<a name="XHCI_DEBUG"></a>
 ### XHCI_DEBUG
 This property is a bit field which controls the verbosity of USB debug messages for mass storage boot mode. Enabling all of these messages generates a huge amount of log data which will slow down booting and may even cause boot to fail. For verbose logs it's best to use `NETCONSOLE`.
 
@@ -268,6 +298,8 @@ XHCI_DEBUG=0x3
 Default: `0x0` (no USB debug messages enabled)  
 
 ## config.txt - configuration properties
+
+<a name="boot_load_flags"></a>
 ### boot_load_flags
 Experimental property for custom firmware (bare metal).
 
@@ -275,13 +307,15 @@ Bit 0 (0x1) indicates that the .elf file is custom firmware. This disables any c
 
 Default: `0x0`  
 
+<a name="uart_2ndstage"></a>
 ### uart_2ndstage
 If set to 0x1 then enable debug logging to the UART. In newer firmware versions (Raspberry Pi OS 2020-08-20 and later) UART logging is also automatically enabled in start.elf. This is also described on the [Boot options](../../configuration/config-txt/boot.md) page.
 
 The `BOOT_UART` property also enables bootloader UART logging but does not enable UART logging in `start.elf` unless `uart_2ndstage=1` is also set.
 
-Default: `0`    
+Default: `0`  
 
+<a name="eeprom_write_protect"></a>
 ### eeprom_write_protect
 The `2020-09-03` `recovery.bin` EEPROM updater provides a feature to configure the EEPROM `Write Status Register`. This can be set to either mark the entire EEPROM as write-protected or clear write-protection.
 
@@ -301,75 +335,15 @@ N.B `flashrom` does not support clearing of the write-protect regions and will f
 
 Default: `-1`  
 
+<a name="bootloader_update"></a>
 ### bootloader_update
-This option may be set to 0 to block self-update without requiring the EEPROM configuration to be updated. This is sometimes useful when updating multiple Pis via network boot because this option can be controlled per Raspberry Pi (e.g. via a serial number filter in config.txt).
+This option may be set to 0 to block self-update without requiring the EEPROM configuration to be updated. This is sometimes useful when updating multiple Pis via network boot because this option can be controlled per Raspberry Pi (e.g. via a serial number filter in `config.txt`).
 
 Default: `1` (`0` in versions prior to 2020-09-03)  
 
-## USB and network boot
-## Operating system support 
-Before using USB and network boot, it is advisable to update the operating system to the latest version. 
+<a name="config_txt"></a>
+### config.txt section
+From Raspberry Pi OS 2021-01-11, the firmware now reads the bootloader configuration from the EEPROM. If a section called `[config.txt]` is found then the contents from the start of this section to the end of the file is appended in memory, to the contents of the `config.txt` file read from the boot partition.  This can be used to automatically apply settings to every operating system, for example, dtoverlays.
 
-## Selecting the boot mode
-Pi 400 and newer Raspberry Pi 4B boards support USB boot by default. On earlier Pi4B boards, or to select alternate boot modes, the bootloader must be updated.
+If an invalid configuration which causes boot to fail is specified then an EEPROM recovery image or RPIBOOT will be required to restore the EEPROM to factory defaults.
 
-### Using Raspberry Pi Imager to update the bootloader (recommended)
-Raspberry Pi Imager provides a GUI for updating the bootloader
-
-1. Download [Raspberry Pi Imager](https://www.raspberrypi.org/downloads/)
-2. Select a spare SD card. The contents will get overwritten!
-3. Launch `Raspberry Pi Imager`
-4. Select `Misc utility images` under `Operating System`
-5. Select `Bootloader`
-6. Select a boot-mode 
-7. Select `SD card` and then `Write`
-
-### Using raspi-config to update the bootloader from within Raspberry Pi OS
-To change the boot-mode or bootloader version from within Raspberry Pi OS run [raspi-config](../../configuration/raspi-config.md)
-
-1. Run `sudo raspi-config`
-2. Select `Advanced Options`
-3. Select `Boot Order`
-4. Select SD, USB or Network boot
-5. Reboot
-
-### Custom boot-order
-The `rpi-eeprom-config` utility has an editor mode which can be used to make quick changes to the EEPROM config file. Use this to define the `BOOT_ORDER` setting directly
-
-```
-sudo apt update
-sudo apt full-upgrade
-sudo -E rpi-eeprom-config --edit
-```
-Make changes, then save and quit. `rpi-eeprom-config` will print details of the EEPROM release and how to revert changes. Reboot to apply the bootloader update.
-
-The [Boot EEPROM](booteeprom.md) page provides more information about the EEPROM flashing process.
-
-
-#### Hardware compatibility for USB mass storage devices
-Before attempting to boot from a USB mass storage device it is advisible to verify that the device works correctly under Linux. Boot using an SD card and plug in the USB mass storage device. This should appears as a removable drive.
-
-*Spinning hard-disk drives nearly always require a powered USB hub. Even if it appears to work you are likely to encounter intermittent failures without a powered USB HUB*
-
-This is especially important with USB SATA adapters which may be supported by the bootloader in mass storage mode but fail if Linux selects [USB Attached SCSI - UAS](https://en.wikipedia.org/wiki/USB_Attached_SCSI) mode.
-
-See this [forum thread](https://www.raspberrypi.org/forums/viewtopic.php?t=245931) about UAS and how to add [usb-storage.quirks](https://www.kernel.org/doc/html/v5.0/admin-guide/kernel-parameters.html) to workaround this issue.
-
-#### Multiple bootable drives
-When searching for a bootable partition the bootloader scans all USB mass storage devices in parallel and will select the first to respond. If the boot partition does not contain a suitable start.elf file the next available device is selected.
-
-As with earlier Raspberry Pi models there is no method for specifying the boot device according to the USB topology because this would slow down boot and adds unecessary and hard to support configuration complexity.
-
-N.B. config.txt [conditional filters](../../configuration/config-txt/conditional.md) can be used to select alternate firmware in complex device configurations.
-
-### Network boot server configuration
-Network boot requires a TFTP and NFS server to be configured. See [Network boot server tutorial](bootmodes/net_tutorial.md)
-
-Additional notes:-
-* The MAC address on the Pi 4 is programmed at manufacture and is not derived from the serial number.
-```
-# mac address (ip addr) - it should start with DC:A6:32
-ip addr | grep ether | head -n1 | awk '{print $2}' | tr [a-z] [A-Z]
-# serial number
-vcgencmd otp_dump | grep 28: | sed s/.*://g
-```

--- a/hardware/raspberrypi/boot_diagnostics.md
+++ b/hardware/raspberrypi/boot_diagnostics.md
@@ -15,7 +15,7 @@ The diagnostic information is as follows:
 | Line: | Information |
 | ---- | ----------- |
 | bootloader | Bootloader version - build date |
-| board      | Board revision - Serial Number - Ethernet MAC address | 
+| board      | Board revision - Serial Number - Ethernet MAC address |
 | boot       | mode: (ROM boot mode - 6 SPI), order: EEPROM config [BOOT_ORDER](https://www.raspberrypi.org/documentation/hardware/raspberrypi/bcm2711_bootloader_config.md), RSTS: PM_RSTS register |
 | SD CID	   | SD Card Identifier defined by SD-CARD manufacturer |
 | part	     | Master Boot Record primary partitions type:LBA |
@@ -24,6 +24,6 @@ The diagnostic information is as follows:
 | tftp       | Network boot: TFTP server IP address|
 
 
-This display can be disabled using the DISABLE_HDMI option, see [Pi4 Bootloader Configuration](./bcm2711_bootloader_config.md).
+This display can be disabled using the `DISABLE_HDMI` option, see [Bootloader Configuration](./bcm2711_bootloader_config.md).
 
 N.B. This is purely for diagnosing boot failures; it is not an interactive bootloader. If you require an interactive bootloader, consider using a tool such as NOOBS or U-Boot.

--- a/hardware/raspberrypi/booteeprom.md
+++ b/hardware/raspberrypi/booteeprom.md
@@ -6,104 +6,151 @@ The Raspberry Pi 4 has an SPI-attached EEPROM (4MBits/512KB), which contains cod
 If an error occurs during boot then an [error code](../../configuration/led_blink_warnings.md) will be displayed via the green LED. Newer versions of the bootloader will display a [diagnostic message](boot_diagnostics.md) which will be shown on both HDMI displays.
 
 ## Updating the bootloader
+### Pi 4 and Pi 400
+Raspberry Pi OS automatically updates the bootloader for critical bug fixes. The recommended methods for manually updating the bootloader or changing the boot modes are [Raspberry Pi Imager](https://www.raspberrypi.org/downloads) and [raspi-config](../../configuration/raspi-config.md)
 
-## Compute Module 4
+### Compute Module 4
 Bootloader EEPROM updates on Compute Module 4 require [rpiboot](https://github.com/raspberrypi/usbboot) which is also used for flashing the EMMC. Please see the [Compute Module flashing guide](../computemodule/cm-emmc-flashing.md) for instructions.
 
-### Raspberry Pi Imager
-The easiest way to to update the bootloader to the latest version with default settings is to use the [Raspberry Pi Imager](https://www.raspberrypi.org/downloads/) to install a boot recovery image onto a spare SD card.
+<a name="imager"></a>
+### Using Raspberry Pi Imager to update the bootloader (recommended)
+Raspberry Pi Imager provides a GUI for updating the bootloader and selecting the boot mode.
 
-Select "Choose OS -> Misc utility images -> Raspberry Pi 4 EEPROM boot recovery"
+1. Download [Raspberry Pi Imager](https://www.raspberrypi.org/downloads/)
+2. Select a spare SD card. The contents will get overwritten!
+3. Launch `Raspberry Pi Imager`
+4. Select `Misc utility images` under `Operating System`
+5. Select `Bootloader`
+6. Select a boot-mode i.e. `SD` (recommended), `USB` or `Network`.
+7. Select `SD card` and then `Write`
+8. Boot the Raspberry Pi with the new image and wait for at least 10 seconds.
+9. The green activity LED will blink with a steady pattern and the HDMI display will be green on success.
+10. Power off the Raspberry Pi and remove the SD card.
 
-Raspberry Pi OS also keeps the EEPROM up-to-date: new EEPROM images are applied when the Raspberry Pi 4 next boots.
+<a name="raspi-config"></a>
+### Using raspi-config to update the bootloader from within Raspberry Pi OS
+To change the boot-mode or bootloader version from within Raspberry Pi OS run [raspi-config](../../configuration/raspi-config.md)
 
-### Updating from Raspberry Pi OS
-Bootloader updates are instigated during a normal `apt update`, `apt full-upgrade` cycle, this means you will get new features and bug fixes during your normal updates. 
-
-Bootloader updates are performed by `rpi-eeprom-update` service provided by the `rpi-eeprom` package. This service runs at boot and updates the bootloader at the next reboot if a new production release is available. The service automatically migrates the current boot settings to the new bootloader release.
-
-To update your system, including the bootloader:
-```
-sudo apt update
-sudo apt full-upgrade
-sudo reboot
-```
-
-## Manually checking if an update is available
-Running the `rpi-eeprom-update` command with no parameters indicates whether an update is required. An update is required if the version of the most recent file in the firmware directory (normally `/lib/firmware/raspberrypi/bootloader/default`) is newer than that reported by the current bootloader.
-The images under `/lib/firmware/raspberrypi/bootloader` are part of the `rpi-eeprom` package and are only updated via `apt upgrade`.
-
-```
-sudo rpi-eeprom-update
-```
-
-If an update is available, you can install it using:
-```
-sudo rpi-eeprom-update -a
-sudo reboot
-```
-
-### Reading the current EEPROM version
-```
-vcgencmd bootloader_version
-```
+1. [Update](../../raspbian/updating.md) Raspberry Pi OS to get the latest version of the `rpi-eeprom` package.
+2. Run `sudo raspi-config`
+3. Select `Advanced Options`
+4. Select `Bootloader Version`
+5. Select `Default` for factory default settings or `Latest` for the latest stable bootloader release.
+6. Reboot
 
 ## Updating the EEPROM configuration
-The bootloader EEPROM image contains an embedded configuration file to define the boot behaviour (e.g. selecting between SD, network and USB boot). 
-The `rpi-eeprom-config` tool may be used to modify embedded configuration file in an EEPROM image file. 
+The boot behaviour (e.g. SD or USB boot) is controlled by a configuration file embedded in the EEPROM image and can be modified via the `rpi-eeprom-config` tool.
 
-See the [Bootloader Configuration Page](./bcm2711_bootloader_config.md) for details of the configuration file.
+Please see the [Bootloader Configuration Page](bcm2711_bootloader_config.md) for details of the configuration.
 
 ### Reading the current EEPROM configuration
-To view the configuration file used by the bootloader at boot time run `rpi-eeprom-config` or `vcgencmd bootloader_config`.
+To view the configuration used by the current bootloader during the last boot run `rpi-eeprom-config` or `vcgencmd bootloader_config`.
 
-### Reading the configuration file from an EEPROM image
-To read the configuration file from an EEPROM image file:
-```
+### Reading the configuration from an EEPROM image
+To read the configuration from an EEPROM image:
+```bash
 rpi-eeprom-config pieeprom.bin
 ```
-
 ### Editing the current bootloader configuration
 The following command loads the current EEPROM configuration into a text editor. When the editor is closed, `rpi-eeprom-config` applies the updated configuration to latest available EEPROM release and uses `rpi-eeprom-update` to schedule an update when the system is rebooted:
 
-```
+```bash
 sudo -E rpi-eeprom-config --edit
 sudo reboot
 ```
-If the updated configuration file is identical or empty then no changes are made.
+If the updated configuration is identical or empty then no changes are made.
 
 The editor is selected by the `EDITOR` environment variable.
 
-### Applying a saved configuration file
+### Applying a saved configuration
 The following command applies `boot.conf` to the latest available EEPROM image and uses `rpi-eeprom-update` to schedule an update when the system is rebooted.
 ```
 sudo rpi-eeprom-config --apply boot.conf
 sudo reboot
 ```
 
-### Low level commands
+<a name="automaticupdates"></a>
+## Automatic updates
+The `rpi-eeprom-update` `systemd` service runs at startup and applies an update if a new image is available, automatically migrating the current bootloader configuration.
 
-#### Updating the configuration in an EEPROM image
-The following command reads `pieeprom.bin` and replaces the configuration file with the contents of `boot.conf`. The result is written to `new.bin`
+To disable automatic updates:  
+```bash
+sudo systemctl mask rpi-eeprom-update
 ```
+
+To re-enable automatic updates:  
+```bash
+sudo systemctl unmask rpi-eeprom-update
+```
+
+#### Disabling automatic updates on multiple operating systems
+If the [FREEZE_VERSION](bcm2711_bootloader_config.md#FREEZE_VERSION) bootloader EEPROM config is set then the EEPROM update service will skip any automatic updates. This removes the need to individually disable the EEPROM update service if there are multiple operating systems installed or when swapping SD-cards.
+
+<a name="bootloader-release"></a>
+## Bootloader release status
+The firmware release status corresponds to a particular subdirectory of bootloader firmware images (`/lib/firmware/raspberrypi/bootloader/...`), and can be changed to select a different release stream.
+
+* `default` - Updated for new hardware support, critical bug fixes and periodic update for new features that have been tested via the `latest` release.
+* `latest` - Updated when new features have been successfully beta tested.
+* `beta` - New or experimental features are tested here first.
+
+Since the release status string is just a subdirectory name, then it is possible to create your own release streams e.g. a pinned release or custom network boot configuration.
+
+N.B. `default` and `latest` are symbolic links to the older release names of `critical` and `stable`.
+
+### Changing the bootloader release
+
+You can change which release stream is to be used during an update by editing the `/etc/default/rpi-eeprom-update` file and changing the `FIRMWARE_RELEASE_STATUS` entry to the appropriate stream.
+
+## Low level commands
+
+## rpi-eeprom-update
+Raspberry Pi OS uses the `rpi-eeprom-update` script to implement an [automatic update](#automaticupdates) service. The script can also be run interactively or wrapped to create a custom bootloader update service.
+
+Reading the current EEPROM version:  
+```bash
+vcgencmd bootloader_version
+```
+
+Check if an update is available:  
+```bash
+sudo rpi-eeprom-update
+```
+
+Install the update:  
+```
+sudo rpi-eeprom-update -a
+sudo reboot
+```
+
+Cancel the pending update:  
+```bash
+sudo rpi-eeprom-update -r
+```
+
+Installing a specific bootloader EEPROM image:  
+```bash
+sudo rpi-eeprom-update -d -f pieeprom.bin
+```
+The `-d` flag instructs `rpi-eeprom-update` to use the configuration in the specified image file instead of automatically migrating the current configuration.
+
+Display the built-in documentation:  
+```
+rpi-eeprom-update -h
+```
+
+### Updating the bootloader configuration in an EEPROM image file
+The following command replaces the bootloader configuration in `pieeprom.bin` with `boot.conf` and writes the new image to `new.bin`:
+```bash
 rpi-eeprom-config --config boot.conf --out new.bin pieeprom.bin
 ```
 
-For more information about advanced options please run `rpi-eeprom-config -h`.
-
-#### Updating the bootloader EEPROM
-The following will cause the bootloader EEPROM to be updated the next time the system is rebooted.
-```
-# -d instructs rpi-eeprom-update to use the EEPROM configuration inside new.bin instead of
-# of replacing it with the current configuration from vcgencmd bootloader.
-sudo rpi-eeprom-update -d -f new.bin
-```
-For more information about advanced options please run `rpi-eeprom-update -h`.
-
 ### recovery.bin
-At power on, the BCM2711 ROM looks for a file called `recovery.bin` in the root directory of the boot partition on the sd-card. If a valid `recovery.bin` is found then the ROM executes this instead of the SPI EEPROM image. This mechanism ensures that the bootloader SPI EEPROM can always be reset to a valid image with factory default settings.
+At power on, the BCM2711 ROM looks for a file called `recovery.bin` in the root directory of the boot partition on the SD card. If a valid `recovery.bin` is found then the ROM executes this instead of the SPI EEPROM image. This mechanism ensures that the bootloader SPI EEPROM can always be reset to a valid image with factory default settings.
 
-#### EEPROM update files
+See also [Raspberry Pi 4 boot-flow](bootmodes/bootflow_bcm2711.md)
+
+### EEPROM update files
 | Filename | Purpose |
 |----------|---------|
 | recovery.bin | VideoCore EEPROM recovery executable |
@@ -117,38 +164,12 @@ At power on, the BCM2711 ROM looks for a file called `recovery.bin` in the root 
 * If the bootloader update image is called `pieeprom.bin` the `recovery.bin` will stop after the update has completed. On success the HDMI output will be green and the green activity LED is flashed rapidly. Otherwise, the HDMI output will be red and an [error code](../../configuration/led_blink_warnings.md) will be displayed via the activity LED.
 * The `.sig` files should just contain the sha256 checksum (in hex) of the corresponding image file. Other fields may be added in the future.
 * The BCM2711 ROM does not support loading `recovery.bin` from USB mass storage or TFTP. Instead, newer versions of the bootloader support a self-update mechanism where the SPI bootloader is able to reflash the SPI EEPROM itself. See `ENABLE_SELF_UPDATE` on the [bootloader configuration](bcm2711_bootloader_config.md) page.
-* The temporary EEPROM update files are automatically deleted by the `rpi-eeprom-update` service at startup. 
-
-### Firmware release status
-The firmware release status corresponds to a particular subdirectory of bootloader firmware images (`/lib/firmware/raspberrypi/bootloader/...`), and can be changed to select a different release stream. By default, Raspberry Pi OS automatically updates the bootloader if 'default' image in the 'rpi-eeprom' image is newer than the current bootloader image. The bootloader EEPROM config is migrated during the upgrade.
-
-* `default` - Updated for new hardware support, critical bug fixes and periodic update for new features that have been tested via the `latest` release.
-* `latest` - Updated when new features have been successfully beta tested.
-* `beta` - New or experimental features are tested here first.
-
-Since the release status string is just a subdirectory name then it's possible to create your own release streams e.g. a pinned release or custom network boot configuration.
-
-N.B. `default` and `latest` are symbolic links to the older release names of `critical` and `stable`.
-
-### Changing the firmware release
-
-You can change which release stream is to be used during an update by editing the `/etc/default/rpi-eeprom-update` file and changing the `FIRMWARE_RELEASE_STATUS` entry to the appropriate stream. 
+* The temporary EEPROM update files are automatically deleted by the `rpi-eeprom-update` service at startup.
 
 For more information about the `rpi-eeprom-update` configuration file please run `rpi-eeprom-update -h`.
 
-### Disabling automatic updates
-If you wish to control when the updates are applied you can disable the `rpi-eeprom-update` systemd service.
-```
-# Disable
-sudo systemctl mask rpi-eeprom-update
-
-# Enable it again
-sudo systemctl unmask rpi-eeprom-update
-```
-The `FREEZE_VERSION` option in the [EEPROM config file](bcm2711_bootloader_config.md) may be used to indicate to the `rpi-eeprom-update` service that the EEPROM should not be updated on this board. 
-
 ### EEPROM write protect
-Both the bootloader and VLI SPI EEPROMs support hardware write-protection.  See the [eeprom_write_protect](bcm2711_bootloader_config.md) option for more information about how to enabled this when flashing the EEPROMs.
+Both the bootloader and VLI SPI EEPROMs support hardware write-protection.  See the [eeprom_write_protect](bcm2711_bootloader_config.md#eeprom_write_protect) option for more information about how to enable this when flashing the EEPROMs.
 
 ## Release Notes
 * [Release notes](https://github.com/raspberrypi/rpi-eeprom/blob/master/firmware/release-notes.md) for bootloader EEPROMs.

--- a/hardware/raspberrypi/bootmodes/bootflow_2711.md
+++ b/hardware/raspberrypi/bootmodes/bootflow_2711.md
@@ -1,20 +1,20 @@
-# Raspberry Pi 4B, 400 and CM4 bootflow
+# Raspberry Pi 4 boot flow
 
-This page describes the bootflow for BCM2711-based products. The main difference betweeen this and previous products is that the second stage bootloader is loaded from an SPI flash [EEPROM](../booteeprom.md) instead of the `bootcode.bin` file on previous products.
+This page describes the boot flow for BCM2711-based products. The main difference betweeen this and previous products is that the second stage bootloader is loaded from an SPI flash [EEPROM](../booteeprom.md) instead of the `bootcode.bin` file on previous products.
 
 ## First stage bootloader
 
-The bootflow for the ROM (first stage) is as follows:-
+The boot flow for the ROM (first stage) is as follows:-
 
 * BCM2711 SoC powers up
 * Read OTP to determine if the `nRPIBOOT` GPIO is configured
-* If `nRPIBOOT` GPIO is high or OTP does NOT define `nRPIBOOT` GPIO 
+* If `nRPIBOOT` GPIO is high or OTP does NOT define `nRPIBOOT` GPIO
    * Check OTP to see if `recovery.bin` can be loaded from SD/EMMC
       * If SD recovery.bin is enabled then check primary SD/EMMC for `recovery.bin`
          * Success - run `recovery.bin` and update the SPI EEPROM
          * Fail - continue
    * Check SPI EEPROM for second stage loader
-      * Success - run second stage bootloader 
+      * Success - run second stage bootloader
       * Fail - continue
 * While True
    * Attempt to load recovery.bin from [USB device boot](../../computemodule/cm-emmc-flashing.md)
@@ -26,7 +26,7 @@ N.B. Currently only CM4 reserves a GPIO for `nRPIBOOT`.
 ## recovery.bin
 `recovery.bin` is a minimal second stage program used to reflash the bootloader SPI EEPROM image.
 
-## Second stage bootloader 
+## Second stage bootloader
 
 This section describes the high-level flow of the second stage bootloader.
 
@@ -39,7 +39,7 @@ Please see the [bootloader configuration](../bcm2711_bootloader_config.md) page 
    * If `POWER_OFF_ON_HALT` is `1` and `WAKE_ON_GPIO` is `0` then
       * Use PMIC to power off system
    * else if `WAKE_ON_GPIO` is `1`
-      * Enable fall-edge interrupts on GPIO3 to wake-up if GPIO3 is pulled low   
+      * Enable fall-edge interrupts on GPIO3 to wake-up if GPIO3 is pulled low
    * sleep
 * While True
    * Read the next boot-mode from the BOOT_ORDER parameter in the EEPROM config file.
@@ -50,13 +50,13 @@ Please see the [bootloader configuration](../bcm2711_bootloader_config.md) page 
    * else if boot-mode == `SD CARD`
       * Attempt to load firmware from the SD card
          * Success - run the firmware
-         * Failure - continue   
-   * else if boot-mode == `NETWORK` then 
+         * Failure - continue
+   * else if boot-mode == `NETWORK` then
       * Use DHCP protocol to request IP address
       * Load firmware from the DHCP or statically defined TFTP server
       * If the firmware is not found or a timeout or network error occurs then continue
    * else if boot-mode == `USB-MSD` or boot-mode == `BCM-USB-MSD` then
-      * While USB discover has not timed out 
+      * While USB discover has not timed out
          * Check for USB mass storage devices
          * If a new mass storage device is found then
             * For each drive (LUN)
@@ -67,9 +67,9 @@ Please see the [bootloader configuration](../bcm2711_bootloader_config.md) page 
       * Scan PCIe for an NVMe device and if found
          * Attempt to load firmware from the NVMe device
             * Success - run the firmware
-            * Failure - continue            
+            * Failure - continue
    * else if boot-mode == `RPIBOOT` then
       * Attempt to load firmware using USB device mode from the USB OTG port - see [usbboot](https://github.com/raspberrypi/usbboot). There is no timeout for `RPIBOOT` mode.
-         
+
 ## Bootloader updates
 The bootloader may also be updated before the firmware is started if a `pieeprom.upd` file is found. Please see the [bootloader eeprom](../booteeprom.md) page for more information about bootloader updates.

--- a/hardware/raspberrypi/bootmodes/msd.md
+++ b/hardware/raspberrypi/bootmodes/msd.md
@@ -8,29 +8,10 @@ This page explains how to boot your Raspberry Pi from a USB mass storage device 
 ## Raspberry Pi 4B and Raspberry Pi 400
 The Raspberry Pi Pi 400 and newer Raspberry Pi 4B boards support USB boot by default. On earlier Raspberry Pi 4B boards, or to select alternate boot modes, the bootloader must be updated.
 
-### Using Raspberry Pi Imager to update the bootloader (recommended)
-Raspberry Pi Imager provides a GUI for updating the bootloader
-
-1. Download [Raspberry Pi Imager](https://www.raspberrypi.org/downloads/)
-2. Select a spare SD card. The contents will get overwritten!
-3. Launch `Raspberry Pi Imager`
-4. Select `Misc utility images` under `Operating System`
-5. Select `Bootloader`
-6. Select `USB`
-7. Select Storage and then Write
-
-### Using raspi-config to update the bootloader from within Raspberry Pi OS
-To change the boot-mode from within Raspberry Pi OS run [raspi-config](../../../configuration/raspi-config.md)
-
-1. Run `sudo raspi-config`
-2. Select `Advanced Options`
-3. Select `Boot Order`
-4. Select `USB`
-5. Reboot
-
-See also:-
-* The [bootloader configuration](../bcm2711_bootloader_config.md) page for other boot configuration options
-* The [bootloader EEPROM](../booteeprom.md) page for more information 
+See:-
+* Instructions for changing the boot mode via the [Raspberry Pi Imager](../booteeprom.md#imager).
+* Instructions for changing the boot mode via the [raspi-config](../booteeprom.md#raspi-config).
+* The [bootloader configuration](../bcm2711_bootloader_config.md) page for other boot configuration options.
 
 <a name="cm4"></a>
 ## Compute Module 4
@@ -63,7 +44,7 @@ Note that although the option is named `program_usb_boot_mode`, it only enables 
 The next step is to reboot the Raspberry Pi with `sudo reboot` and check that the OTP has been programmed with:
 
 ```bash
-$ vcgencmd otp_dump | grep 17:
+vcgencmd otp_dump | grep 17:
 17:3020000a
 ```
 
@@ -82,10 +63,21 @@ After five to ten seconds, the Raspberry Pi should begin booting and show the ra
 
 See the [bootmodes documentation](README.md) for the boot sequence and alternative boot modes (network, USB device, GPIO or SD boot).
 
-## Known issues (not Pi 4B, CM4 and Pi 400)
+## Known issues (not Raspberry Pi 4)
 
 - The default timeout for checking bootable USB devices is 2 seconds. Some flash drives and hard disks power up too slowly. It is possible to extend this timeout to five seconds (add a new file `timeout` to the SD card), but note that some devices take even longer to respond.
 - Some flash drives have a very specific protocol requirement that is not handled by the bootcode and may thus be incompatible.
 
-## Special bootcode.bin-only boot mode (not Pi 4B, CM4 and Pi 400)
+## Special bootcode.bin-only boot mode (not Raspberry Pi 4)
 If you are unable to use a particular USB device to boot your Raspberry Pi, an alternative for the Pi 2B v1.2, 3A+, 3B and 3B+ is to use the special bootcode.bin-only boot mode as described [here](README.md). The Pi will still boot from the SD card, but `bootcode.bin` is the only file read from it.
+
+## Hardware compatibility for USB mass storage devices
+Before attempting to boot from a USB mass storage device it is advisable to verify that the device works correctly under Linux. Boot using an SD card and plug in the USB mass storage device. This should appears as a removable drive. This is especially important with USB SATA adapters which may be supported by the bootloader in mass storage mode but fail if Linux selects [USB Attached SCSI - UAS](https://en.wikipedia.org/wiki/USB_Attached_SCSI) mode.  See this [forum thread](https://www.raspberrypi.org/forums/viewtopic.php?t=245931) about UAS and how to add [usb-storage.quirks](https://www.kernel.org/doc/html/v5.0/admin-guide/kernel-parameters.html) to workaround this issue.
+
+Spinning hard disk drives nearly always require a powered USB hub. Even if it appears to work you are likely to encounter intermittent failures without a powered USB HUB.
+
+## Multiple bootable drives
+When searching for a bootable partition the bootloader scans all USB mass storage devices in parallel and will select the first to respond. If the boot partition does not contain a suitable `start.elf` file the next available device is selected.  There is no method for specifying the boot device according to the USB topology because this would slow down boot and adds unnecessary and hard to support configuration complexity.
+
+N.B. config.txt [conditional filters](../../../configuration/config-txt/conditional.md) can be used to select alternate firmware in complex device configurations.
+

--- a/hardware/raspberrypi/bootmodes/net.md
+++ b/hardware/raspberrypi/bootmodes/net.md
@@ -1,6 +1,6 @@
 # Network booting
 
-This section describes how network booting works on the Raspberry Pi 3B, 3B+ and 2B v1.2. On the Raspberry Pi 4, network booting is implemented in the second stage bootloader in the EEPROM. Please see the [Pi 4 Bootloader Configuration](../bcm2711_bootloader_config.md) page for more information.
+This section describes how network booting works on the Raspberry Pi 3B, 3B+ and 2B v1.2. On the Raspberry Pi 4 network booting is implemented in the second stage bootloader in the EEPROM. Please see the [Pi 4 Bootloader Configuration](../bcm2711_bootloader_config.md) page for more information.
 We also have a [tutorial about setting up a network boot system](net_tutorial.md). Network booting works only for the wired adapter built into the above models of Raspberry Pi. Booting over wireless LAN is not supported, nor is booting from any other wired network device.
 
 To network boot, the boot ROM does the following:


### PR DESCRIPTION
Move text between the bootloader releases and re-order for clarity

msd.md
This page describes USB boot and the simplest methods for
enabling it.

bootloader_config
This is a technical reference for the bootloader configurtion file. Move
the tutorials for USB and bootloader updates to other pages.

boot_eeprom
The page documents that
1. There is an EEPROM
2. How to update it with the default configuration
3. How to change the high level bootmode
4. How to do custom configuration
5. Automatic updates
6. All the low level bits