### PR TITLE
Update bcm2711_bootloader_config.md

### DIFF
--- a/hardware/raspberrypi/bcm2711_bootloader_config.md
+++ b/hardware/raspberrypi/bcm2711_bootloader_config.md
@@ -46,17 +46,17 @@ The minimum supported bootloader version for custom boot modes is 2020-09-03.
 ##### `BOOT_ORDER` fields
 The BOOT_ORDER property defines the sequence for the different boot modes. It is read right to left and up to 8 digits may be defined.
 
-| Value | Mode            | Description                                                                                                              |
-|-------|-----------------|--------------------------------------------------------------------------------------------------------------------------|
-|  0x0  |  SD CARD DETECT |  Try SD then wait for card-detect to indicate that the card has changed - deprecated now that 0xf (RESTART) is available.|
-|  0x1  |  SD CARD        |  SD card (or eMMC on Compute Module 4).                                                                                  |
-|  0x2  |  NETWORK        |  Network boot - See [Network boot server tutorial](bootmodes/net_tutorial.md)                                            |
-|  0x3  |  RPIBOOT        |  RPIBOOT - See [usbboot](https://github.com/raspberrypi/usbboot)                                                         |
-|  0x4  |  USB-MSD        |  USB mass storage boot - See [USB mass storage boot](bootmodes/msd.md)                                                   |
-|  0x5  |  BCM-USB-MSD    |  USB 2.0 boot from USB Type C socket (CM4: USB type A socket on CM IO board, available since 2020-12-14).                |
-|  0x6  |  NVME           |  CM4 only: boot from an NVMe SSD connected to the PCIe interface. See [NVMe boot](bootmodes/nvme.md) for more details.   |
-|  0xe  |  STOP           |  Stop and display error pattern. A power cycle is required to exit this state.                                           |
-|  0xf  |  RESTART        |  Restart from the first boot-mode in the BOOT_ORDER field i.e. loop                                                      |
+| Value | Mode            | Description                                                                                                                     |
+|-------|-----------------|---------------------------------------------------------------------------------------------------------------------------------|
+|  0x0  |  SD CARD DETECT |  Try SD then wait for card-detect to indicate that the card has changed - deprecated now that 0xf (RESTART) is available.       |
+|  0x1  |  SD CARD        |  SD card (or eMMC on Compute Module 4).                                                                                         |
+|  0x2  |  NETWORK        |  Network boot - See [Network boot server tutorial](bootmodes/net_tutorial.md)                                                   |
+|  0x3  |  RPIBOOT        |  RPIBOOT - See [usbboot](https://github.com/raspberrypi/usbboot)                                                                |
+|  0x4  |  USB-MSD        |  USB mass storage boot - See [USB mass storage boot](bootmodes/msd.md)                                                          |
+|  0x5  |  BCM-USB-MSD    |  USB 2.0 boot from USB Type C socket (CM4: USB type A socket on CM IO board, using bootloader EEPROM from 2020-12-14 onwards).  |
+|  0x6  |  NVME           |  CM4 only: boot from an NVMe SSD connected to the PCIe interface. See [NVMe boot](bootmodes/nvme.md) for more details.          |
+|  0xe  |  STOP           |  Stop and display error pattern. A power cycle is required to exit this state.                                                  |
+|  0xf  |  RESTART        |  Restart from the first boot-mode in the BOOT_ORDER field i.e. loop                                                             |
 
 `RPIBOOT` is intended for use with Compute Module 4 to load a custom debug image (e.g. a Linux RAM-disk) instead of the normal boot. This should be the last boot option because it does not currently support timeouts or retries.
 

--- a/hardware/raspberrypi/bcm2711_bootloader_config.md
+++ b/hardware/raspberrypi/bcm2711_bootloader_config.md
@@ -53,7 +53,7 @@ The BOOT_ORDER property defines the sequence for the different boot modes. It is
 |  0x2  |  NETWORK        |  Network boot - See [Network boot server tutorial](bootmodes/net_tutorial.md)                                            |
 |  0x3  |  RPIBOOT        |  RPIBOOT - See [usbboot](https://github.com/raspberrypi/usbboot)                                                         |
 |  0x4  |  USB-MSD        |  USB mass storage boot - See [USB mass storage boot](bootmodes/msd.md)                                                   |
-|  0x5  |  BCM-USB-MSD    |  Pi 4: USB 2.0 boot from USB Type C socket,  CM4: USB Type A socket on CM4 IO board (since 2020-12-14).                  |
+|  0x5  |  BCM-USB-MSD    |  USB 2.0 boot from USB Type C socket (CM4: USB type A socket on CM IO board, available since 2020-12-14).                |
 |  0x6  |  NVME           |  CM4 only: boot from an NVMe SSD connected to the PCIe interface. See [NVMe boot](bootmodes/nvme.md) for more details.   |
 |  0xe  |  STOP           |  Stop and display error pattern. A power cycle is required to exit this state.                                           |
 |  0xf  |  RESTART        |  Restart from the first boot-mode in the BOOT_ORDER field i.e. loop                                                      |

--- a/hardware/raspberrypi/bcm2711_bootloader_config.md
+++ b/hardware/raspberrypi/bcm2711_bootloader_config.md
@@ -53,8 +53,8 @@ The BOOT_ORDER property defines the sequence for the different boot modes. It is
 |  0x2  |  NETWORK        |  Network boot - See [Network boot server tutorial](bootmodes/net_tutorial.md)                                            |
 |  0x3  |  RPIBOOT        |  RPIBOOT - See [usbboot](https://github.com/raspberrypi/usbboot)                                                         |
 |  0x4  |  USB-MSD        |  USB mass storage boot - See [USB mass storage boot](bootmodes/msd.md)                                                   |
-|  0x5  |  BCM-USB-MSD    |  USB 2.0 boot from USB Type-C socket or USB Type-A socket on CM4 IO board.     (since 2020-12-14)                        |
-|  0x6  |  NVME           |  Boot from an NVMe SSD connected to the PCIe socket (CM4 only). See [NVMe boot](bootmodes/nvme.md) for more details.     |
+|  0x5  |  BCM-USB-MSD    |  Pi 4: USB 2.0 boot from USB Type C socket,  CM4: USB Type A socket on CM4 IO board (since 2020-12-14).                  |
+|  0x6  |  NVME           |  CM4 only: boot from an NVMe SSD connected to the PCIe interface. See [NVMe boot](bootmodes/nvme.md) for more details.   |
 |  0xe  |  STOP           |  Stop and display error pattern. A power cycle is required to exit this state.                                           |
 |  0xf  |  RESTART        |  Restart from the first boot-mode in the BOOT_ORDER field i.e. loop                                                      |
 


### PR DESCRIPTION
The description of BCM-USB-MSD boot mode was not quite specific enough when it came to specifying which devices (Pi 4, CM4) have which type of USB connector. Also, the NVME boot description assumed there was a PCIe `socket`, which may not be the case on 3rd-party boards, so change that to `interface`.