### PR TITLE
Update bcm2711_bootloader_config.md

### DIFF
--- a/hardware/raspberrypi/bcm2711_bootloader_config.md
+++ b/hardware/raspberrypi/bcm2711_bootloader_config.md
@@ -53,7 +53,7 @@ The BOOT_ORDER property defines the sequence for the different boot modes. It is
 |  0x2  |  NETWORK        |  Network boot - See [Network boot server tutorial](bootmodes/net_tutorial.md)                                                   |
 |  0x3  |  RPIBOOT        |  RPIBOOT - See [usbboot](https://github.com/raspberrypi/usbboot)                                                                |
 |  0x4  |  USB-MSD        |  USB mass storage boot - See [USB mass storage boot](bootmodes/msd.md)                                                          |
-|  0x5  |  BCM-USB-MSD    |  USB 2.0 boot from USB Type C socket (CM4: USB type A socket on CM IO board, using bootloader EEPROM from 2020-12-14 onwards).  |
+|  0x5  |  BCM-USB-MSD    |  USB 2.0 boot from USB Type C socket (CM4: micro USB socket on CM IO board, using bootloader EEPROM from 2020-12-14 onwards).  |
 |  0x6  |  NVME           |  CM4 only: boot from an NVMe SSD connected to the PCIe interface. See [NVMe boot](bootmodes/nvme.md) for more details.          |
 |  0xe  |  STOP           |  Stop and display error pattern. A power cycle is required to exit this state.                                                  |
 |  0xf  |  RESTART        |  Restart from the first boot-mode in the BOOT_ORDER field i.e. loop                                                             |


### PR DESCRIPTION
CM4 IO board has a micro USB socket for booting from a USB MSD connected to the BCM2711's XHCI controller, not USB type A.