### PR TITLE
Add disable_poe_fan to config.txt documentation

### DIFF
--- a/configuration/config-txt/boot.md
+++ b/configuration/config-txt/boot.md
@@ -113,7 +113,7 @@ On the Raspberry Pi 4B, if this value is set to `0` then the interrupts will be 
 
 ## force_eeprom_read
 
-Set this option to `0` to prevent the firmware from trying to read an I2C HAT EEPROM (connected to pins ID_SD & ID_SC) at powerup.
+Set this option to `0` to prevent the firmware from trying to read an I2C HAT EEPROM (connected to pins ID_SD & ID_SC) at powerup. See also [`disable_poe_fan`](misc.md#disable_poe_fan).
 
 ## os_prefix
 <a name="os_prefix"></a>

--- a/configuration/config-txt/misc.md
+++ b/configuration/config-txt/misc.md
@@ -22,3 +22,8 @@ For example, adding the line `include extraconfig.txt` to `config.txt` will incl
 ## max_usb_current
 
 **This command is now deprecated and has no effect.** Originally certain models of Raspberry Pi limited the USB ports to a maximum of 600mA. Setting `max_usb_current=1` changed this default to 1200mA. However, all firmware now has this flag set by default, so it is no longer necessary to use this option.
+
+## disable_poe_fan
+<a name="disable_poe_fan"></a>
+
+Set this option to `1` to prevent control of the PoE HAT fan through I2C (on pins ID_SD & ID_SC). Without this, a probe on the I2C bus will happen at startup, even when not using the PoE HAT.


### PR DESCRIPTION
This is a little low on details and mostly based on various forum posts
(I do not have a PoE to test with), but I did confirm that setting this
option indeed prevents a probe on I²C.