### PR TITLE
Update timelapse.md

### DIFF
--- a/usage/camera/raspicam/timelapse.md
+++ b/usage/camera/raspicam/timelapse.md
@@ -51,7 +51,7 @@ sudo apt install ffmpeg
 Now you can use the `ffmpeg` tool to convert your JPEG files into an mp4 video:
 
 ```
-ffmpeg -r 10 -f image2 -pattern_type glob -i 'image_*.jpg' -s 1280x720 -vcodec libx264 timelapse.mp4
+ffmpeg -r 10 -f image2 -pattern_type glob -i 'image*.jpg' -s 1280x720 -vcodec libx264 timelapse.mp4
 ```
 
 On a Raspberry Pi 3, this can encode a little more than two frames per second. The performance of other Pi models will vary. The parameters used are:

--- a/usage/camera/raspicam/timelapse.md
+++ b/usage/camera/raspicam/timelapse.md
@@ -58,8 +58,8 @@ On a Raspberry Pi 3, this can encode a little more than two frames per second. T
 
 - `-r 10` Set frame rate (Hz value) to ten frames per second in the output video.
 - `-f image2` Set ffmpeg to read from a list of image files specified by a pattern.
-- `-pattern_type glob` When importing the image files, use wildcard patterns (globbing) to interpret the filename input by `-i`, in this case "image_*.jpg", where "*" would be the image number.
-- `-i 'image_*.jpg'` The input file specification (to match the files produced during the capture).
+- `-pattern_type glob` When importing the image files, use wildcard patterns (globbing) to interpret the filename input by `-i`, in this case "image*.jpg", where "*" would be the image number.
+- `-i 'image*.jpg'` The input file specification (to match the files produced during the capture).
 - `-s 1280x720` Scale to 720p. You can also use 1920x1080, or lower resolutions, depending on your requirements.
 - `-vcodec libx264` Use the software x264 encoder.
 - `timelapse.mp4` The name of the output video file.


### PR DESCRIPTION
At line 54, removal of the underscore in 'image_*Jpg' for consistency with the creation of the images at line 10 (image%04d.jpg). This will avoid raising error below when people (e.g. me earlier today 😁) brutally copy-paste the example.
> [image2 @ 0x5579541a5780] Could not open file : frame-*.jpg
>[image2 @ 0x5579541a5780] Could not find codec parameters for stream 0 (Video: mjpeg, none(bt470bg/unknown/unknown)): unspecified size
>Consider increasing the value for the 'analyzeduration' and 'probesize' options