### PR TITLE
Replace Chrome App with Chrome Extension

### DIFF
--- a/installation/installing-images/chromeos.md
+++ b/installation/installing-images/chromeos.md
@@ -1,12 +1,12 @@
 # Installing operating system images using Chrome OS
 
-The easiest way to write images to an SD card and USB drives with Chrome OS is to use the official [Chromebook Recovery Utility](https://chrome.google.com/webstore/detail/chromebook-recovery-utili/jndclpdbaamdhonoechobihbbiimdgai). It can be used to create Chromebook Recovery media, and it will also accept .zip files containing images.
+The easiest way to write images to an SD card and USB drives with Chrome OS is to use the official [Chromebook Recovery Utility](https://chrome.google.com/webstore/detail/chromebook-recovery-utili/pocpnlppkickgojjlmhdmidojbmbodfm). It can be used to create Chromebook Recovery media, and it will also accept .zip files containing images.
  
 ## Using the Recovery Utility
 
-- Download the [Chromebook Recovery Utility](https://chrome.google.com/webstore/detail/chromebook-recovery-utili/jndclpdbaamdhonoechobihbbiimdgai).
+- Add the [Chromebook Recovery Utility](https://chrome.google.com/webstore/detail/chromebook-recovery-utili/pocpnlppkickgojjlmhdmidojbmbodfm) extension.
 - Download the [Raspberry Pi OS .zip file](https://www.raspberrypi.org/downloads/raspbian/).
-- Launch the **Recovery Utility**
+- Launch the **Recovery Utility** extension
 - Click on the **Settings Gears** icon in the upper right-hand corner, next to the window close icon.
 - Select the **Use Local Image** option.
 - Choose the .zip file you downloaded.


### PR DESCRIPTION
As announced publicly by the [Chromium blog](https://blog.chromium.org/2020/08/changes-to-chrome-app-support-timeline.html). Google is dropping support for Chrome Apps in June 2021. Please use the _Chromebook Recovery Utility extension_ instead.