### PR TITLE
Change Chromebook Recovery Utility Link

### DIFF
--- a/installation/installing-images/chromeos.md
+++ b/installation/installing-images/chromeos.md
@@ -1,10 +1,10 @@
 # Installing operating system images using Chrome OS
 
-The easiest way to write images to an SD card and USB drives with Chrome OS is to use the official [Chromebook Recovery Utility](https://chrome.google.com/webstore/detail/chromebook-recovery-utili/jndclpdbaamdhonoechobihbbiimdgai). It can be used to create Chromebook Recovery media, and it will also accept .zip files containing images.
+The easiest way to write images to an SD card and USB drives with Chrome OS is to use the official [Chromebook Recovery Utility](https://chrome.google.com/webstore/detail/chromebook-recovery-utili/pocpnlppkickgojjlmhdmidojbmbodfm/). It can be used to create Chromebook Recovery media, and it will also accept .zip files containing images.
  
 ## Using the Recovery Utility
 
-- Download the [Chromebook Recovery Utility](https://chrome.google.com/webstore/detail/chromebook-recovery-utili/jndclpdbaamdhonoechobihbbiimdgai).
+- Download the [Chromebook Recovery Utility](https://chrome.google.com/webstore/detail/chromebook-recovery-utili/pocpnlppkickgojjlmhdmidojbmbodfm/).
 - Download the [Raspberry Pi OS .zip file](https://www.raspberrypi.org/downloads/raspbian/).
 - Launch the **Recovery Utility**
 - Click on the **Settings Gears** icon in the upper right-hand corner, next to the window close icon.


### PR DESCRIPTION
General support for Chrome Apps are over, and this app will not work anytime soon (see https://blog.chromium.org/2020/08/changes-to-chrome-app-support-timeline.html, the app also links to this blog post with a red text saying that chrome apps will be killed off). Fortunately, Google has made the same utility as an extension, so the updated link should work,