### PR TITLE
Track page views with Google Analytics

### DIFF
--- a/jekyll-assets/_includes/head.html
+++ b/jekyll-assets/_includes/head.html
@@ -8,3 +8,10 @@
 <link rel="stylesheet" href="https://www.raspberrypi.org/app/themes/mind-control/css/legacy.min.css?ver=1605195698">
 <link rel="stylesheet" href="{{ site.baseurl }}/css/style.css">
 <link rel="stylesheet" href="{{ site.baseurl }}/css/tabs.css">
+<script async src="https://www.googletagmanager.com/gtag/js?id=UA-46270871-1"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+  gtag('config', 'UA-46270871-1', { 'anonymize_ip': true });
+</script>


### PR DESCRIPTION
To keep continuity with the previous documentation site, add the Google Analytics Global Site Tag with the Raspberry PI property tracking ID.  Use Google's IP anonymization when recording any analytics (see https://support.google.com/analytics/answer/2763052?hl=en)
