### PR TITLE
Correct repository name to documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 # README
 
-Instructions on how to checkout the `documentation-ng` repo, and then install the toolchain needed to convert from Asciidoc to HTML and build the documentation site.
+Instructions on how to checkout the `documentation` repo, and then install the toolchain needed to convert from Asciidoc to HTML and build the documentation site.
 
 ## Checking out the repository
 
-Install `git` if you don't already have it, and check out the `documentation-ng` repo as follows,
+Install `git` if you don't already have it, and check out the `documentation` repo as follows,
 ```
-$ git clone https://github.com/raspberrypi/documentation-ng.git
-$ cd documentation-ng
+$ git clone https://github.com/raspberrypi/documentation.git
+$ cd documentation
 ```
 
 ## Installing the toolchain
@@ -72,7 +72,7 @@ $ brew install ninja
 
 ## Configuring the repository
 
-After you've installed the toolchain, you'll need to install the required Ruby gems. Make sure you're in the `documentation-ng` directory and then run,
+After you've installed the toolchain, you'll need to install the required Ruby gems. Make sure you're in the `documentation` directory and then run,
 ```
 $ bundle install
 ```

--- a/_config.yml
+++ b/_config.yml
@@ -18,8 +18,8 @@ description: >- # this means to ignore newlines until "baseurl:"
   Raspberry Pi Documentation.
 baseurl: "/documentation" # the subpath of your site, e.g. /blog
 url: "" # the base hostname & protocol for your site, e.g. http://example.com
-githuburl: "https://github.com/raspberrypi/documentation-ng/"
-githubbranch: main
+githuburl: "https://github.com/raspberrypi/documentation/"
+githubbranch: master
 
 # Build settings
 theme: minima


### PR DESCRIPTION
As the new site was developed in a separate repository, remove any references to its name now that all work is being done in this repository instead.
