### PR TITLE
Remove the FAQ link from the site footer

### DIFF
--- a/jekyll-assets/_includes/footer.html
+++ b/jekyll-assets/_includes/footer.html
@@ -54,9 +54,6 @@
                         <li class="c-footer-nav__item">
                             <a class="c-footer-nav__link" href="/forums">Forums</a>
                         </li>
-                        <li class="c-footer-nav__item">
-                            <a class="c-footer-nav__link" href="/help/faqs">FAQ</a>
-                        </li>
                     </ul>
                 </div>
             </div>


### PR DESCRIPTION
As the new documentation site has no FAQ section, remove the now-redundant link from the site footer.
