### PR TITLE
Run the GitHub Actions build on pull requests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,6 @@
 name: Build
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
   build:


### PR DESCRIPTION
During internal development, we have been pushing branches to this repository thereby triggering the GitHub Actions build using the "push" event. However, now that we accept pull requests from outside the repository, we want builds _before_ pushing to a branch.
