### PR TITLE
Update boot.adoc

### DIFF
--- a/documentation/asciidoc/computers/config_txt/boot.adoc
+++ b/documentation/asciidoc/computers/config_txt/boot.adoc
@@ -21,8 +21,6 @@ On the Pi 4, if the files `start4x.elf` and `fixup4x.dat` are present, these fil
    `start_file=start_db.elf`
    `fixup_file=fixup_db.dat`
 
-There is no specific handling for the Pi 4, so if you wish to use the Pi 4 debug firmware files, you need to manually specify `start_file` and `fixup_file`.
-
 `start_x=1` should be specified when using the camera module. Enabling the camera via `raspi-config` will set this automatically.
 
 === `disable_commandline_tags`


### PR DESCRIPTION
The Pi4 bootloader has supported start_db since at least 2018-11 so this note can be removed to avoid confusion.