### PR TITLE
Update spi-bus-on-raspberry-pi.adoc

### DIFF
--- a/documentation/asciidoc/computers/raspberry-pi/spi-bus-on-raspberry-pi.adoc
+++ b/documentation/asciidoc/computers/raspberry-pi/spi-bus-on-raspberry-pi.adoc
@@ -1,12 +1,12 @@
 [[spi-overview]]
 == Serial Peripheral Interface (SPI)
 
-The Raspberry Pi family of devices is equipped with a number of https://en.wikipedia.org/wiki/Serial_Peripheral_Interface_Bus[SPI] buses. SPI can be used to connect a wide variety of peripherals - displays, network controllers (Ethernet, CAN bus), UARTs, etc. These devices are best supported by kernel device drivers, but the `spidev` API allows userspace drivers to be written in a wide array of languages.
+Raspberry Pi computers are equipped with a number of https://en.wikipedia.org/wiki/Serial_Peripheral_Interface_Bus[SPI] buses. SPI can be used to connect a wide variety of peripherals - displays, network controllers (Ethernet, CAN bus), UARTs, etc. These devices are best supported by kernel device drivers, but the `spidev` API allows userspace drivers to be written in a wide array of languages.
 
 [[spi-hardware]]
 === SPI Hardware
 
-The BCM2835 core common to all Raspberry Pi devices has 3 SPI Controllers:
+The BCM2835 core common to all Raspberry Pi computers has 3 SPI Controllers:
 
 * SPI0, with two hardware chip selects, is available on the header of all Pis (although there is an alternate mapping that is only usable on a Compute Module.
 * SPI1, with three hardware chip selects, is available on 40-pin versions of Pis.
@@ -20,13 +20,37 @@ Chapter 10 in the https://datasheets.raspberrypi.org/bcm2835/bcm2835-peripherals
 
 ===== SPI0 (available on J8/P1 headers on all RPi versions)
 
-| SPI Function | Header Pin | Broadcom Pin Name | Broadcom Pin Function |
-|--|--|--|--|
-| MOSI | 19 | GPIO10 | SPI0_MOSI |
-| MISO | 21 | GPIO09 | SPI0_MISO |
-| SCLK | 23 | GPIO11 | SPI0_SCLK |
-| CE0  | 24 | GPIO08 | SPI0_CE0_N |
-| CE1  | 26 | GPIO07 | SPI0_CE1_N |
+[cols="1,1"]
+|===
+| SPI Function
+| Header Pin
+| Broadcom Pin Name
+| Broadcom Pin Function
+
+| MOSI
+| 19
+| GPIO10
+| SPI0_MOSI
+
+| MISO
+| 21
+| GPIO09
+| SPI0_MISO
+
+| SCLK
+| 23
+| GPIO11
+| SPI0_SCLK
+
+| CE0
+| 24
+| GPIO08
+| SPI0_CE0_N
+
+| CE1
+| 26
+| GPIO07
+| SPI0_CE1_N
 
 ===== SPI0 alternate mapping (available only on Compute Modules)
 

--- a/documentation/asciidoc/computers/raspberry-pi/spi-bus-on-raspberry-pi.adoc
+++ b/documentation/asciidoc/computers/raspberry-pi/spi-bus-on-raspberry-pi.adoc
@@ -124,54 +124,176 @@ Chapter 10 in the https://datasheets.raspberrypi.org/bcm2835/bcm2835-peripherals
 
 ===== SPI2 (available only on compute modules)
 
-| SPI Function | Broadcom Pin Name | Broadcom Pin Function |
-|--|--|--|
-| MOSI | GPIO41 | SPI2_MOSI |
-| MISO | GPIO40 | SPI2_MISO |
-| SCLK | GPIO42 | SPI2_SCLK |
-| CE0  | GPIO43 | SPI2_CE0_N |
-| CE1  | GPIO44 | SPI2_CE1_N |
-| CE2  | GPIO45 | SPI2_CE2_N |
+[cols="1,1,1,1"]
+|===
+| SPI Function
+| Broadcom Pin Name
+| Broadcom Pin Function
+
+| MOSI
+| GPIO41
+| SPI2_MOSI
+
+| MISO
+| GPIO40
+| SPI2_MISO
+
+| SCLK
+| GPIO42
+| SPI2_SCLK
+
+| CE0
+| GPIO43
+| SPI2_CE0_N
+
+| CE1
+| GPIO44
+| SPI2_CE1_N
+
+| CE2
+| GPIO45
+| SPI2_CE2_N
+|===
 
 ===== SPI3 (BCM2711 only)
 
-| SPI Function | Header Pin | Broadcom Pin Name | Broadcom Pin Function |
-|--|--|--|--|
-| MOSI | 03 | GPIO02 | SPI3_MOSI |
-| MISO | 28 | GPIO01 | SPI3_MISO |
-| SCLK | 05 | GPIO03 | SPI3_SCLK |
-| CE0  | 27 | GPIO00 | SPI3_CE0_N |
-| CE1  | 18 | GPIO24 | SPI3_CE1_N |
+[cols="1,1,1,1"]
+|===
+| SPI Function
+| Header Pin
+| Broadcom Pin Name
+| Broadcom Pin Function
+
+| MOSI
+| 03
+| GPIO02
+| SPI3_MOSI
+
+| MISO
+| 28
+| GPIO01
+| SPI3_MISO
+
+| SCLK
+| 05
+| GPIO03
+| SPI3_SCLK
+
+| CE0
+| 27
+| GPIO00
+| SPI3_CE0_N
+
+| CE1
+| 18
+| GPIO24
+| SPI3_CE1_N
+|===
 
 ===== SPI4 (BCM2711 only)
 
-| SPI Function | Header Pin | Broadcom Pin Name | Broadcom Pin Function |
-|--|--|--|--|
-| MOSI | 31 | GPIO06 | SPI4_MOSI |
-| MISO | 29 | GPIO05 | SPI4_MISO |
-| SCLK | 26 | GPIO07 | SPI4_SCLK |
-| CE0  | 07 | GPIO04 | SPI4_CE0_N |
-| CE1  | 22 | GPIO25 | SPI4_CE1_N |
+[cols="1,1,1,1"]
+|===
+| SPI Function
+| Header Pin
+| Broadcom Pin Name
+| Broadcom Pin Function
+
+| MOSI
+| 31
+| GPIO06
+| SPI4_MOSI
+
+| MISO
+| 29
+| GPIO05
+| SPI4_MISO
+
+| SCLK
+| 26
+| GPIO07
+| SPI4_SCLK
+
+| CE0 
+| 07
+| GPIO04
+| SPI4_CE0_N
+
+| CE1
+| 22
+| GPIO25
+| SPI4_CE1_N
+|===
 
 ===== SPI5 (BCM2711 only)
 
-| SPI Function | Header Pin | Broadcom Pin Name | Broadcom Pin Function |
-|--|--|--|--|
-| MOSI | 08 | GPIO14 | SPI5_MOSI |
-| MISO | 33 | GPIO13 | SPI5_MISO |
-| SCLK | 10 | GPIO15 | SPI5_SCLK |
-| CE0  | 32 | GPIO12 | SPI5_CE0_N |
-| CE1  | 37 | GPIO26 | SPI5_CE1_N |
+[cols="1,1,1,1"]
+|===
+| SPI Function
+|Header Pin
+| Broadcom Pin Name
+| Broadcom Pin Function
+
+| MOSI
+| 08
+| GPIO14
+| SPI5_MOSI
+
+| MISO
+| 33
+| GPIO13
+| SPI5_MISO
+
+| SCLK
+| 10
+| GPIO15
+| SPI5_SCLK
+
+| CE0
+| 32
+| GPIO12
+| SPI5_CE0_N
+
+| CE1
+| 37
+| GPIO26
+| SPI5_CE1_N
+|===
 
 ===== SPI6 (BCM2711 only)
 
-| SPI Function | Header Pin | Broadcom Pin Name | Broadcom Pin Function |
-|--|--|--|--|
-| MOSI | 38 | GPIO20 | SPI6_MOSI |
-| MISO | 35 | GPIO19 | SPI6_MISO |
-| SCLK | 40 | GPIO21 | SPI6_SCLK |
-| CE0  | 12 | GPIO18 | SPI6_CE0_N |
-| CE1  | 13 | GPIO27 | SPI6_CE1_N |
+[cols="1,1,1,1"]
+|===
+| SPI Function
+| Header Pin
+| Broadcom Pin Name
+| Broadcom Pin Function
+
+| MOSI
+| 38
+| GPIO20
+| SPI6_MOSI
+
+| MISO
+| 35
+| GPIO19
+| SPI6_MISO
+
+| SCLK
+| 40
+| GPIO21
+| SPI6_SCLK
+
+| CE0
+| 12
+| GPIO18
+| SPI6_CE0_N
+
+| CE1
+| 13
+| GPIO27
+| SPI6_CE1_N
+|===
 
 ==== Master modes
 

--- a/documentation/asciidoc/computers/raspberry-pi/spi-bus-on-raspberry-pi.adoc
+++ b/documentation/asciidoc/computers/raspberry-pi/spi-bus-on-raspberry-pi.adoc
@@ -333,8 +333,9 @@ The CDIV (Clock Divider) field of the CLK register sets the SPI clock speed:
 
 ----
 SCLK = Core Clock / CDIV
-If CDIV is set to 0, the divisor is 65536. The divisor must be a multiple of 2, with odd numbers rounded down. Note that not all possible clock rates are usable because of analogue electrical issues (rise times, drive strengths, etc.)
 ----
+
+If CDIV is set to 0, the divisor is 65536. The divisor must be a multiple of 2, with odd numbers rounded down. Note that not all possible clock rates are usable because of analogue electrical issues (rise times, drive strengths, etc)
 
 See the <<driver,Linux driver>> section for more info.
 

--- a/documentation/asciidoc/computers/raspberry-pi/spi-bus-on-raspberry-pi.adoc
+++ b/documentation/asciidoc/computers/raspberry-pi/spi-bus-on-raspberry-pi.adoc
@@ -6,11 +6,11 @@ Raspberry Pi computers are equipped with a number of https://en.wikipedia.org/wi
 [[spi-hardware]]
 === SPI Hardware
 
-The BCM2835 core common to all Raspberry Pi computers has 3 SPI Controllers:
+The BCM2835 core common to all Raspberry Pi computers has 3 SPI controllers:
 
-* SPI0, with two hardware chip selects, is available on the header of all Pis (although there is an alternate mapping that is only usable on a Compute Module.
-* SPI1, with three hardware chip selects, is available on 40-pin versions of Pis.
-* SPI2, also with three hardware chip selects, is only usable on compute modules because the pins are not brought out onto the 40-pin header.
+* SPI0, with two hardware chip selects, is available on the header of all Pis; there is also an alternate mapping that is only available on compute modules.
+* SPI1, with three hardware chip selects, is available on all Raspberry Pi models except the original Pi 1 Models A and B.
+* SPI2, also with three hardware chip selects, is only avalable on compute modules.
 
 BCM2711 adds another 4 SPI buses - SPI3 to SPI6, each with 2 hardware chip selects; these extra SPI buses are available via alternate function assignments on certain GPIO pins - see the https://datasheets.raspberrypi.org/bcm2711/bcm2711-peripherals.pdf[BCM2711 ARM Peripherals] datasheet.
 
@@ -341,7 +341,7 @@ See the <<driver,Linux driver>> section for more info.
 
 ==== Chip Selects
 
-Setup and Hold times related to the automatic assertion and de-assertion of the CS lines when operating in *DMA* mode are as follows:
+Setup and hold times related to the automatic assertion and de-assertion of the CS lines when operating in *DMA* mode are as follows:
 
 * The CS line will be asserted at least 3 core clock cycles before the msb of the first byte of the transfer.
 * The CS line will be de-asserted no earlier than 1 core clock cycle after the trailing edge of the final clock pulse.

--- a/documentation/asciidoc/computers/raspberry-pi/spi-bus-on-raspberry-pi.adoc
+++ b/documentation/asciidoc/computers/raspberry-pi/spi-bus-on-raspberry-pi.adoc
@@ -6,13 +6,13 @@ Raspberry Pi computers are equipped with a number of https://en.wikipedia.org/wi
 [[spi-hardware]]
 === SPI Hardware
 
-The BCM2835 core common to all Raspberry Pi computers has 3 SPI controllers:
+Rapsberry Pi Zero, 1, 2 and 3 have three SPI controllers:
 
 * SPI0, with two hardware chip selects, is available on the header of all Pis; there is also an alternate mapping that is only available on compute modules.
-* SPI1, with three hardware chip selects, is available on all Raspberry Pi models except the original Pi 1 Models A and B.
+* SPI1, with three hardware chip selects, is available on all Raspberry Pi models except the original Pi 1 models A and B.
 * SPI2, also with three hardware chip selects, is only avalable on compute modules.
 
-BCM2711 adds another 4 SPI buses - SPI3 to SPI6, each with 2 hardware chip selects; these extra SPI buses are available via alternate function assignments on certain GPIO pins - see the https://datasheets.raspberrypi.org/bcm2711/bcm2711-peripherals.pdf[BCM2711 ARM Peripherals] datasheet.
+On the Raspberry Pi 4, 400 and Compute Module 4 there are four additional SPI buses: SPI3 to SPI6, each with 2 hardware chip selects. These extra SPI buses are available via alternate function assignments on certain GPIO pins - see the https://datasheets.raspberrypi.org/bcm2711/bcm2711-peripherals.pdf[BCM2711 ARM Peripherals] datasheet.
 
 Chapter 10 in the https://datasheets.raspberrypi.org/bcm2835/bcm2835-peripherals.pdf[BCM2835 ARM Peripherals] datasheet describes the main controller.  Chapter 2.3 describes the auxiliary controller.
 

--- a/documentation/asciidoc/computers/raspberry-pi/spi-bus-on-raspberry-pi.adoc
+++ b/documentation/asciidoc/computers/raspberry-pi/spi-bus-on-raspberry-pi.adoc
@@ -10,9 +10,9 @@ The BCM2835 core common to all Raspberry Pi computers has 3 SPI Controllers:
 
 * SPI0, with two hardware chip selects, is available on the header of all Pis (although there is an alternate mapping that is only usable on a Compute Module.
 * SPI1, with three hardware chip selects, is available on 40-pin versions of Pis.
-* SPI2, also with three hardware chip selects, is only usable on a Compute Module because the pins aren't brought out onto the 40-pin header.
+* SPI2, also with three hardware chip selects, is only usable on compute modules because the pins are not brought out onto the 40-pin header.
 
-BCM2711 adds another 4 SPI buses - SPI3 to SPI6, each with 2 hardware chip selects. All are available on the 40-pin header (provided nothing else is trying to use the same pins).
+BCM2711 adds another 4 SPI buses - SPI3 to SPI6, each with 2 hardware chip selects; the new SPI buses are available via alternate function assignments on certain GPIO pins - see the https://datasheets.raspberrypi.org/bcm2711/bcm2711-peripherals.pdf[BCM2711 ARM Peripherals] datasheet.
 
 Chapter 10 in the https://datasheets.raspberrypi.org/bcm2835/bcm2835-peripherals.pdf[BCM2835 ARM Peripherals] datasheet describes the main controller.  Chapter 2.3 describes the auxiliary controller.
 
@@ -319,7 +319,7 @@ In bidirectional SPI mode the same SPI standard is implemented, except that a si
 
 The LoSSI standard allows issuing of commands to peripherals (LCD) and to transfer data to and from them. LoSSI commands and parameters are 8 bits long, but an extra bit is used to indicate whether the byte is a command or parameter/data. This extra bit is set high for a data and low for a command. The resulting 9-bit value is serialized to the output. LoSSI is commonly used with http://mipi.org/specifications/display-interface[MIPI DBI] type C compatible LCD controllers.
 
-NOTE: Some commands trigger an automatic read by the SPI controller, so this mode can't be used as a multipurpose 9-bit SPI.
+NOTE: Some commands trigger an automatic read by the SPI controller, so this mode cannot be used as a multipurpose 9-bit SPI.
 
 ==== Transfer modes
 
@@ -353,7 +353,7 @@ Setup and Hold times related to the automatic assertion and de-assertion of the 
 
 The default Linux driver is now the standard spi-bcm2835.
 
-SPI0 is disabled by default. To enable it, use xref:configuration.adoc#raspi-config[raspi-config], or ensure the line `dtparam=spi=on` isn't commented out in `/boot/config.txt`. By default it uses 2 chip select lines, but this can be reduced to 1 using `dtoverlay=spi0-1cs`. `dtoverlay=spi0-2cs` also exists, and without any parameters it is equivalent to `dtparam=spi=on`.
+SPI0 is disabled by default. To enable it, use xref:configuration.adoc#raspi-config[raspi-config], or ensure the line `dtparam=spi=on` is not commented out in `/boot/config.txt`. By default it uses 2 chip select lines, but this can be reduced to 1 using `dtoverlay=spi0-1cs`. `dtoverlay=spi0-2cs` also exists, and without any parameters it is equivalent to `dtparam=spi=on`.
 
 To enable SPI1, you can use 1, 2 or 3 chip select lines, adding in each case:
 
@@ -399,11 +399,11 @@ This https://www.raspberrypi.org/forums/viewtopic.php?f=44&t=19489[thread] discu
 
 ==== spidev
 
-spidev presents an ioctl-based userspace interface to individual SPI CS lines. Device Tree is used to indicate whether a CS line is going to be driven by a kernel driver module or managed by spidev on behalf of the user; it isn't possible to do both at the same time. Note that Raspberry Pi's own kernels are more relaxed about the use of Device Tree to enable spidev - the upstream kernels print warnings about such usage, and ultimately may prevent it altogether.
+spidev presents an ioctl-based userspace interface to individual SPI CS lines. Device Tree is used to indicate whether a CS line is going to be driven by a kernel driver module or managed by spidev on behalf of the user; it is not possible to do both at the same time. Note that Raspberry Pi's own kernels are more relaxed about the use of Device Tree to enable spidev - the upstream kernels print warnings about such usage, and ultimately may prevent it altogether.
 
 ===== Using spidev from C
 
-There's a loopback test program in the Linux documentation that can be used as a starting point. See the <<troubleshooting,Troubleshooting>> section.
+There is a loopback test program in the Linux documentation that can be used as a starting point. See the <<troubleshooting,Troubleshooting>> section.
 
 ===== Using spidev from Python
 

--- a/documentation/asciidoc/computers/raspberry-pi/spi-bus-on-raspberry-pi.adoc
+++ b/documentation/asciidoc/computers/raspberry-pi/spi-bus-on-raspberry-pi.adoc
@@ -20,7 +20,7 @@ Chapter 10 in the https://datasheets.raspberrypi.org/bcm2835/bcm2835-peripherals
 
 ===== SPI0 (available on J8/P1 headers on all RPi versions)
 
-[cols="1,1"]
+[cols="1,1,1,1"]
 |===
 | SPI Function
 | Header Pin

--- a/documentation/asciidoc/computers/raspberry-pi/spi-bus-on-raspberry-pi.adoc
+++ b/documentation/asciidoc/computers/raspberry-pi/spi-bus-on-raspberry-pi.adoc
@@ -10,7 +10,7 @@ Rapsberry Pi Zero, 1, 2 and 3 have three SPI controllers:
 
 * SPI0, with two hardware chip selects, is available on the header of all Pis; there is also an alternate mapping that is only available on compute modules.
 * SPI1, with three hardware chip selects, is available on all Raspberry Pi models except the original Pi 1 models A and B.
-* SPI2, also with three hardware chip selects, is only avalable on compute modules.
+* SPI2, also with three hardware chip selects, is only avalable on Compute Module 1, 3 and 3+.
 
 On the Raspberry Pi 4, 400 and Compute Module 4 there are four additional SPI buses: SPI3 to SPI6, each with 2 hardware chip selects. These extra SPI buses are available via alternate function assignments on certain GPIO pins - see the https://datasheets.raspberrypi.org/bcm2711/bcm2711-peripherals.pdf[BCM2711 ARM Peripherals] datasheet.
 

--- a/documentation/asciidoc/computers/raspberry-pi/spi-bus-on-raspberry-pi.adoc
+++ b/documentation/asciidoc/computers/raspberry-pi/spi-bus-on-raspberry-pi.adoc
@@ -335,7 +335,7 @@ The CDIV (Clock Divider) field of the CLK register sets the SPI clock speed:
 SCLK = Core Clock / CDIV
 ----
 
-If CDIV is set to 0, the divisor is 65536. The divisor must be a multiple of 2, with odd numbers rounded down. Note that not all possible clock rates are usable because of analogue electrical issues (rise times, drive strengths, etc)
+If CDIV is set to 0, the divisor is 65536. The divisor must be a multiple of 2, with odd numbers rounded down. Note that not all possible clock rates are usable because of analogue electrical issues (rise times, drive strengths, etc).
 
 See the <<driver,Linux driver>> section for more info.
 

--- a/documentation/asciidoc/computers/raspberry-pi/spi-bus-on-raspberry-pi.adoc
+++ b/documentation/asciidoc/computers/raspberry-pi/spi-bus-on-raspberry-pi.adoc
@@ -53,7 +53,7 @@ Chapter 10 in the https://datasheets.raspberrypi.org/bcm2835/bcm2835-peripherals
 | SPI0_CE1_N
 |===
 
-===== SPI0 alternate mapping (available only on compute modules)
+===== SPI0 alternate mapping (compute modules only)
 
 [cols="1,1,1,1"]
 |===
@@ -122,7 +122,7 @@ Chapter 10 in the https://datasheets.raspberrypi.org/bcm2835/bcm2835-peripherals
 | SPI1_CE2_N
 |===
 
-===== SPI2 (available only on compute modules)
+===== SPI2 (compute modules only)
 
 [cols="1,1,1,1"]
 |===

--- a/documentation/asciidoc/computers/raspberry-pi/spi-bus-on-raspberry-pi.adoc
+++ b/documentation/asciidoc/computers/raspberry-pi/spi-bus-on-raspberry-pi.adoc
@@ -352,7 +352,7 @@ Setup and Hold times related to the automatic assertion and de-assertion of the 
 [[driver]]
 ==== Linux driver
 
-The default Linux driver is now the standard spi-bcm2835.
+The default Linux driver is `spi-bcm2835`.
 
 SPI0 is disabled by default. To enable it, use xref:configuration.adoc#raspi-config[raspi-config], or ensure the line `dtparam=spi=on` is not commented out in `/boot/config.txt`. By default it uses 2 chip select lines, but this can be reduced to 1 using `dtoverlay=spi0-1cs`. `dtoverlay=spi0-2cs` also exists, and without any parameters it is equivalent to `dtparam=spi=on`.
 
@@ -383,7 +383,7 @@ SPI_NO_CS   - 1 device per bus, no Chip Select
 SPI_3WIRE   - Bidirectional mode, data in and out pin shared
 ----
 
-Bidirectional or "3-wire" mode is supported by the spi-bcm2835 kernel module. Please note that in this mode, either the tx or rx field of the spi_transfer struct must be a NULL pointer, since only half-duplex communication is possible. Otherwise, the transfer will fail. The spidev_test.c source code does not consider this correctly, and therefore does not work at all in 3-wire mode.
+Bidirectional or "3-wire" mode is supported by the `spi-bcm2835` kernel module. Please note that in this mode, either the tx or rx field of the spi_transfer struct must be a NULL pointer, since only half-duplex communication is possible. Otherwise, the transfer will fail. The spidev_test.c source code does not consider this correctly, and therefore does not work at all in 3-wire mode.
 
 ===== Supported bits per word
 
@@ -400,7 +400,7 @@ This https://www.raspberrypi.org/forums/viewtopic.php?f=44&t=19489[thread] discu
 
 ==== spidev
 
-spidev presents an ioctl-based userspace interface to individual SPI CS lines. Device Tree is used to indicate whether a CS line is going to be driven by a kernel driver module or managed by spidev on behalf of the user; it is not possible to do both at the same time. Note that Raspberry Pi's own kernels are more relaxed about the use of Device Tree to enable spidev - the upstream kernels print warnings about such usage, and ultimately may prevent it altogether.
+`spidev` presents an ioctl-based userspace interface to individual SPI CS lines. Device Tree is used to indicate whether a CS line is going to be driven by a kernel driver module or managed by spidev on behalf of the user; it is not possible to do both at the same time. Note that Raspberry Pi's own kernels are more relaxed about the use of Device Tree to enable `spidev` - the upstream kernels print warnings about such usage, and ultimately may prevent it altogether.
 
 ===== Using spidev from C
 
@@ -408,7 +408,7 @@ There is a loopback test program in the Linux documentation that can be used as 
 
 ===== Using spidev from Python
 
-There are several Python libraries that provide access to spidev, including the imaginatively named `spidev` (`pip install spidev` - see https://pypi.org/project/spidev/) and `SPI-Py` (https://github.com/lthiery/SPI-Py).
+There are several Python libraries that provide access to `spidev`, including `spidev` (`pip install spidev` - see https://pypi.org/project/spidev/) and `SPI-Py` (https://github.com/lthiery/SPI-Py).
 
 ===== Using spidev from a shell such as bash
 
@@ -420,7 +420,7 @@ echo -ne "\x01\x02\x03" > /dev/spidev0.0
 
 ==== Other SPI libraries
 
-There are other userspace libraries that provide SPI control by directly manipulating the hardware. This is not recommended.
+There are other userspace libraries that provide SPI control by directly manipulating the hardware: this is not recommended.
 
 [[troubleshooting-spi-hardware]]
 === Troubleshooting

--- a/documentation/asciidoc/computers/raspberry-pi/spi-bus-on-raspberry-pi.adoc
+++ b/documentation/asciidoc/computers/raspberry-pi/spi-bus-on-raspberry-pi.adoc
@@ -12,7 +12,7 @@ The BCM2835 core common to all Raspberry Pi computers has 3 SPI Controllers:
 * SPI1, with three hardware chip selects, is available on 40-pin versions of Pis.
 * SPI2, also with three hardware chip selects, is only usable on compute modules because the pins are not brought out onto the 40-pin header.
 
-BCM2711 adds another 4 SPI buses - SPI3 to SPI6, each with 2 hardware chip selects; the new SPI buses are available via alternate function assignments on certain GPIO pins - see the https://datasheets.raspberrypi.org/bcm2711/bcm2711-peripherals.pdf[BCM2711 ARM Peripherals] datasheet.
+BCM2711 adds another 4 SPI buses - SPI3 to SPI6, each with 2 hardware chip selects; these extra SPI buses are available via alternate function assignments on certain GPIO pins - see the https://datasheets.raspberrypi.org/bcm2711/bcm2711-peripherals.pdf[BCM2711 ARM Peripherals] datasheet.
 
 Chapter 10 in the https://datasheets.raspberrypi.org/bcm2835/bcm2835-peripherals.pdf[BCM2835 ARM Peripherals] datasheet describes the main controller.  Chapter 2.3 describes the auxiliary controller.
 

--- a/documentation/asciidoc/computers/raspberry-pi/spi-bus-on-raspberry-pi.adoc
+++ b/documentation/asciidoc/computers/raspberry-pi/spi-bus-on-raspberry-pi.adoc
@@ -18,7 +18,7 @@ Chapter 10 in the https://datasheets.raspberrypi.org/bcm2835/bcm2835-peripherals
 
 ==== Pin/GPIO mappings
 
-===== SPI0 (available on J8/P1 headers on all RPi versions)
+===== SPI0
 
 [cols="1,1,1,1"]
 |===
@@ -51,29 +51,78 @@ Chapter 10 in the https://datasheets.raspberrypi.org/bcm2835/bcm2835-peripherals
 | 26
 | GPIO07
 | SPI0_CE1_N
+|===
 
-===== SPI0 alternate mapping (available only on Compute Modules)
+===== SPI0 alternate mapping (available only on compute modules)
 
-| SPI Function | Broadcom Pin Name | Broadcom Pin Function |
-|--|--|--|
-| MOSI | GPIO38 | SPI0_MOSI |
-| MISO | GPIO37 | SPI0_MISO |
-| SCLK | GPIO39 | SPI0_SCLK |
-| CE0  | GPIO36 | SPI0_CE0_N |
-| CE1  | GPIO35 | SPI0_CE1_N |
+[cols="1,1,1,1"]
+|===
+| SPI Function
+| Broadcom Pin Name
+| Broadcom Pin Function
 
-===== SPI1 (available only on 40-pin J8 header)
+| MOSI
+| GPIO38
+| SPI0_MOSI
 
-| SPI Function | Header Pin | Broadcom Pin Name | Broadcom Pin Function |
-|--|--|--|--|
-| MOSI | 38 | GPIO20 | SPI1_MOSI |
-| MISO | 35 | GPIO19 | SPI1_MISO |
-| SCLK | 40 | GPIO21 | SPI1_SCLK |
-| CE0  | 12 | GPIO18 | SPI1_CE0_N |
-| CE1  | 11 | GPIO17 | SPI1_CE1_N |
-| CE2  | 36 | GPIO16 | SPI1_CE2_N |
+| MISO
+| GPIO37
+| SPI0_MISO
 
-===== SPI2 (available only on Compute Modules)
+| SCLK
+| GPIO39
+| SPI0_SCLK
+
+| CE0
+| GPIO36
+| SPI0_CE0_N
+
+| CE1
+| GPIO35
+| SPI0_CE1_N
+|===
+
+===== SPI1
+
+[cols="1,1,1,1"]
+|===
+| SPI Function
+| Header Pin
+| Broadcom Pin Name
+| Broadcom Pin Function
+
+| MOSI
+| 38
+| GPIO20
+| SPI1_MOSI
+
+| MISO
+| 35
+| GPIO19
+| SPI1_MISO
+
+| SCLK
+| 40
+| GPIO21
+| SPI1_SCLK
+
+| CE0
+| 12
+| GPIO18
+| SPI1_CE0_N
+
+| CE1
+| 11
+| GPIO17
+| SPI1_CE1_N
+
+| CE2
+| 36
+| GPIO16
+| SPI1_CE2_N
+|===
+
+===== SPI2 (available only on compute modules)
 
 | SPI Function | Broadcom Pin Name | Broadcom Pin Function |
 |--|--|--|


### PR DESCRIPTION
- convert table markdown to asciidoc
- devices -> computers, since not all Raspberry Pi devices are computers now
- grammar - `Compute Modules` -> `compute modules`
- grammar - remove contractions