### PR TITLE
Update boot-eeprom-rpi4.adoc

### DIFF
--- a/documentation/asciidoc/computers/raspberry-pi/boot-eeprom-rpi4.adoc
+++ b/documentation/asciidoc/computers/raspberry-pi/boot-eeprom-rpi4.adoc
@@ -1,6 +1,6 @@
 == Raspberry Pi 4 Boot EEPROM
 
-Raspberry Pi 4 and 400 computers use an EEPROM to boot the system. All other models of Raspberry Pi computer use the `bootcode.bin` file located in the boot filesystem.
+Raspberry Pi 4, 400 and Compute Module 4 computers use an EEPROM to boot the system. All other models of Raspberry Pi computer use the `bootcode.bin` file located in the boot filesystem.
 
 NOTE: The scripts and pre-compiled binaries used to create the `rpi-eeprom` package which is used to update the Raspberry Pi 4 bootloader and VLI USB controller EEPROMs is available https://github.com/raspberrypi/rpi-eeprom/[on Github].
 

--- a/documentation/asciidoc/computers/raspberry-pi/boot-eeprom-rpi4.adoc
+++ b/documentation/asciidoc/computers/raspberry-pi/boot-eeprom-rpi4.adoc
@@ -210,6 +210,7 @@ See also xref:raspberry-pi.adoc#raspberry-pi-4-boot-flow[Raspberry Pi 4 boot-flo
 | The VLI805 USB firmware EEPROM image - ignored on 1.4 board revision which does not have a dedicated VLI EEPROM
 
 | vl805.sig| The sha256 checksum of vl805.bin
+|===
 
 * If the bootloader update image is called `pieeprom.upd` then `recovery.bin` renames itself to `recovery.000` and resets the CPU. Since `recovery.bin` is no longer present the ROM loads the newly updated bootloader from SPI EEPROM and the OS is booted as normal.
 * If the bootloader update image is called `pieeprom.bin` then `recovery.bin` will stop after the update has completed. On success the HDMI output will be green and the green activity LED is flashed rapidly. If the update fails, the HDMI output will be red and an xref:configuration.adoc#led-warning-flash-codes[error code] will be displayed via the activity LED.

--- a/documentation/asciidoc/computers/raspberry-pi/boot-eeprom-rpi4.adoc
+++ b/documentation/asciidoc/computers/raspberry-pi/boot-eeprom-rpi4.adoc
@@ -212,7 +212,7 @@ See also xref:raspberry-pi.adoc#raspberry-pi-4-boot-flow[Raspberry Pi 4 boot-flo
 | vl805.sig| The sha256 checksum of vl805.bin
 |===
 
-* If the bootloader update image is called `pieeprom.upd` then `recovery.bin` renames itself to `recovery.000` and resets the CPU. Since `recovery.bin` is no longer present the ROM loads the newly updated bootloader from EEPROM and the OS is booted as normal.
+* If the bootloader update image is called `pieeprom.upd` then `recovery.bin` is renamed to `recovery.000` once the update has completed, then the system is rebooted. Since `recovery.bin` is no longer present the ROM loads the newly updated bootloader from EEPROM and the OS is booted as normal.
 * If the bootloader update image is called `pieeprom.bin` then `recovery.bin` will stop after the update has completed. On success the HDMI output will be green and the green activity LED is flashed rapidly. If the update fails, the HDMI output will be red and an xref:configuration.adoc#led-warning-flash-codes[error code] will be displayed via the activity LED.
 * The `.sig` files contain the hexadecimal sha256 checksum of the corresponding image file; additional fields may be added in the future.
 * The BCM2711 ROM does not support loading `recovery.bin` from USB mass storage or TFTP. Instead, newer versions of the bootloader support a self-update mechanism where the bootloader is able to reflash the EEPROM itself. See `ENABLE_SELF_UPDATE` on the xref:raspberry-pi.adoc#raspberry-pi-4-bootloader-configuration[bootloader configuration] page.

--- a/documentation/asciidoc/computers/raspberry-pi/boot-eeprom-rpi4.adoc
+++ b/documentation/asciidoc/computers/raspberry-pi/boot-eeprom-rpi4.adoc
@@ -1,6 +1,6 @@
 == Raspberry Pi 4 Boot EEPROM
 
-The Raspberry Pi 4 has an SPI-attached EEPROM (4MBits/512KB), which contains code to boot up the system and replaces `bootcode.bin` previously found in the boot partition of the SD card. Note that if a `bootcode.bin` is present in the boot partition of the SD card in a Pi 4, it is ignored.
+The Raspberry Pi 4 has an SPI-attached EEPROM, which contains code to boot up the system and replaces `bootcode.bin` previously found in the boot partition of the SD card. Note that if a `bootcode.bin` is present in the boot partition of the SD card in a Pi 4, it is ignored.
 
 NOTE: The scripts and pre-compiled binaries used to create the `rpi-eeprom` package which is used to update the Raspberry Pi 4 bootloader and VLI USB controller EEPROMs is available https://github.com/raspberrypi/rpi-eeprom/[on Github].
 
@@ -189,23 +189,36 @@ See also xref:raspberry-pi.adoc#raspberry-pi-4-boot-flow[Raspberry Pi 4 boot-flo
 
 ==== EEPROM update files
 
-| Filename | Purpose |
-|-------|------|
-| recovery.bin | VideoCore EEPROM recovery executable |
-| pieeprom.upd | Bootloader EEPROM image |
-| pieeprom.bin | Bootloader EEPROM image - same as pieeprom.upd but changes recovery.bin behaviour |
-| pieeprom.sig | The sha256 checksum of bootloader image (pieeprom.upd/pieeprom.bin) |
-| vl805.bin | The VLI805 USB firmware EEPROM image - ignored on 1.4 board revision which does not have a dedicated VLI EEPROM|
-| vl805.sig | The sha256 checksum of vl805.bin |
+[cols="1,1"]
+|===
+| Filename
+| Purpose
+
+| recovery.bin
+| bootloader EEPROM recovery executable
+
+| pieeprom.upd
+| Bootloader EEPROM image
+
+| pieeprom.bin
+| Bootloader EEPROM image - same as pieeprom.upd but changes recovery.bin behaviour
+
+| pieeprom.sig
+| The sha256 checksum of bootloader image (pieeprom.upd/pieeprom.bin)
+
+| vl805.bin
+| The VLI805 USB firmware EEPROM image - ignored on 1.4 board revision which does not have a dedicated VLI EEPROM
+
+| vl805.sig| The sha256 checksum of vl805.bin
 
 * If the bootloader update image is called `pieeprom.upd` then `recovery.bin` renames itself to `recovery.000` and resets the CPU. Since `recovery.bin` is no longer present the ROM loads the newly updated bootloader from SPI EEPROM and the OS is booted as normal.
-* If the bootloader update image is called `pieeprom.bin` the `recovery.bin` will stop after the update has completed. On success the HDMI output will be green and the green activity LED is flashed rapidly. Otherwise, the HDMI output will be red and an xref:configuration.adoc#led-warning-flash-codes[error code] will be displayed via the activity LED.
-* The `.sig` files should just contain the sha256 checksum (in hex) of the corresponding image file. Other fields may be added in the future.
+* If the bootloader update image is called `pieeprom.bin` then `recovery.bin` will stop after the update has completed. On success the HDMI output will be green and the green activity LED is flashed rapidly. If the update fails, the HDMI output will be red and an xref:configuration.adoc#led-warning-flash-codes[error code] will be displayed via the activity LED.
+* The `.sig` files contain the hexadecimal sha256 checksum of the corresponding image file; additional fields may be added in the future.
 * The BCM2711 ROM does not support loading `recovery.bin` from USB mass storage or TFTP. Instead, newer versions of the bootloader support a self-update mechanism where the SPI bootloader is able to reflash the SPI EEPROM itself. See `ENABLE_SELF_UPDATE` on the xref:raspberry-pi.adoc#raspberry-pi-4-bootloader-configuration[bootloader configuration] page.
 * The temporary EEPROM update files are automatically deleted by the `rpi-eeprom-update` service at startup.
 
-For more information about the `rpi-eeprom-update` configuration file please run `rpi-eeprom-update -h`.
+For more information about the `rpi-eeprom-update` configuration file see `rpi-eeprom-update -h`.
 
 ==== EEPROM write protect
 
-Both the bootloader and VLI SPI EEPROMs support hardware write-protection.  See the xref:raspberry-pi.adoc#eeprom_write_protect[eeprom_write_protect] option for more information about how to enable this when flashing the EEPROMs.
+Both the bootloader and VLI SPI EEPROMs support hardware write protection.  See the xref:raspberry-pi.adoc#eeprom_write_protect[eeprom_write_protect] option for more information about how to enable this when flashing the EEPROMs.

--- a/documentation/asciidoc/computers/raspberry-pi/boot-eeprom-rpi4.adoc
+++ b/documentation/asciidoc/computers/raspberry-pi/boot-eeprom-rpi4.adoc
@@ -1,6 +1,6 @@
 == Raspberry Pi 4 Boot EEPROM
 
-The Raspberry Pi 4 has an SPI-attached EEPROM, which contains code to boot up the system and replaces `bootcode.bin` previously found in the boot partition of the SD card. Note that if a `bootcode.bin` is present in the boot partition of the SD card in a Pi 4, it is ignored.
+Raspberry Pi 4 and 400 computers use an EEPROM to boot the system. All other models of Raspberry Pi computer use the `bootcode.bin` file located in the boot filesystem.
 
 NOTE: The scripts and pre-compiled binaries used to create the `rpi-eeprom` package which is used to update the Raspberry Pi 4 bootloader and VLI USB controller EEPROMs is available https://github.com/raspberrypi/rpi-eeprom/[on Github].
 
@@ -183,7 +183,7 @@ rpi-eeprom-config --config boot.conf --out new.bin pieeprom.bin
 
 ==== recovery.bin
 
-At power on, the BCM2711 ROM looks for a file called `recovery.bin` in the root directory of the boot partition on the SD card. If a valid `recovery.bin` is found then the ROM executes this instead of the SPI EEPROM image. This mechanism ensures that the bootloader SPI EEPROM can always be reset to a valid image with factory default settings.
+At power on, the BCM2711 ROM looks for a file called `recovery.bin` in the root directory of the boot partition on the SD card. If a valid `recovery.bin` is found then the ROM executes this instead of the contents of the EEPROM. This mechanism ensures that the bootloader EEPROM can always be reset to a valid image with factory default settings.
 
 See also xref:raspberry-pi.adoc#raspberry-pi-4-boot-flow[Raspberry Pi 4 boot-flow]
 
@@ -207,19 +207,19 @@ See also xref:raspberry-pi.adoc#raspberry-pi-4-boot-flow[Raspberry Pi 4 boot-flo
 | The sha256 checksum of bootloader image (pieeprom.upd/pieeprom.bin)
 
 | vl805.bin
-| The VLI805 USB firmware EEPROM image - ignored on 1.4 board revision which does not have a dedicated VLI EEPROM
+| The VLI805 USB firmware EEPROM image - ignored on 1.4 and later board revisions which do not have a dedicated VLI EEPROM
 
 | vl805.sig| The sha256 checksum of vl805.bin
 |===
 
-* If the bootloader update image is called `pieeprom.upd` then `recovery.bin` renames itself to `recovery.000` and resets the CPU. Since `recovery.bin` is no longer present the ROM loads the newly updated bootloader from SPI EEPROM and the OS is booted as normal.
+* If the bootloader update image is called `pieeprom.upd` then `recovery.bin` renames itself to `recovery.000` and resets the CPU. Since `recovery.bin` is no longer present the ROM loads the newly updated bootloader from EEPROM and the OS is booted as normal.
 * If the bootloader update image is called `pieeprom.bin` then `recovery.bin` will stop after the update has completed. On success the HDMI output will be green and the green activity LED is flashed rapidly. If the update fails, the HDMI output will be red and an xref:configuration.adoc#led-warning-flash-codes[error code] will be displayed via the activity LED.
 * The `.sig` files contain the hexadecimal sha256 checksum of the corresponding image file; additional fields may be added in the future.
-* The BCM2711 ROM does not support loading `recovery.bin` from USB mass storage or TFTP. Instead, newer versions of the bootloader support a self-update mechanism where the SPI bootloader is able to reflash the SPI EEPROM itself. See `ENABLE_SELF_UPDATE` on the xref:raspberry-pi.adoc#raspberry-pi-4-bootloader-configuration[bootloader configuration] page.
+* The BCM2711 ROM does not support loading `recovery.bin` from USB mass storage or TFTP. Instead, newer versions of the bootloader support a self-update mechanism where the bootloader is able to reflash the EEPROM itself. See `ENABLE_SELF_UPDATE` on the xref:raspberry-pi.adoc#raspberry-pi-4-bootloader-configuration[bootloader configuration] page.
 * The temporary EEPROM update files are automatically deleted by the `rpi-eeprom-update` service at startup.
 
 For more information about the `rpi-eeprom-update` configuration file see `rpi-eeprom-update -h`.
 
 ==== EEPROM write protect
 
-Both the bootloader and VLI SPI EEPROMs support hardware write protection.  See the xref:raspberry-pi.adoc#eeprom_write_protect[eeprom_write_protect] option for more information about how to enable this when flashing the EEPROMs.
+Both the bootloader and VLI EEPROMs support hardware write protection.  See the xref:raspberry-pi.adoc#eeprom_write_protect[eeprom_write_protect] option for more information about how to enable this when flashing the EEPROMs.


### PR DESCRIPTION
- various grammar fixes.
- removed reference to the capacity of the bootloader EEPROM, since jamesh is on record (in one of the forums) as saying that there is no guarantee that the capacity of the EEPROM won't change. 
- clarified meaning of sentence which says when red HDMI screen will be shown to make it clear this happens when a bootloader EEPROM update fails.
- removed all occurrences of `SPI` from this page - it's an implementation detail and there is potential for confusion if people are also looking for information about configuring the SPI interfaces on the Pi 4.

I've also had to convert another table from markdown to asciidoc since it has not been done as part of the switch to asciidoc. It might be worth doing an automated scan of the repo for any more such tables, since they are unreadable once rendered into HTML by the current toolchain.