### PR TITLE
Add redirect for libcamera PDF

### DIFF
--- a/documentation/redirects/datasheets.csv
+++ b/documentation/redirects/datasheets.csv
@@ -38,3 +38,4 @@
 /documentation/hardware/computemodule/dt-blob-dualcam.dts,https://datasheets.raspberrypi.org/cmio/dt-blob-dualcam.dts
 /documentation/hardware/computemodule/example1-overlay.dts,https://datasheets.raspberrypi.org/cm/example1-overlay.dts
 /documentation/hardware/computemodule/minimal-cm-dt-blob.dts,https://datasheets.raspberrypi.org/cm/minimal-cm-dt-blob.dts
+/documentation/linux/software/libcamera/rpi_SOFT_libcamera_1p0.pdf,https://datasheets.raspberrypi.org/camera/raspberry-pi-camera-guide.pdf


### PR DESCRIPTION
As raised by @wolfd in https://github.com/raspberrypi/documentation/issues/1973#issuecomment-895647222, add a redirect for the Raspberry Pi Camera Algorithm and Tuning Guide as linked to from sites such as https://libcamera.org/open-projects.html#learning-how-an-isp-is-used
