### PR TITLE
Add redirects for all libcamera PDF versions

### DIFF
--- a/documentation/redirects/datasheets.csv
+++ b/documentation/redirects/datasheets.csv
@@ -39,3 +39,5 @@
 /documentation/hardware/computemodule/example1-overlay.dts,https://datasheets.raspberrypi.org/cm/example1-overlay.dts
 /documentation/hardware/computemodule/minimal-cm-dt-blob.dts,https://datasheets.raspberrypi.org/cm/minimal-cm-dt-blob.dts
 /documentation/linux/software/libcamera/rpi_SOFT_libcamera_1p0.pdf,https://datasheets.raspberrypi.org/camera/raspberry-pi-camera-guide.pdf
+/documentation/linux/software/libcamera/rpi_SOFT_libcamera_1p1.pdf,https://datasheets.raspberrypi.org/camera/raspberry-pi-camera-guide.pdf
+/documentation/linux/software/libcamera/rpi_SOFT_libcamera_1p2.pdf,https://datasheets.raspberrypi.org/camera/raspberry-pi-camera-guide.pdf


### PR DESCRIPTION
As raised by @lurch in https://github.com/raspberrypi/documentation/pull/2006#discussion_r685799630, add redirects for all three versions of the Raspberry Pi Camera Algorithm and Tuning Guide.
