### PR TITLE
Redirect compliance page to PIP

### DIFF
--- a/documentation/htaccess_extra.txt
+++ b/documentation/htaccess_extra.txt
@@ -1,4 +1,5 @@
 <IfModule mod_alias.c>
+Redirect 302 "/documentation/hardware/raspberrypi/conformity.md" "https://pip.raspberrypi.org"
 RedirectMatch 302 "^/documentation/faqs" "/documentation/"
 RedirectMatch 302 "^/documentation/hardware/raspberrypi/compliance/" "https://pip.raspberrypi.org"
 RedirectMatch 302 "^/documentation/hardware/camera/" "/documentation/accessories/camera.html"

--- a/scripts/create_htaccess.py
+++ b/scripts/create_htaccess.py
@@ -41,10 +41,6 @@ if __name__ == "__main__":
                     datasheets_filenames.add(child.find('S3:Key', ns).text)
 
     with open(output_filename, 'w') as out_fh:
-        if os.path.isfile(extra):
-            with open(extra) as extra_fh:
-                out_fh.write(extra_fh.read())
-                out_fh.write('\n')
         out_fh.write('<IfModule mod_alias.c>\n')
         for redir in sorted(redirects):
             link = redirects[redir]
@@ -54,3 +50,7 @@ if __name__ == "__main__":
                     raise Exception('{} seems to be an invalid URL'.format(link))
             out_fh.write('Redirect 301 {} {}\n'.format(redir, link))
         out_fh.write('</IfModule>\n')
+        if os.path.isfile(extra):
+            with open(extra) as extra_fh:
+                out_fh.write(extra_fh.read())
+                out_fh.write('\n')


### PR DESCRIPTION
While we now redirect https://www.raspberrypi.org/compliance to the Product Information Portal, we should also redirect the old "Product compliance and safety" page as it is directly linked in various places such as forum posts, etc.

As redirects are processed in order, we need the most specific matches to come first. As the redirects generated from the datasheets CSV are specific URLs, they should therefore appear first in our .htaccess with the "extra" configuration coming second (as this tends to be broader).

Without this, the redirects for the top-level documentation categories break the more specific redirects for PDFs that now live at https://datasheets.raspberrypi.org
