### PR TITLE
Add redirects for Pi 4 mechanical drawings

### DIFF
--- a/documentation/redirects/datasheets.csv
+++ b/documentation/redirects/datasheets.csv
@@ -41,3 +41,6 @@
 /documentation/linux/software/libcamera/rpi_SOFT_libcamera_1p0.pdf,https://datasheets.raspberrypi.org/camera/raspberry-pi-camera-guide.pdf
 /documentation/linux/software/libcamera/rpi_SOFT_libcamera_1p1.pdf,https://datasheets.raspberrypi.org/camera/raspberry-pi-camera-guide.pdf
 /documentation/linux/software/libcamera/rpi_SOFT_libcamera_1p2.pdf,https://datasheets.raspberrypi.org/camera/raspberry-pi-camera-guide.pdf
+/documentation/hardware/raspberrypi/mechanical/rpi_MECH_4b_4p0-with_mounting.dxf,https://datasheets.raspberrypi.org/rpi4/raspberry-pi-4-mechanical-drawing.dxf
+/documentation/hardware/raspberrypi/mechanical/rpi_MECH_4b_4p0.dxf,https://datasheets.raspberrypi.org/rpi4/raspberry-pi-4-mechanical-drawing.dxf
+/documentation/hardware/raspberrypi/mechanical/rpi_MECH_4b_4p0.pdf,https://datasheets.raspberrypi.org/rpi4/raspberry-pi-4-mechanical-drawing.pdf


### PR DESCRIPTION
Now the Raspberry Pi 4 mechanical drawings have moved to https://datasheets.raspberrypi.org, add a redirect from their old URLs to the new location.
