### PR TITLE
Don't run build twice for pull requests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,10 @@
 name: Build
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - master
+  pull_request:
 
 jobs:
   build:


### PR DESCRIPTION
To prevent the GitHub Actions build running twice for pull requests raised by contributors with write access to this repository, update our configuration to only run the build for pull requests or pushes to the master branch specifically. This way, pushes to other branches (e.g.  feature branches) will not trigger a build.
