### PR TITLE
Footer accessibility changes

### DIFF
--- a/jekyll-assets/_includes/footer.html
+++ b/jekyll-assets/_includes/footer.html
@@ -63,11 +63,11 @@
                     <span class="c-footer-newsletter__legend">
                         Sign up to our newsletter
                     </span>
-                    <input class="c-footer-newsletter__input" name="email" placeholder="Your email here" required="" type="email">
+                    <input class="c-footer-newsletter__input" name="email" placeholder="Your email here" required="" type="email" aria-label="Enter your email address">
                     <input type="hidden" name="htmlemail" value="1">
                     <input type="hidden" name="list[3]" value="signup">
                     <input type="hidden" name="listname[3]" value="Raspberry Pi Weekly">
-                    <input class="c-footer-newsletter__input--verification-code" type="text" name="VerificationCodeX" value="" size="20">
+                    <input type="hidden" class="c-footer-newsletter__input--verification-code" type="text" name="VerificationCodeX" value="" size="20">
                     <button class="c-footer-newsletter__button" name="subscribe">
                         Subscribe
                     </button>


### PR DESCRIPTION
Add aria label to newsletter form for accessibility and add type="hidden" class to VerificationCodeX item so it is not narrated as a form to screen reader users.

These changes have been made in response to suggestions made by the WAVE Accessibility testing tool, specifically:

```
Missing form label

A form control does not have a corresponding label.
```