### PR TITLE
Add some more redirects (and fix some broken ones)

### DIFF
--- a/documentation/redirects/datasheets.csv
+++ b/documentation/redirects/datasheets.csv
@@ -9,12 +9,14 @@
 /documentation/hardware/keyboard_mouse/mechanical/rpi_MECH_keyboard_UK_layout.png,https://datasheets.raspberrypi.org/keyboard-mouse/UK-layout.png
 /documentation/hardware/keyboard_mouse/mechanical/rpi_MECH_keyboard_US_layout.png,https://datasheets.raspberrypi.org/keyboard-mouse/US-layout.png
 /documentation/hardware/keyboard_mouse/mechanical/rpi_MECH_keyboard_mouse.pdf,https://datasheets.raspberrypi.org/keyboard-mouse/keyboard-mouse-mechanical-drawing.pdf
+/documentation/hardware/display/7InchDisplayDrawing-14092015.pdf,https://datasheets.raspberrypi.org/display/7-inch-display-mechanical-drawing.pdf
 /documentation/hardware/display/mechanical/7InchDisplayDrawing-14092015.pdf,https://datasheets.raspberrypi.org/display/7-inch-display-mechanical-drawing.pdf
 /documentation/hardware/camera/mechanical/rpi_MECH_Camera2_2p1.pdf,https://datasheets.raspberrypi.org/camera/camera-v2-mechanical-drawing.pdf
 /documentation/hardware/camera/mechanical/rpi_MECH_HQcamera_1p0.pdf,https://datasheets.raspberrypi.org/hq-camera/hq-camera-mechanical-drawing.pdf
 /documentation/hardware/camera/mechanical/rpi_MECH_HQcamera_lensmount_1p0.pdf,https://datasheets.raspberrypi.org/hq-camera/hq-camera-lensmount-drawing.pdf
 /documentation/hardware/camera/schematics/rpi_SCH_Camera2_2p1.pdf,https://datasheets.raspberrypi.org/camera/camera-v2-schematics.pdf
 /documentation/hardware/camera/schematics/rpi_SCH_HQcamera_1p0.pdf,https://datasheets.raspberrypi.org/hq-camera/hq-camera-schematics.pdf
+/documentation/hardware/sense-hat/images/Sense-HAT-V1_0.pdf,https://datasheets.raspberrypi.org/sense-hat/sense-hat-schematics.pdf
 /documentation/hardware/sense-hat/schematics/Sense-HAT-V1_0.pdf,https://datasheets.raspberrypi.org/sense-hat/sense-hat-schematics.pdf
 /documentation/hardware/raspberrypi/bcm2711/rpi_DATA_2711_1p0.pdf,https://datasheets.raspberrypi.org/bcm2711/bcm2711-peripherals.pdf
 /documentation/hardware/raspberrypi/bcm2711/rpi_DATA_2711_1p0_preliminary.pdf,https://datasheets.raspberrypi.org/rpi4/raspberry-pi-4-datasheet.pdf
@@ -51,7 +53,9 @@
 /documentation/hardware/computemodule/schematics/rpi_SCH_CM_1p1.pdf,https://datasheets.raspberrypi.org/cm/cm1-schematics.pdf
 /documentation/hardware/raspberrypi/mechanical/rpi_MECH_3aplus.pdf,https://datasheets.raspberrypi.org/rpi3/raspberry-pi-3-a-plus-mechanical-drawing.pdf
 /documentation/hardware/raspberrypi/mechanical/rpi_MECH_3aplus_case.pdf,https://datasheets.raspberrypi.org/case/raspberry-pi-3-a-plus-case-mechanical-drawing.pdf
+/documentation/hardware/raspberrypi/mechanical/rpi_MECH_3b_1p2.dxf,https://datasheets.raspberrypi.org/rpi3/raspberry-pi-3-b-mechanical-drawing.dxf
 /documentation/hardware/raspberrypi/mechanical/rpi_MECH_3b_1p2.pdf,https://datasheets.raspberrypi.org/rpi3/raspberry-pi-3-b-mechanical-drawing.pdf
+/documentation/hardware/raspberrypi/mechanical/rpi_MECH_3bplus.dxf,https://datasheets.raspberrypi.org/rpi3/raspberry-pi-3-b-plus-mechanical-drawing.dxf
 /documentation/hardware/raspberrypi/mechanical/rpi_MECH_3bplus.pdf,https://datasheets.raspberrypi.org/rpi3/raspberry-pi-3-b-plus-mechanical-drawing.pdf
 /documentation/hardware/raspberrypi/mechanical/rpi_MECH_3bplus_case.pdf,https://datasheets.raspberrypi.org/case/raspberry-pi-3-b-plus-case-mechanical-drawing.pdf
 /documentation/hardware/raspberrypi/mechanical/rpi_MECH_PoEHAT.pdf,https://datasheets.raspberrypi.org/poe/poe-hat-mechanical-drawing.pdf
@@ -60,7 +64,9 @@
 /documentation/hardware/raspberrypi/mechanical/rpi_MECH_Zero_case_blank.pdf,https://datasheets.raspberrypi.org/case/raspberry-pi-zero-case-mechanical-drawing.pdf
 /documentation/hardware/raspberrypi/mechanical/rpi_MECH_Zero_case_camera.pdf,https://datasheets.raspberrypi.org/case/raspberry-pi-zero-case-with-camera-mechanical-drawing.pdf
 /documentation/hardware/raspberrypi/mechanical/rpi_MECH_Zero_case_gpio.pdf,https://datasheets.raspberrypi.org/case/raspberry-pi-zero-case-with-gpio-mechanical-drawing.pdf
+/documentation/hardware/raspberrypi/mechanical/rpi_MECH_bplus_1p2.dxf,https://datasheets.raspberrypi.org/rpi/raspberry-pi-b-plus-mecahnical-drawing.dxf
 /documentation/hardware/raspberrypi/mechanical/rpi_MECH_bplus_1p2.pdf,https://datasheets.raspberrypi.org/rpi/raspberry-pi-b-plus-mecahnical-drawing.pdf
+/documentation/hardware/raspberrypi/mechanical/rpi_MECH_TVHAT_1p0.PNG,https://datasheets.raspberrypi.org/tv-hat/tv-hat-mechanical-drawing.pdf
 /documentation/hardware/raspberrypi/schematics/rpi_SCH_1aplus_1p1_reduced.pdf,https://datasheets.raspberrypi.org/rpi/raspberry-pi-a-plus-reduced-schematics.pdf
 /documentation/hardware/raspberrypi/schematics/rpi_SCH_1bplus_1p2_reduced.pdf,https://datasheets.raspberrypi.org/rpi/raspberry-pi-b-plus-reduced-schematics.pdf
 /documentation/hardware/raspberrypi/schematics/rpi_SCH_2b_1p2_reduced.pdf,https://datasheets.raspberrypi.org/rpi2/raspberry-pi-2-b-reduced-schematics.pdf
@@ -70,6 +76,8 @@
 /documentation/hardware/raspberrypi/schematics/rpi_SCH_4b_4p0_reduced.pdf,https://datasheets.raspberrypi.org/rpi4/raspberry-pi-4-reduced-schematics.pdf
 /documentation/hardware/raspberrypi/schematics/rpi_SCH_ZeroW_1p1_reduced.pdf,https://datasheets.raspberrypi.org/rpizero/raspberry-pi-zero-w-reduced-schematics.pdf
 /documentation/hardware/raspberrypi/schematics/rpi_SCH_Zero_1p3_reduced.pdf,https://datasheets.raspberrypi.org/rpizero/raspberry-pi-zero-reduced-schematics.pdf
-/documentationardware/computemodule/designdata/rpi_DSGN_CMCDA_1p1.zip,https://datasheets.raspberrypi.org/cmcda/RPi-CMCDA-1P1.zip
-/documentationardware/computemodule/designdata/rpi_DSGN_CMIO_1p2.zip,https://datasheets.raspberrypi.org/cmio/RPi-CMIO-R1P2.zip
-/documentationardware/computemodule/designdata/rpi_DSGN_CMIO_3p0.zip,https://datasheets.raspberrypi.org/cmio/RPi-CMIO-R3P0.zip
+/documentation/hardware/computemodule/designdata/rpi_DSGN_CMCDA_1p1.zip,https://datasheets.raspberrypi.org/cmcda/RPi-CMCDA-1P1.zip
+/documentation/hardware/computemodule/designdata/rpi_DSGN_CMIO_1p2.zip,https://datasheets.raspberrypi.org/cmio/RPi-CMIO-R1P2.zip
+/documentation/hardware/computemodule/designdata/rpi_DSGN_CMIO_3p0.zip,https://datasheets.raspberrypi.org/cmio/RPi-CMIO-R3P0.zip
+/documentation/hardware/raspberrypi/bootmodes/pxetools/prepare_pxetools,https://datasheets.raspberrypi.org/soft/prepare_pxetools.sh
+/documentation/hardware/raspberrypi/bootmodes/pxetools/pxetools,https://datasheets.raspberrypi.org/soft/pxetools.py

--- a/scripts/create_htaccess.py
+++ b/scripts/create_htaccess.py
@@ -9,6 +9,7 @@ import xml.etree.ElementTree as ET
 
 DATASHEETS_BASE_URL = 'https://datasheets.raspberrypi.org'
 DATASHEETS_BUCKET_URL = 'https://rptl-datasheets.s3.eu-west-1.amazonaws.com'
+REDIRECT_SOURCE_PREFIX = '/documentation/'
 
 
 if __name__ == "__main__":
@@ -22,11 +23,15 @@ if __name__ == "__main__":
         if os.path.splitext(filename)[1] == '.csv':
             with open(os.path.join(redirects_dir, filename)) as csvfile:
                 for row in csv.reader(csvfile):
-                    if row[0] in redirects:
-                        raise Exception('Multiple redirects for source-URL {}'.format(row[0]))
-                    if row[1].startswith(DATASHEETS_BASE_URL):
-                        any_datasheets_redirects = True
-                    redirects[row[0]] = row[1]
+                    if row:
+                        old, new = row
+                        if not old.startswith(REDIRECT_SOURCE_PREFIX):
+                            raise Exception('Redirect {} doesn\'t start with {}'.format(REDIRECT_SOURCE_PREFIX))
+                        if old in redirects:
+                            raise Exception('Multiple redirects for source-URL {}'.format(old))
+                        if new.startswith(DATASHEETS_BASE_URL):
+                            any_datasheets_redirects = True
+                        redirects[old] = new
 
     datasheets_filenames = set()
     if any_datasheets_redirects:


### PR DESCRIPTION
I picked an arbitrary "[old commit](https://github.com/raspberrypi/documentation/tree/c7475c40099af57ae4400e20e0286d34a05e807b)" from before we started moving files about, as I guess these "oldest" links are the ones that are most likely to be broken. And then I added redirects (that we didn't already have) for all the non-markdown and non-image files that existed in the repo at that time.