### PR TITLE
Adjusting alignment of copyright text

### DIFF
--- a/jekyll-assets/css/style.css
+++ b/jekyll-assets/css/style.css
@@ -409,10 +409,11 @@ div.videoblock iframe {
 }
 
 div.legal {
-  margin: 80px 10% 0 10%;
-  max-width: 1300px;
+  margin: 80px auto 0 auto;
+  max-width: 1200px;
   display: flex;
   align-items: center;
+  justify-content: center;
   flex-direction: column;
 }
 


### PR DESCRIPTION
This adjusts the alignment of the copyright text. It's a bit tricky, since the text itself needs to be left-aligned, and isn't actually long enough to fill it's containing box. I went with a "least offensive" max-width that still looks slightly wider on the box page:

<img width="1360" alt="Screen Shot 2021-08-12 at 6 16 33 PM" src="https://user-images.githubusercontent.com/812739/129291282-52b931d9-56c4-45a4-a08e-106a92c42d76.png">

but slightly shorter on the actual documentation pages:

<img width="1362" alt="Screen Shot 2021-08-12 at 6 17 14 PM" src="https://user-images.githubusercontent.com/812739/129291296-4d662534-821f-443d-8f91-8cadd6c70c31.png">

(also figured out I can emulate larger screens with Chrome tools 😎 )

@aallan take a look and let me know if you can think of something better!