### PR TITLE
Fixes #1463

### DIFF
--- a/documentation/asciidoc/computers/raspberry-pi/gpio-pad-controls.adoc
+++ b/documentation/asciidoc/computers/raspberry-pi/gpio-pad-controls.adoc
@@ -28,19 +28,19 @@ If the pad is driven high and it is shorted to ground, in due time it will fail.
 
 Meeting the specification is determined by the guaranteed voltage levels. Because the pads are digital, there are two voltage levels, high and low. The I/O ports have two parameters which deal with the output level:
 
-* V~IL~, the maximum low-level voltage (0.9V at 3V3 VDD IO)
-* V~IH~, the minimum high-level voltage (1.6V at 3V3 VDD IO)
+* V~OL~, the maximum low-level voltage (0.14V at 3V3 VDD IO)
+* V~OH~, the minimum high-level voltage (3.0V at 3V3 VDD IO)
 
-V~IL~=0.9V means that if the output is Low, it will be \<= 0.9V.
-V~IH~=1.6V means that if the output is High, it will be >= 1.6V.
+V~OL~=0.14V means that if the output is Low, it will be \<= 0.14V.
+V~OH~=3.0V means that if the output is High, it will be >= 3.0V.
 
 Thus a drive strength of 16mA means:
 
-If you set the pad high, you can draw up to 16mA, and the output voltage is guaranteed to be >=V~IH~. This also means that if you set a drive strength of 2mA and you draw 16mA, the voltage will *not* be V~IH~ but lower. In fact, it may not be high enough to be seen as high by an external device.
+If you set the pad high, you can draw up to 16mA, and the output voltage is guaranteed to be >=V~OH~. This also means that if you set a drive strength of 2mA and you draw 16mA, the voltage will *not* be V~OH~ but lower. In fact, it may not be high enough to be seen as high by an external device.
 
 There is more information on the xref:raspberry-pi.adoc#gpio[physical characteristics] of the GPIO pins. 
 
-NOTE: On the Compute Module devices, it is possible to change the VDD IO from the standard 3V3. In this case, V~IL~ and V~IH~ will change according to the table on the linked page.
+NOTE: On the Compute Module devices, it is possible to change the VDD IO from the standard 3V3. In this case, V~OL~ and V~OH~ will change according to the table on the linked page.
 
 [discrete]
 === Why don't I set all my pads to the maximum current?


### PR DESCRIPTION
Changed the V_OH and V_IH labels and values to reflect the correct ones from gpio-on-raspberry-pi.adoc.
