### PR TITLE
Ensure PRs based on master can only come from the develop branch

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,6 +10,12 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
+      - name: Only allow pull requests based on master from the develop branch
+        if: ${{ github.base_ref == 'master' && github.ref != 'refs/heads/develop' }}
+        run: |
+          echo "Pull requests based on master can only come from the develop branch"
+          echo "Please check your base branch as it should be develop by default"
+          exit 1
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
         with:


### PR DESCRIPTION
GitHub: https://github.com/raspberrypi/documentation/issues/2098

Add a check to the GitHub Actions workflow to check that all pull requests use "develop" as their base branch. If not, fail the workflow and prevent merging.

Note that we still need to allow pull requests to be raised between "develop" and "master" so we skip this check if the current branch is "develop".