### PR TITLE
Test that new workflow check rejects PRs based on master from other repositories' develop branch

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,6 +10,12 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
+      - name: Only allow pull requests based on master from the develop branch
+        if: ${{ github.base_ref == 'master' && github.ref != 'refs/heads/develop' }}
+        run: |
+          echo "Pull requests based on master can only come from the develop branch"
+          echo "Please check your base branch as it should be develop by default"
+          exit 1
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
         with:

--- a/README.md
+++ b/README.md
@@ -108,4 +108,4 @@ which will copy the `fonts.html` and `header.html` files from `offline_includes`
 
 ## License
 
-The Raspberry Pi documentation is [licensed](https://github.com/raspberrypi/documentation/blob/develop/LICENSE.md) under a Creative Commons Attribution 4.0 International Licence.
+The Raspberry Pi documentation is [licensed](https://github.com/raspberrypi/documentation/blob/develop/LICENSE.md) under a Creative Commons Attribution 4.0 International Licence. While the toolchain source code is Copyright © 2020 Raspberry Pi (Trading) Ltd. and licensed under the [BSD 3-Clause](https://opensource.org/licenses/BSD-3-Clause) licence.


### PR DESCRIPTION
Confirm that the new step in our GitHub Actions workflow to prevent merges into `master` from branches other than `develop` rejects pull requests from forks when the fork's branch name also happens to be`develop` (see @lurch's [comment](https://github.com/raspberrypi/documentation/pull/2100#issuecomment-901254248)).

This build should fail.