### PR TITLE
Update installing-from-an-image.adoc

### DIFF
--- a/documentation/asciidoc/computers/getting-started/installing-from-an-image.adoc
+++ b/documentation/asciidoc/computers/getting-started/installing-from-an-image.adoc
@@ -4,7 +4,7 @@ Raspberry Pi recommend the use of https://www.raspberrypi.org/software/[Raspberr
 
 NOTE: Before you start, don't forget to check the xref:getting-started.adoc#sd-cards[SD card requirements].
 
-IMPORTANT: NOOBS, or New Out Of the Box Software to give it its full name, was an SD card-based installer for the Raspberry Pi. We no longer recommend using NOOBS.
+IMPORTANT: NOOBS, or New Out Of the Box Software to give it its full name, was an SD card-based installer for the Raspberry Pi; We no longer recommend using NOOBS.
 
 === Using Raspberry Pi Imager
 

--- a/documentation/asciidoc/computers/getting-started/installing-from-an-image.adoc
+++ b/documentation/asciidoc/computers/getting-started/installing-from-an-image.adoc
@@ -19,7 +19,7 @@ Download the latest version of https://www.raspberrypi.org/downloads/[Raspberry 
 * Choose  the SD card you wish to write your image to.
 * Review your selections and click on the `Write` button to begin writing data to the SD Card.
 
-NOTE: If using Raspberry Pi Imager on Windows 10 with controlled folder access enabled, you will need to explicitly allow the Raspberry Pi Imager permission to write the SD card. If this is not done, Imager will fail with a "failed to write" error.
+NOTE: If using Raspberry Pi Imager on Windows 10 with controlled folder access enabled, you will need to explicitly allow Raspberry Pi Imager permission to write the SD card. If this is not done, the imaging process will fail with a "failed to write" error.
 
 NOTE: You can see which operating systems are most often downloaded, on our https://rpi-imager-stats.raspberrypi.org/[statistics page].
 

--- a/documentation/asciidoc/computers/getting-started/installing-from-an-image.adoc
+++ b/documentation/asciidoc/computers/getting-started/installing-from-an-image.adoc
@@ -4,7 +4,7 @@ Raspberry Pi recommend the use of https://www.raspberrypi.org/software/[Raspberr
 
 NOTE: Before you start, don't forget to check the xref:getting-started.adoc#sd-cards[SD card requirements].
 
-IMPORTANT: NOOBS, or New Out Of the Box Software to give it its full name, was an SD card-based installer for the Raspberry Pi; We no longer recommend using NOOBS.
+IMPORTANT: NOOBS, or New Out Of the Box Software to give it its full name, was an SD card-based installer for Raspberry Pi computers; We no longer recommend using NOOBS.
 
 === Using Raspberry Pi Imager
 
@@ -29,7 +29,7 @@ You should change the default password straight away to ensure your Raspberry Pi
 
 === Downloading an Image
 
-If you are using a different tool than Raspberry Pi Imager to write to your SD Card, most require you to download the image first, then use the tool to write it to the card. Official images for recommended operating systems are available to download from the Raspberry Pi website https://www.raspberrypi.org/downloads/[downloads page]. Alternative distributions for the Raspberry Pi are also available from some third-party vendors.
+If you are using a different tool than Raspberry Pi Imager to write to your SD Card, most require you to download the image first, then use the tool to write it to the card. Official images for recommended operating systems are available to download from the Raspberry Pi website https://www.raspberrypi.org/downloads/[downloads page]. Alternative distributions for Raspberry Pi computers are also available from some third-party vendors.
 
 You may need to unzip the downloaded file (`.zip`) to get the image file (`.img`) you need to write to the card.
 

--- a/documentation/asciidoc/computers/getting-started/installing-from-an-image.adoc
+++ b/documentation/asciidoc/computers/getting-started/installing-from-an-image.adoc
@@ -4,7 +4,7 @@ Raspberry Pi recommend the use of https://www.raspberrypi.org/software/[Raspberr
 
 NOTE: Before you start, don't forget to check the xref:getting-started.adoc#sd-cards[SD card requirements].
 
-IMPORTANT: NOOBS, or New Out Of the Box Software to give it its full name, was an SD card-based installer for Raspberry Pi computers; We no longer recommend using NOOBS.
+IMPORTANT: NOOBS, or New Out Of the Box Software to give it its full name, was an SD card-based installer for Raspberry Pi computers; we no longer recommend using NOOBS.
 
 === Using Raspberry Pi Imager
 

--- a/documentation/asciidoc/computers/getting-started/installing-from-an-image.adoc
+++ b/documentation/asciidoc/computers/getting-started/installing-from-an-image.adoc
@@ -29,7 +29,7 @@ You should change the default password straight away to ensure your Raspberry Pi
 
 === Downloading an Image
 
-If you are using a different tool than Raspberry Pi Imager to write to your SD Card, most require you to download the image first, then use the tool to write it to the card. Official images for recommended operating systems are available to download from the Raspberry Pi website https://www.raspberrypi.org/downloads/[downloads page]. Alternative distributions for Raspberry Pi computers are also available from some third-party vendors.
+If you are using a different tool than Raspberry Pi Imager to write to your SD Card, most require you to download the image first, then use the tool to write it to the card. Official images for recommended operating systems are available to download from the Raspberry Pi website https://www.raspberrypi.org/downloads/[downloads page]. Alternative operating systems for Raspberry Pi computers are also available from some third-party vendors.
 
 You may need to unzip the downloaded file (`.zip`) to get the image file (`.img`) you need to write to the card.
 

--- a/documentation/asciidoc/computers/getting-started/installing-from-an-image.adoc
+++ b/documentation/asciidoc/computers/getting-started/installing-from-an-image.adoc
@@ -1,36 +1,36 @@
 == Installing the Operating System
 
-Raspberry Pi now recommend the use of the https://www.raspberrypi.org/software/[Raspberry Pi Imager] tool to install an operating system on your SD Card. You will need another computer with an SD card reader to install the image.
+Raspberry Pi recommend the use of https://www.raspberrypi.org/software/[Raspberry Pi Imager] to install an operating system on your SD card. You will need another computer with an SD card reader to install the image.
 
-NOTE: Before you start, don't forget to check xref:getting-started.adoc#sd-cards[the SD card requirements].
+NOTE: Before you start, don't forget to check the xref:getting-started.adoc#sd-cards[SD card requirements].
+
+IMPORTANT: NOOBS, or New Out Of the Box Software to give it its full name, was an SD card-based installer for the Raspberry Pi. We no longer recommend using NOOBS.
 
 === Using Raspberry Pi Imager
 
-IMPORTANT: NOOBS, or "New Out Of the Box Software" to give it its full name, was an SD Card-based installer for Raspberry Pi OS. It is now deprecated, and the recommended route to install Raspberry Pi OS is by using the https://www.raspberrypi.org/downloads/[Raspberry Pi Imager].
-
-Raspberry Pi have developed a graphical SD card writing tool that works on Mac OS, Ubuntu 18.04, and Windows. The https://www.raspberrypi.org/downloads/[Raspberry Pi Imager] is the easiest option for most users as it will download the image and install it automatically to the SD card.
+Raspberry Pi have developed a graphical SD card writing tool that works on Mac OS, Ubuntu 18.04, and Windows called https://www.raspberrypi.org/downloads/[Raspberry Pi Imager]; this is the easiest option for most users since it will download the image automatically and install it to the SD card.
 
 video::ntaXWS8Lk34[youtube]
 
-Download the latest version of https://www.raspberrypi.org/downloads/[Raspberry Pi Imager] and install it. If you want to use Raspberry Pi Imager from a second Raspberry Pi, you can install it from a terminal using `sudo apt install rpi-imager`. Then;
+Download the latest version of https://www.raspberrypi.org/downloads/[Raspberry Pi Imager] and install it. If you want to use Raspberry Pi Imager from a second Raspberry Pi, you can install it from a terminal using `sudo apt install rpi-imager`. Then:
 
 * Connect an SD card reader with the SD card inside.
 * Open Raspberry Pi Imager and choose the required OS from the list presented.
 * Choose  the SD card you wish to write your image to.
-* Review your selections and click on the 'Write' button to begin writing data to the SD Card.
+* Review your selections and click on the `Write` button to begin writing data to the SD Card.
 
-NOTE: If using the Raspberry Pi Imager on Windows 10 with "Controlled Folder Access" enabled, you will need to explicitly allow the Raspberry Pi Imager permission to write the SD card. If this is not done, the Imager will fail with a "failed to write" error.
+NOTE: If using Raspberry Pi Imager on Windows 10 with controlled folder access enabled, you will need to explicitly allow the Raspberry Pi Imager permission to write the SD card. If this is not done, Imager will fail with a "failed to write" error.
 
 NOTE: You can see which operating systems are most often downloaded, on our https://rpi-imager-stats.raspberrypi.org/[statistics page].
 
-You can now insert the SD card into the Raspberry Pi and power it up. For the official Raspberry Pi OS, if you need to manually log in, the default user name is `pi`, with password `raspberry`, and the default keyboard layout is set to https://datasheets.raspberrypi.org/keyboard-mouse/UK-layout.png[United Kingdom (UK)].
+You can now insert the SD card into the Raspberry Pi and power it up. For Raspberry Pi OS, if you need to manually log in, the default user name is `pi`, with password `raspberry`, and the default keyboard layout is set to https://datasheets.raspberrypi.org/keyboard-mouse/UK-layout.png[United Kingdom (UK)].
 
 You should change the default password straight away to ensure your Raspberry Pi is xref:configuration.adoc#securing-your-raspberry-pi[secure].
 
 === Downloading an Image
 
-If you are using a different tool than the Raspberry Pi Imager to write to your SD Card most require you to download the image first, and then use the tool to write it to the card. Official images for recommended operating systems are available to download from the Raspberry Pi website https://www.raspberrypi.org/downloads/[downloads page]. Alternative distributions for the Raspberry Pi are also available from some third-party vendors.
+If you are using a different tool than Raspberry Pi Imager to write to your SD Card, most require you to download the image first, then use the tool to write it to the card. Official images for recommended operating systems are available to download from the Raspberry Pi website https://www.raspberrypi.org/downloads/[downloads page]. Alternative distributions for the Raspberry Pi are also available from some third-party vendors.
 
 You may need to unzip the downloaded file (`.zip`) to get the image file (`.img`) you need to write to the card.
 
-NOTE: The Raspberry Pi OS with desktop image contained in the ZIP archive is over 4GB in size and uses the https://en.wikipedia.org/wiki/Zip_%28file_format%29#ZIP64[ZIP64] format. To uncompress the archive, a unzip tool that supports ZIP64 is required. The following zip tools support ZIP64; http://www.7-zip.org/[7-Zip] for Windows, http://unarchiver.c3.cx/unarchiver[The Unarchiver] for macOS, and https://linux.die.net/man/1/unzip[unzip] on Linux.
+NOTE: The Raspberry Pi OS with desktop image contained in the ZIP archive is over 4GB in size and uses the https://en.wikipedia.org/wiki/Zip_%28file_format%29#ZIP64[ZIP64] format. To uncompress the archive, an unzip tool that supports ZIP64 is required. The following zip tools support ZIP64: http://www.7-zip.org/[7-Zip] for Windows, http://unarchiver.c3.cx/unarchiver[The Unarchiver] for macOS, and https://linux.die.net/man/1/unzip[unzip] on Linux.


### PR DESCRIPTION
Style and grammar fixups. Mostly removing extraneous `the`. Also Raspberry Pi style guide says not to use `the` in front of product names - I would assert that Raspberry Pi Imager is a product although it is a piece of software and is available for free.

I've also removed some duplication which was created by the recent insertion of a paragraph advising that NOOBS is deprecated, and moved that paragraph out of the Raspberry Pi Imager section to a more appropriate location.

I've also removed two instances of scare quotes, which are not to be used, according to the Raspberry Pi style guide. I don't have access to the AP style guide, since it requires payment, which I have not made, but I would expect it also advises against using scare quotes.