### PR TITLE
Revert "prefix hex number with 0x"

### DIFF
--- a/documentation/asciidoc/computers/raspberry-pi/gpio-pad-controls.adoc
+++ b/documentation/asciidoc/computers/raspberry-pi/gpio-pad-controls.adoc
@@ -67,7 +67,7 @@ All the electronics of the pads are designed for 16mA. That is a safe value unde
 
 | 31:24
 | PASSWRD
-| Must be 0x5A when writing; accidental write protect password
+| Must be 5A when writing; accidental write protect password
 | W
 | 0
 


### PR DESCRIPTION
Reverts raspberrypi/documentation#2108 was based against `master`.