### PR TITLE
Log the current branches with GitHub Actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,6 +10,10 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
+      - name: Log current branches
+        run: |
+          echo "Current ref: $GITHUB_REF"
+          echo "Base ref: $GITHUB_BASE_REF"
       - name: Only allow pull requests based on master from the develop branch
         if: ${{ github.base_ref == 'master' && github.ref != 'refs/heads/develop' }}
         run: |


### PR DESCRIPTION
In order to debug why https://github.com/raspberrypi/documentation/runs/3398064273 ran and failed, print the current GitHub ref and base ref during the GitHub Actions build workflow.
