### PR TITLE
Log the GitHub head ref during the build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,6 +14,7 @@ jobs:
         run: |
           echo "Current ref: $GITHUB_REF"
           echo "Base ref: $GITHUB_BASE_REF"
+          echo "Head ref: $GITHUB_HEAD_REF"
       - name: Only allow pull requests based on master from the develop branch
         if: ${{ github.base_ref == 'master' && github.ref != 'refs/heads/develop' }}
         run: |


### PR DESCRIPTION
As the GitHub ref for a pull requests always seems to be of the form refs/pulls/1234/merge, log the head ref to see if that reveals the source branch's human readable name.
