### PR TITLE
Test raising pull requests from a fork's "develop" branch fails

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,8 +15,10 @@ jobs:
           echo "Current ref: $GITHUB_REF"
           echo "Base ref: $GITHUB_BASE_REF"
           echo "Head ref: $GITHUB_HEAD_REF"
+          echo "Repository: $GITHUB_REPOSITORY"
+          echo "Head repository ${{ github.event.pull_request.head.repo.full_name }}"
       - name: Only allow pull requests based on master from the develop branch
-        if: ${{ github.base_ref == 'master' && github.head_ref != 'develop' }}
+        if: ${{ github.base_ref == 'master' && !(github.head_ref == 'develop' && github.event.pull_request.head.repo.full_name == github.repository) }}
         run: |
           echo "Pull requests based on master can only come from the develop branch"
           echo "Please check your base branch as it should be develop by default"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
           echo "Base ref: $GITHUB_BASE_REF"
           echo "Head ref: $GITHUB_HEAD_REF"
       - name: Only allow pull requests based on master from the develop branch
-        if: ${{ github.base_ref == 'master' && github.ref != 'refs/heads/develop' }}
+        if: ${{ github.base_ref == 'master' && github.head_ref != 'develop' }}
         run: |
           echo "Pull requests based on master can only come from the develop branch"
           echo "Please check your base branch as it should be develop by default"


### PR DESCRIPTION
Will this pull request fail if we use `head_ref` instead of `ref` and my fork's branch name is `develop`?