### PR TITLE
Use head ref (not ref) for checking source branch

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,15 +10,17 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - name: Log current branches
+      - name: Log current branches and repositories
         run: |
           echo "Current ref: $GITHUB_REF"
           echo "Base ref: $GITHUB_BASE_REF"
           echo "Head ref: $GITHUB_HEAD_REF"
-      - name: Only allow pull requests based on master from the develop branch
-        if: ${{ github.base_ref == 'master' && github.ref != 'refs/heads/develop' }}
+          echo "Repository: $GITHUB_REPOSITORY"
+          echo "Head repository: ${{ github.event.pull_request.head.repo.full_name }}"
+      - name: Only allow pull requests based on master from the develop branch of the current repository
+        if: ${{ github.base_ref == 'master' && !(github.head_ref == 'develop' && github.event.pull_request.head.repo.full_name == github.repository) }}
         run: |
-          echo "Pull requests based on master can only come from the develop branch"
+          echo "Pull requests based on master can only come from the develop branch of this repository"
           echo "Please check your base branch as it should be develop by default"
           exit 1
       - uses: actions/checkout@v2


### PR DESCRIPTION
As ref will always be set to something like refs/pulls/123/merge for pull requests, use head ref instead which reveals the source branch's name.

As this would make it possible for someone to raise a PR from a fork with the branch name "develop", we also add a check to ensure that "master" can only be merged into from a branch local to this repository.
