### PR TITLE
fix dtb and zImage  "No such file or directory"

### DIFF
--- a/documentation/asciidoc/computers/linux_kernel/building.adoc
+++ b/documentation/asciidoc/computers/linux_kernel/building.adoc
@@ -120,10 +120,10 @@ For the 64-bit kernel:
 ----
 make -j4 Image modules dtbs
 sudo make modules_install
-sudo cp arch/arm64/boot/dts/*.dtb /boot/
+sudo cp arch/arm64/boot/dts/broadcom/*.dtb /boot/
 sudo cp arch/arm64/boot/dts/overlays/*.dtb* /boot/overlays/
 sudo cp arch/arm64/boot/dts/overlays/README /boot/overlays/
-sudo cp arch/arm64/boot/zImage /boot/$KERNEL.img
+sudo cp arch/arm64/boot/Image /boot/$KERNEL.img
 ----
 
 NOTE: On a Raspberry Pi 2/3/4, the `-j4` flag splits the work between all four cores, speeding up compilation significantly.


### PR DESCRIPTION
While building the Kernel
Build and install the kernel, modules, and Device Tree blobs, find the errors:

cp: cannot stat 'arch/arm64/boot/dts/*.dtb': No such file or directory
cp: cannot stat 'arch/arm64/boot/zImage': No such file or directory

There is wrong path and file name in the bash script.

Signed-off-by: Yunli Liu <994605959@qq.com>