### PR TITLE
Redirect Pico landing site to microcontroller docs

### DIFF
--- a/documentation/htaccess_extra.txt
+++ b/documentation/htaccess_extra.txt
@@ -1,6 +1,8 @@
 <IfModule mod_alias.c>
 Redirect 302 "/documentation/hardware/raspberrypi/conformity.md" "https://pip.raspberrypi.org"
 RedirectMatch 302 "^/documentation/faqs" "/documentation/"
+RedirectMatch 302 "^/documentation/pico" "/documentation/microcontrollers/"
+RedirectMatch 302 "^/documentation/rp2040" "/documentation/microcontrollers/"
 RedirectMatch 302 "^/documentation/hardware/raspberrypi/compliance/" "https://pip.raspberrypi.org"
 RedirectMatch 302 "^/documentation/hardware/camera/" "/documentation/accessories/camera.html"
 RedirectMatch 302 "^/documentation/hardware/computemodule/" "/documentation/computers/compute-module.html"


### PR DESCRIPTION
Now information about RP2040 and Raspberry Pi Pico have been folded into the documentation site, redirect requests for the old "Getting Started" landing site to the Microcontrollers section.

Note this won't have any effect until we remove the configuration from Cloudflare (both a page rule which currently handles the redirect from /documentation/pico to /documentation/rp2040 and a worker route which directs requests to the Getting Started site). Once that is gone, we'll be able to control all redirects under /documentation from this project.
