### PR TITLE
Adding classes for floats and widths

### DIFF
--- a/documentation/asciidoc/microcontrollers/micropython/what-is-micropython.adoc
+++ b/documentation/asciidoc/microcontrollers/micropython/what-is-micropython.adoc
@@ -15,7 +15,7 @@ https://docs.micropython.org/en/latest/library/rp2.html[RP2 Library]:: The offic
 
 There is also a book by https://store.rpipress.cc/[Raspberry Pi Press] available written by Gareth Halfacree and Ben Everard.
 
-image::images/micropython_book.png[width="40%",float=left] 
+image::images/micropython_book.png[role="w40",float=left] 
 In "Get Started with MicroPython on Raspberry Pi Pico", you will learn how to use the beginner-friendly language MicroPython to write programs and connect hardware to make your Raspberry Pi Pico interact with the world around it. Using these skills, you can create your own electro-mechanical projects, whether for fun or to make your life easier. 
 
 * Set up your Raspberry Pi Pico and start using it

--- a/jekyll-assets/css/style.css
+++ b/jekyll-assets/css/style.css
@@ -470,6 +470,33 @@ td div.listingblock div.content code {
   height: auto;
 }
 
+.w10 { width: 10%; }
+.w20 { width: 20%; }
+.w30 { width: 30%; }
+.w40 { width: 40%; }
+.w50 { width: 50%; }
+.w60 { width: 60%; }
+.w70 { width: 70%; }
+.w80 { width: 80%; }
+.w90 { width: 90%; }
+
+#content .imageblock.left {
+  float: left;
+  margin-right: 30px;
+}
+
+#content .imageblock.right {
+  float: right;
+  margin-left: 30px;
+}
+
+#content .imageblock.left,
+#content .imageblock.left img,
+#content .imageblock.right,
+#content  .imageblock.right img {
+  margin-top: 0px;
+}
+
 div.admonitionblock table {
   display: flex;
   width: 100%;
@@ -653,6 +680,27 @@ footer {
   #content {
     width: 100%;
     min-width: auto;
+    margin-left: 0px;
+  }
+
+  .w10, .w20, .w30, .w40, .w50, .w60, .w70, .w80, .w90 {
+    width: 100%;
+  }
+
+  #content .imageblock.left {
+    float: none;
+  }
+
+  #content .imageblock.right {
+    float: none;
+  }
+
+  #content .imageblock.left,
+  #content .imageblock.left img,
+  #content .imageblock.right,
+  #content .imageblock.right img {
+    margin-top: 20px;
+    margin-right: 0px;
     margin-left: 0px;
   }
 }


### PR DESCRIPTION
@aallan this should fix the floats issue. You're right that it needed styles, but there's also some funniness in how asciidoctor applies the classes/styles to the converted HTML. The solution that made the most sense to me was to add some custom classes to control the width of elements (the built-in asciidoctor width attributes don't work in this case, which I'm happy to get into but don't want to overwhelm you...). There are 9 new role names/classes (`w10`, aka 10% of the container width, up to `w90`, aka 90% of the container width) that you can apply to asciidoc images along with either `float: left` or `float: right`, to get the desired effect.

See the asciidoc in this PR for an example of how to use them.