### PR TITLE
Fix text overflowing on configuration page

### DIFF
--- a/documentation/asciidoc/computers/configuration/pin-configuration.adoc
+++ b/documentation/asciidoc/computers/configuration/pin-configuration.adoc
@@ -47,8 +47,8 @@ The `dt-blob.bin` is used to configure the binary blob (VideoCore) at boot time.
 This section contains all of the VideoCore blob information. All subsequent sections must be enclosed within this section.
 
 . `pins_*`
-
-  There are a number of separate `pins_*` sections, based on particular Raspberry Pi models, namely:
++
+There are a number of separate `pins_*` sections, based on particular Raspberry Pi models, namely:
 
 * *pins_rev1* Rev1 pin setup. There are some differences because of the moved I2C pins.
 * *pins_rev2* Rev2 pin setup. This includes the additional codec pins on P5.


### PR DESCRIPTION
Google Search Console flagged that https://www.raspberrypi.com/documentation/computers/configuration.html has "content wider than screen". This appears to be caused by the line beginning "There are a number of separate pins_* sections" which is being rendered as a `<pre>` tag but with no scroll bars. Fix the markup so it is rendered as a paragraph instead.

Before:
<img width="449" alt="Screenshot 2021-10-08 at 09 54 56" src="https://user-images.githubusercontent.com/287/136528037-2c2b4995-45c0-4a5f-a139-ab083b53646e.png">

After:
<img width="494" alt="Screenshot 2021-10-08 at 09 55 04" src="https://user-images.githubusercontent.com/287/136528059-071c8c84-c972-4099-89ea-45c1af5748ec.png">

