### PR TITLE
Update links to Product Information Portal

### DIFF
--- a/documentation/asciidoc/computers/raspberry-pi/raspberry-pi-compliance.adoc
+++ b/documentation/asciidoc/computers/raspberry-pi/raspberry-pi-compliance.adoc
@@ -1,6 +1,6 @@
 == Product compliance and safety
 
-All Raspberry Pi products have undergone extensive compliance testing, for more information see the https://pip.raspberrypi.org[Product Information Portal]
+All Raspberry Pi products have undergone extensive compliance testing, for more information see the https://pip.raspberrypi.com[Product Information Portal]
 
 === Flammability Rating
 

--- a/documentation/htaccess_extra.txt
+++ b/documentation/htaccess_extra.txt
@@ -1,9 +1,9 @@
 <IfModule mod_alias.c>
-Redirect 302 "/documentation/hardware/raspberrypi/conformity.md" "https://pip.raspberrypi.org"
+Redirect 302 "/documentation/hardware/raspberrypi/conformity.md" "https://pip.raspberrypi.com"
 RedirectMatch 302 "^/documentation/faqs" "/documentation/"
 RedirectMatch 302 "^/documentation/pico" "/documentation/microcontrollers/"
 RedirectMatch 302 "^/documentation/rp2040" "/documentation/microcontrollers/"
-RedirectMatch 302 "^/documentation/hardware/raspberrypi/compliance/" "https://pip.raspberrypi.org"
+RedirectMatch 302 "^/documentation/hardware/raspberrypi/compliance/" "https://pip.raspberrypi.com"
 RedirectMatch 302 "^/documentation/hardware/camera/" "/documentation/accessories/camera.html"
 RedirectMatch 302 "^/documentation/hardware/computemodule/" "/documentation/computers/compute-module.html"
 RedirectMatch 302 "^/documentation/hardware/display/" "/documentation/accessories/display.html"

--- a/documentation/index.json
+++ b/documentation/index.json
@@ -69,7 +69,7 @@
                     "title": "PIP",
                     "description": "The Product Information Portal (PIP) for Raspberry Pi compliance documents",
                     "image": "full-sized/PIP.png",
-                    "url": "https://pip.raspberrypi.org/"
+                    "url": "https://pip.raspberrypi.com/"
                 },
                 {
                     "title": "Datasheets",
@@ -124,7 +124,7 @@
                     "title": "PIP",
                     "description": "The Product Information Portal (PIP) for Raspberry Pi compliance documents",
                     "image": "full-sized/PIP.png",
-                    "url": "https://pip.raspberrypi.org/"
+                    "url": "https://pip.raspberrypi.com/"
                 },
                 {
                     "title": "Datasheets",
@@ -166,7 +166,7 @@
                     "title": "PIP",
                     "description": "The Product Information Portal (PIP) for Raspberry Pi compliance documents",
                     "image": "full-sized/PIP.png",
-                    "url": "https://pip.raspberrypi.org/"
+                    "url": "https://pip.raspberrypi.com/"
                 },
                 {
                     "title": "Datasheets",

--- a/jekyll-assets/_includes/footer.html
+++ b/jekyll-assets/_includes/footer.html
@@ -184,7 +184,7 @@
         <div class="__rptl-footer-heading">Documentation</div>
         <ul class="__rptl-footer-list">
           <li class="__rptl-footer-item"><a href="/documentation/" class="__rptl-footer-link">All categories</a></li>
-          <li class="__rptl-footer-item"><a href="https://pip.raspberrypi.org" class="__rptl-footer-link">Product information portal</a></li>
+          <li class="__rptl-footer-item"><a href="https://pip.raspberrypi.com" class="__rptl-footer-link">Product information portal</a></li>
           <li class="__rptl-footer-item"><a href="https://datasheets.raspberrypi.org" class="__rptl-footer-link">Datasheets</a></li>
         </ul>
         <div class="__rptl-footer-heading">Forums</div>


### PR DESCRIPTION
Now PIP has moved to pip.raspberrypi.com, update any links accordingly.
