### PR TITLE
Add libelf-dev to packages to install

### DIFF
--- a/documentation/asciidoc/computers/linux_kernel/building.adoc
+++ b/documentation/asciidoc/computers/linux_kernel/building.adoc
@@ -18,7 +18,7 @@ First install Git and the build dependencies:
 
 [,bash]
 ----
-sudo apt install git bc bison flex libssl-dev make
+sudo apt install git bc bison flex libssl-dev libelf-dev make
 ----
 
 Next get the sources, which will take some time:


### PR DESCRIPTION
On a new RasPi installation, the kernel build will fail without libelf-dev. The single apt command in this doc lacks this package.