### PR TITLE
Make header consistent across raspberrypi.com

### DIFF
--- a/jekyll-assets/_includes/header.html
+++ b/jekyll-assets/_includes/header.html
@@ -4,6 +4,7 @@
   margin: 0;
   padding: 0;
   border: 0;
+  line-height: 1;
   font-family: "Roboto", sans-serif;
   font-size: medium;
   font-weight: 400;
@@ -256,47 +257,13 @@
   <nav class="__rptl-header-nav">
     <div class="__rptl-header-wrapper">
       <ul class="__rptl-header-nav-list">
-        <li class="__rptl-header-nav-list-item">
-          <a href="/for-industry/" class="__rptl-header-nav-link">
-            For Industry
-          </a>
-        </li>
-
-        <li class="__rptl-header-nav-list-item">
-          <a href="/products/" class="__rptl-header-nav-link">
-            Hardware
-          </a>
-        </li>
-
-        <li class="__rptl-header-nav-list-item">
-          <a href="/software/" class="__rptl-header-nav-link">
-            Software
-          </a>
-        </li>
-
-        <li class="__rptl-header-nav-list-item">
-          <a href="/documentation/" class="__rptl-header-nav-link">
-            Documentation
-          </a>
-        </li>
-
-        <li class="__rptl-header-nav-list-item">
-          <a href="/news/" class="__rptl-header-nav-link">
-            News
-          </a>
-        </li>
-
-        <li class="__rptl-header-nav-list-item">
-          <a href="https://forums.raspberrypi.com/" class="__rptl-header-nav-link">
-            Forums
-          </a>
-        </li>
-
-        <li class="__rptl-header-nav-list-item">
-          <a href="https://www.raspberrypi.org" class="__rptl-header-nav-link" rel="noopener">
-            Foundation
-          </a>
-        </li>
+        <li class="__rptl-header-nav-list-item"><a href="/for-industry/" class="__rptl-header-nav-link">For Industry</a>
+        <li class="__rptl-header-nav-list-item"><a href="/products/" class="__rptl-header-nav-link">Hardware</a>
+        <li class="__rptl-header-nav-list-item"><a href="/software/" class="__rptl-header-nav-link">Software</a>
+        <li class="__rptl-header-nav-list-item"><a href="/documentation/" class="__rptl-header-nav-link">Documentation</a>
+        <li class="__rptl-header-nav-list-item"><a href="/news/" class="__rptl-header-nav-link">News</a>
+        <li class="__rptl-header-nav-list-item"><a href="https://forums.raspberrypi.com/" class="__rptl-header-nav-link">Forums</a>
+        <li class="__rptl-header-nav-list-item"><a href="https://www.raspberrypi.org" class="__rptl-header-nav-link" rel="noopener">Foundation</a>
       </ul>
     </div>
   </nav>


### PR DESCRIPTION
Brian noticed that the header changed sizes across Gatsby, WordPress and the documentation site. This was due to a missing line-height reset for the header and the introduction of significant whitespace in the header links.

To fix the latter, we use the fact <li> elements do not need to be closed in HTML5 as long as they are followed by another <li> or the last item in the list. This avoids introducing any accidental whitespace. See https://html.spec.whatwg.org/dev/syntax.html#optional-tags
