### PR TITLE
Remove extra height from logo in header

### DIFF
--- a/jekyll-assets/_includes/header.html
+++ b/jekyll-assets/_includes/header.html
@@ -57,6 +57,7 @@
   text-decoration: none;
   box-sizing: border-box;
   display: inline-block;
+  vertical-align: middle;
 }
 #__rptl-header .__rptl-header-logo {
   margin: 0;
@@ -64,6 +65,7 @@
   border: 0;
   box-sizing: border-box;
   display: block;
+  vertical-align: middle;
 }
 #__rptl-header .__rptl-header-burger {
   margin: 0;


### PR DESCRIPTION
While fixing the consistency of the header across raspberrypi.com, I noticed an extra 1.5px of height added to the wrapper around the logo. This seems to be coming from an inconsistent vertical alignment of the logo in the header so explicitly set the alignment for both the logo and its containing anchor tag.
