### PR TITLE
Update "Terms and conditions of sale" link

### DIFF
--- a/jekyll-assets/_includes/footer.html
+++ b/jekyll-assets/_includes/footer.html
@@ -144,7 +144,7 @@
           <li class="__rptl-footer-item"><a href="/accessibility/" class="__rptl-footer-link">Accessibility</a></li>
           <li class="__rptl-footer-item"><a href="/cookies/" class="__rptl-footer-link">Cookies</a></li>
           <li class="__rptl-footer-item"><a href="/licensing/" class="__rptl-footer-link">Licensing</a></li>
-          <li class="__rptl-footer-item"><a href="/terms-conditions-sale/" class="__rptl-footer-link">Terms and conditions of sales</a></li>
+          <li class="__rptl-footer-item"><a href="/terms-conditions-sale/" class="__rptl-footer-link">Terms and conditions of sale</a></li>
           <li class="__rptl-footer-item"><a href="/privacy/" class="__rptl-footer-link">Privacy</a></li>
           <li class="__rptl-footer-item"><a href="/contact/security/" class="__rptl-footer-link">Security</a></li>
         </ul>


### PR DESCRIPTION
As the page title is "Terms of conditions of sale" and not "sales", update the link text in the footer to match.
