### PR TITLE
Update magazine links to raspberrypi.com

### DIFF
--- a/jekyll-assets/_includes/footer.html
+++ b/jekyll-assets/_includes/footer.html
@@ -190,10 +190,10 @@
         <div class="__rptl-footer-heading">Raspberry Pi Press</div>
         <ul class="__rptl-footer-list">
           <li class="__rptl-footer-item"><a href="/books-magazines/" class="__rptl-footer-link">About Raspberry Pi Press</a></li>
-          <li class="__rptl-footer-item"><a href="https://magpi.raspberrypi.org" class="__rptl-footer-link">The MagPi</a></li>
-          <li class="__rptl-footer-item"><a href="https://hackspace.raspberrypi.org" class="__rptl-footer-link">HackSpace</a></li>
-          <li class="__rptl-footer-item"><a href="https://wireframe.raspberrypi.org" class="__rptl-footer-link">Wireframe</a></li>
-          <li class="__rptl-footer-item"><a href="https://custompc.raspberrypi.org" class="__rptl-footer-link">Custom PC</a></li>
+          <li class="__rptl-footer-item"><a href="https://magpi.raspberrypi.com" class="__rptl-footer-link">The MagPi</a></li>
+          <li class="__rptl-footer-item"><a href="https://hackspace.raspberrypi.com" class="__rptl-footer-link">HackSpace</a></li>
+          <li class="__rptl-footer-item"><a href="https://wireframe.raspberrypi.com" class="__rptl-footer-link">Wireframe</a></li>
+          <li class="__rptl-footer-item"><a href="https://custompc.raspberrypi.com" class="__rptl-footer-link">Custom PC</a></li>
         </ul>
       </div>
     </div>


### PR DESCRIPTION
Now the magazines have moved from raspberrypi.org to raspberrypi.com, update the footer links accordingly.
