### PR TITLE
camera: Add a new section on packages and update build instructions

### DIFF
--- a/documentation/asciidoc/accessories/camera.adoc
+++ b/documentation/asciidoc/accessories/camera.adoc
@@ -34,6 +34,8 @@ include::camera/libcamera_apps_post_processing_tflite.adoc[]
 
 include::camera/libcamera_apps_post_processing_writing.adoc[]
 
+include::camera/libcamera_apps_packages.adoc[]
+
 include::camera/libcamera_apps_building.adoc[]
 
 include::camera/libcamera_apps_writing.adoc[]

--- a/documentation/asciidoc/accessories/camera/libcamera_apps_building.adoc
+++ b/documentation/asciidoc/accessories/camera/libcamera_apps_building.adoc
@@ -6,13 +6,15 @@ Building `libcamera` and `libcamera-apps` for yourself can bring the following b
 
 * `libcamera-apps` can be compiled with extra optimisation for Pi 3 and Pi 4 devices running a 32-bit OS.
 
-* You can include the various optional OpenCV and/or TFLite post-processing stages.
+* You can include the various optional OpenCV and/or TFLite post-processing stages (or add your own).
+
+* You can customise or add your own applications derived from `libcamera-apps`.
 
 NOTE: When building for Pi 3 or earlier devices there is a risk that the device may run out of swap and fail. We recommend either increasing the amount of swap, or building with fewer threads (the `-j` option to `ninja` and to `make`).
 
 ==== Building `libcamera-apps` without rebuilding `libcamera`
 
-On _Bullseye_ or later images, you can rebuild `libcamera-apps` _without_ first rebuilding the whole of `libcamera` and `libepoxy`. To do this, please execute:
+You can rebuild `libcamera-apps` _without_ first rebuilding the whole of `libcamera` and `libepoxy`. To do this, please execute:
 
 ----
 sudo apt install -y libcamera-dev libepoxy-dev libjpeg-dev libtiff5-dev
@@ -28,6 +30,8 @@ Now proceed directly to the instructions for xref:camera.adoc#building-libcamera
 
 ==== Building `libcamera`
 
+Rebuilding `libcamera` from scratch should be necessary only if you need the latest features that may not yet have reached the `apt` repositories, or if you need to customise its behaviour in some way.
+
 First install all the necessary dependencies for `libcamera`.
 
 NOTE: Raspberry Pi OS Lite users will first need to install the following additional packages if they have not done so previously:
@@ -37,7 +41,7 @@ sudo apt install -y python3-pip git
 sudo pip3 install jinja2
 ----
 
-All users should then install the following.
+All users should then install the following:
 
 ----
 sudo apt install -y libboost-dev
@@ -54,19 +58,36 @@ Now we can check out and build `libcamera` itself.
 cd
 git clone git://linuxtv.org/libcamera.git
 cd libcamera
-meson build --buildtype=release
-cd build
-meson configure -Dpipelines=raspberrypi -Dtest=false
-cd ..
+----
+
+Next we recommend that Raspberry Pi OS Lite users run
+
+----
+meson build --buildtype=release -Dpipelines=raspberrypi -Dipas=raspberrypi -Dv4l2=true -Dgstreamer=enabled -Dtest=false -Dlc-compliance=disabled -Dcam=disabled -Dqcam=disabled -Ddocumentation=disabled
+----
+
+Users of Raspberry Pi OS can instead use
+
+----
+meson build --buildtype=release -Dpipelines=raspberrypi -Dipas=raspberrypi -Dv4l2=true -Dgstreamer=enabled -Dtest=false -Dlc-compliance=disabled -Dcam=disabled -Dqcam=enabled -Ddocumentation=disabled
+----
+
+The only difference is that the latter also builds the `qcam` test application, which has dependencies on Qt and X Windows (after completing the `libcamera` build users can run `build/src/qcam/qcam` to verify that `libcamera` is functioning correctly).
+
+To complete the `libcamera` build, please run
+
+----
 ninja -C build
 sudo ninja -C build install   # use -j 2 on Pi 3 or earlier devices
 ----
 
-NOTE: If you wish to build the `libcamerasrc` _gstreamer_ element, please ensure that _gstreamer_ and `libgstreamer1.0-dev` and `libgstreamer-plugins-base1.0-dev` are installed before running `meson`. If you wish to build the V4L2 compatabilitiy layer, please add `-Dv4l2=true` to the `meson configure` command. More information is available on the https://www.libcamera.org/index.html[libcamera website].
+NOTE: If you wish to build the `libcamerasrc` _gstreamer_ element, please ensure that _gstreamer_ and `libgstreamer1.0-dev` and `libgstreamer-plugins-base1.0-dev` are installed before running `meson`. More information is available on the https://www.libcamera.org/index.html[libcamera website].
 
 ==== Building `libepoxy`
 
-If you wish to build and install `libepoxy`, please start by installing the necessary dependencies.
+Rebuilding `libepoxy` should not normally be necessary as this library changes only very rarely. If you do want to build it from scratch, however, please follow the instructions below.
+
+Start by installing the necessary dependencies.
 
 ----
 sudo apt install -y libegl1-mesa-dev
@@ -93,13 +114,7 @@ First fetch the necessary dependencies for `libcamera-apps`.
 sudo apt install -y cmake libboost-program-options-dev libdrm-dev libexif-dev
 ----
 
-Finally build `libcamera-apps` as shown. You will need to decide what extra flags to pass to `cmake`. The valid flags are:
-
-* `-DENABLE_COMPILE_FLAGS_FOR_TARGET=armv8-neon` - you may supply this when building for Pi 3 or Pi 4 devices running a 32-bit OS. Some post-processing features may run more quickly.
-
-* `-DENABLE_OPENCV=0` or `-DENABLE_OPENCV=1` - you may choose one of these to force OpenCV-based post-processing stages to be linked (or not). If you enable them, then OpenCV must be installed on your system. Normally they will be built by default if OpenCV is available.
-
-* `-DENABLE_TFLITE=0` or `-DENABLE_TFLITE=1` - choose one of these to enable TensorFlow Lite post-processing stages (or not). By default they will not be enabled. If you enable them then TensorFlow Lite must be available on your system. Depending on how you have built and/or installed TFLite, you may need to tweak the `CMakeLists.txt` file in the `post_processing_stages` directory.
+The `libcamera-apps` build process begins with the following:
 
 ----
 cd
@@ -107,12 +122,44 @@ git clone https://github.com/raspberrypi/libcamera-apps.git
 cd libcamera-apps
 mkdir build
 cd build
-cmake ..  # add your extra cmake flags here
-make -j4  # use -j2 on Pi 3 or earlier devices
-sudo make install
-sudo ldconfig  # this is only necessary on the first build
 ----
 
-NOTE: On _Bullseye_ and later images, if you want to run the new `libcamera-apps` executables from the same terminal window where you have just built and installed them for the first time, you may need to run `hash -r` to be sure to pick up the new ones over the system supplied ones.
+At this point you will need to run `cmake` after deciding what extra flags to pass it. The valid flags are:
+
+* `-DENABLE_COMPILE_FLAGS_FOR_TARGET=armv8-neon` - you may supply this when building for Pi 3 or Pi 4 devices running a 32-bit OS. Some post-processing features may run more quickly.
+
+* `-DENABLE_DRM=1` or `-DENABLE_DRM=0` - this enables or disables the DRM/KMS preview rendering. This is what implements the preview window when X Windows is not running.
+
+* `-DENABLE_X11=1` or `-DENABLE_X11=0` - this enables or disables the X Windows based preview. You should disable this if your system does not have X Windows installed.
+
+* `-DENABLE_QT=1` or `-DENABLE_QT=0` - this enables or disables support for the Qt-based implementation of the preview window. You should disable it if you do not have X Windows installed, or if you have no intention of using the Qt-based preview window. The Qt-based preview is normally not recommended because it is computationally very expensive, however it does work with X display forwarding.
+
+* `-DENABLE_OPENCV=1` or `-DENABLE_OPENCV=0` - you may choose one of these to force OpenCV-based post-processing stages to be linked (or not). If you enable them, then OpenCV must be installed on your system. Normally they will be built by default if OpenCV is available.
+
+* `-DENABLE_TFLITE=1` or `-DENABLE_TFLITE=0` - choose one of these to enable TensorFlow Lite post-processing stages (or not). By default they will not be enabled. If you enable them then TensorFlow Lite must be available on your system. Depending on how you have built and/or installed TFLite, you may need to tweak the `CMakeLists.txt` file in the `post_processing_stages` directory.
+
+For Raspberry Pi OS users we recommend the following `cmake` command:
+
+----
+cmake .. -DENABLE_DRM=1 -DENABLE_X11=1 -DENABLE_QT=1 -DENABLE_OPENCV=0 -DENABLE_TFLITE=0
+----
+
+and for Raspberry Pi OS Lite users:
+
+----
+cmake .. -DENABLE_DRM=1 -DENABLE_X11=0 -DENABLE_QT=0 -DENABLE_OPENCV=0 -DENABLE_TFLITE=0
+----
+
+In both cases, consider `-DENABLE_COMPILE_FLAGS_FOR_TARGET=armv8-neon` if you are using a 32-bit OS on a Pi 3 or Pi 4. Consider `-DENABLE_OPENCV=1` if you have installed _OpenCV_ and wish to use OpenCV-based post-processing stages. Finally also consider `-DENABLE_TFLITE=1` if you have installed _TensorFlow Lite_ and wish to use it in post-processing stages.
+
+After executing the `cmake` command of your choice, the whole process concludes with the following:
+
+----
+make -j4  # use -j2 on Pi 3 or earlier devices
+sudo make install
+sudo ldconfig /usr/bin/local # this is only necessary on the first build
+----
+
+NOTE: If you are using an image where `libcamera-apps` have been previously installed as an `apt` package, and you want to run the new `libcamera-apps` executables from the same terminal window where you have just built and installed them, you may need to run `hash -r` to be sure to pick up the new ones over the system supplied ones.
 
 Finally, if you have not already done so, please be sure to follow the `dtoverlay` and display driver instructions in the  xref:camera.adoc#getting-started[Getting Started section] (and rebooting if you changed anything there).

--- a/documentation/asciidoc/accessories/camera/libcamera_apps_getting_started.adoc
+++ b/documentation/asciidoc/accessories/camera/libcamera_apps_getting_started.adoc
@@ -2,7 +2,7 @@
 
 ==== Using the camera for the first time
 
-When running a Raspberry Pi OS based on _Bullseye_ or later, the 5 basic `libcamera-apps` are already installed. In this case, official Raspberry Pi cameras will also be detected and enabled automatically.
+When running a Raspberry Pi OS based on _Bullseye_, the 5 basic `libcamera-apps` are already installed. In this case, official Raspberry Pi cameras will also be detected and enabled automatically.
 
 You can check that everything is working by entering:
 
@@ -13,7 +13,7 @@ libcamera-hello
 
 You should see a camera preview window for about 5 seconds.
 
-Normally there is nothing further to do, but if you do need to alter the configuration of your Raspberry Pi, please consult the next section.
+Users running _Buster_ will need to xref:camera.adoc#binary-packages[install one of the `libcamera-apps` packages] first and then configure their `/boot/config.txt` file xref:camera.adoc#if-you-do-need-to-alter-the-configuration[with the appropriate overlay] for the connected camera. Be aware that _libcamera_ and the legacy _raspicam_ stack cannot operate at the same time - to return to the legacy stack after using _libcamera_ you will need to comment out the `dtoverlay` change you made and reboot the system.
 
 NOTE: Pi 3 and older devices may not by default be using the correct display driver. Refer to the `/boot/config.txt` file and ensure that either `dtoverlay=vc4-fkms-v3d` or `dtoverlay=vc4-kms-v3d` is currently active. Please reboot if you needed to change this.
 
@@ -53,7 +53,7 @@ If you do need to add your own `dtoverlay`, the following are currently recognis
 | `dtoverlay=ov9281`
 |===
 
-Please also delete the entry
+To override the automatic camera detection, _Bullseye_ users will also need to delete the entry
 
 `camera_auto_detect=1`
 

--- a/documentation/asciidoc/accessories/camera/libcamera_apps_packages.adoc
+++ b/documentation/asciidoc/accessories/camera/libcamera_apps_packages.adoc
@@ -1,0 +1,33 @@
+=== `libcamera` and `libcamera-apps` Packages
+
+A number of `apt` packages are provided for convenience. In order to access them, we recommend keeping your OS up to date xref:../computers/os.adoc#using-apt[in the usual way].
+
+==== Binary Packages
+
+There are two `libcamera-apps` packages available, that contain the necessary executables:
+
+* `libcamera-apps` contains the full applications with support for previews using X Windows. This package is pre-installed in the _Bullseye_ release of Raspberry Pi OS, and can be installed in _Buster_ using `sudo apt install libcamera-apps`.
+
+* `libcamera-apps-lite` omits X Windows support and only the DRM preview is available. This package is pre-installed in the _Bullseye_ release of Raspberry Pi OS Lite, and can be installed in _Buster_ using `sudo apt install libcamera-apps-lite`.
+
+For _Bullseye_ users, official Raspberry Pi cameras should be detected automatically. Other users will need to xref:camera.adoc#if-you-do-need-to-alter-the-configuration[edit their `/boot/config.txt`] file if they have not done so previously.
+
+==== Dependencies
+
+These applications depend on a number of library packages which are named _library-name<n>_ where _<n>_ is a version number (actually the ABI, or Application Binary Interface, version), and which stands at zero at the time of writing. Thus we have the following:
+
+* The package `libcamera0` contains the `libcamera` libraries.
+
+* The package `libepoxy0` contains the `libepoxy` libraries.
+
+These will be installed automatically when needed.
+
+==== Dev Packages
+
+`libcamera-apps` can be rebuilt on their own without installing and building `libcamera` and `libepoxy` from scratch. To enable this, the following packages should be installed:
+
+* `libcamera-dev` contains the necessary `libcamera` header files and resources.
+
+* `libepoxy-dev` contains the necessary `libepoxy` header files and resources.
+
+Subsequently `libcamera-apps` can be xref:camera.adoc#building-libcamera-apps-without-rebuilding-libcamera[checked out from Github and rebuilt].

--- a/documentation/asciidoc/accessories/camera/libcamera_differences.adoc
+++ b/documentation/asciidoc/accessories/camera/libcamera_differences.adoc
@@ -25,7 +25,7 @@ Whilst the `libcamera-apps` attempt to emulate most features of the legacy _Rasp
 
 * There are some differences in the metering, exposure and AWB options. In particular the legacy apps conflate metering (by which we mean the "metering mode") and the exposure (by which we now mean the "exposure profile"). With regards to AWB, to turn it off you have to set a pair of colour gains (e.g. `--awbgains 1.0,1.0`).
 
-* `libcamera` has no mechanism to set the AWB into "grey world" mode, which is useful for "NOIR" camera modules. However, tuning files are supplied which switch the AWB into the correct mode, so for example, you could use `libcamera-hello --tuning-file /usr/local/share/libcamera/ipa/raspberrypi/imx219_noir.json`.
+* `libcamera` has no mechanism to set the AWB into "grey world" mode, which is useful for "NOIR" camera modules. However, tuning files are supplied which switch the AWB into the correct mode, so for example, you could use `libcamera-hello --tuning-file /usr/share/libcamera/ipa/raspberrypi/imx219_noir.json`.
 
 * There is support for setting the exposure time (`--shutter`) and analogue gain (`--analoggain` or just `--gain`). There is no explicit control of the digital gain; you get this if the gain requested is larger than the analogue gain can deliver by itself.
 

--- a/documentation/asciidoc/accessories/camera/libcamera_hello.adoc
+++ b/documentation/asciidoc/accessories/camera/libcamera_hello.adoc
@@ -33,14 +33,14 @@ For example, the NOIR (no IR-filter) versions of sensors require different AWB s
 
 [,bash]
 ----
-libcamera-hello --tuning-file /usr/local/share/libcamera/ipa/raspberrypi/imx219_noir.json
+libcamera-hello --tuning-file /usr/share/libcamera/ipa/raspberrypi/imx219_noir.json
 ----
 
 If you are using a Soho Enterprises SE327M12 module you should use
 
 [,bash]
 ----
-libcamera-hello --tuning-file /usr/local/share/libcamera/ipa/raspberrypi/se327m12.json
+libcamera-hello --tuning-file /usr/share/libcamera/ipa/raspberrypi/se327m12.json
 ----
 
 Notice how this also means that users can copy an existing tuning file and alter it according to their own preferences, so long as the `--tuning-file` parameter is pointed to the new version.


### PR DESCRIPTION
A short new section explains what libcamera-apps related packages are
available in the upcoming Bullseye release. The build instructions are
also updated to reflect various improved options that we have applied
in fine-tuning these packages.