### PR TITLE
Add RPi Zero 2 W overclocking defaults

### DIFF
--- a/documentation/asciidoc/computers/config_txt/overclocking.adoc
+++ b/documentation/asciidoc/computers/config_txt/overclocking.adoc
@@ -99,7 +99,7 @@ This table gives the default values for the options on various Raspberry Pi Mode
 
 [cols=",^,^,^,^,^,^,^,^"]
 |===
-| Option | Pi 0/W | Pi1 | Pi2 | Pi3 | Pi3A+/Pi3B+ | CM4 & Pi4B <= R1.3 | Pi4B R1.4 | Pi 400
+| Option | Pi 0/W | Pi1 | Pi2 | Pi3 | Pi3A+/Pi3B+ | CM4 & Pi4B <= R1.3 | Pi4B R1.4 | Pi 400 | Pi Zero 2 W
 
 | arm_freq
 | 1000
@@ -110,6 +110,7 @@ This table gives the default values for the options on various Raspberry Pi Mode
 | 1500
 | 1500 or 1800 if arm_boost=1
 | 1800
+| 1000
 
 | core_freq
 | 400
@@ -120,6 +121,7 @@ This table gives the default values for the options on various Raspberry Pi Mode
 | 500
 | 500
 | 500
+| 400
 
 | h264_freq
 | 300
@@ -130,6 +132,7 @@ This table gives the default values for the options on various Raspberry Pi Mode
 | 500
 | 500
 | 500
+| 400
 
 | isp_freq
 | 300
@@ -140,6 +143,7 @@ This table gives the default values for the options on various Raspberry Pi Mode
 | 500
 | 500
 | 500
+| 400
 
 | v3d_freq
 | 300
@@ -150,6 +154,7 @@ This table gives the default values for the options on various Raspberry Pi Mode
 | 500
 | 500
 | 500
+| 400
 
 | hevc_freq
 | N/A
@@ -160,6 +165,7 @@ This table gives the default values for the options on various Raspberry Pi Mode
 | 500
 | 500
 | 500
+| N/A
 
 | sdram_freq
 | 450
@@ -170,10 +176,12 @@ This table gives the default values for the options on various Raspberry Pi Mode
 | 3200
 | 3200
 | 3200
+| 450
 
 | arm_freq_min
 | 700
 | 700
+| 600
 | 600
 | 600
 | 600
@@ -190,8 +198,10 @@ This table gives the default values for the options on various Raspberry Pi Mode
 | 200
 | 200
 | 200
+| 250
 
 | gpu_freq_min
+| 250
 | 250
 | 250
 | 250
@@ -210,8 +220,10 @@ This table gives the default values for the options on various Raspberry Pi Mode
 | 250
 | 250
 | 250
+| 250
 
 | isp_freq_min
+| 250
 | 250
 | 250
 | 250
@@ -230,6 +242,7 @@ This table gives the default values for the options on various Raspberry Pi Mode
 | 250
 | 250
 | 250
+| 250
 
 | sdram_freq_min
 | 400
@@ -240,6 +253,7 @@ This table gives the default values for the options on various Raspberry Pi Mode
 | 3200
 | 3200
 | 3200
+| 400
 |===
 
 This table gives defaults for options that are the same across all models.
@@ -284,19 +298,23 @@ The firmware uses Adaptive Voltage Scaling (AVS) to determine the optimum CPU/GP
 
 | Pi 2
 | 0
-| 1.2-1.3125V
+| 1.2-1.35V
 
 | Pi 3
 | 0
-| 1.2-1.3125V
+| 1.2-1.35V
 
 | Pi 4, Pi400, CM4
 | 0
 | 0.88V
 
 | Pi Zero
-| 6
-| 1.35V
+| 0
+| 1.2-1.35V
+
+| Pi Zero 2 W
+| 0
+| 1.2-1.35V
 |===
 
 [discrete]


### PR DESCRIPTION
Additionally incorrect `over_voltage` defaults and ranges have been fixed.

On RPi 4/400, if default maximum voltage (`over_voltage=0`) means 0.88V, is it adjusted in 0.025V steps as well? And what is the default minimum voltage (`over_voltage_min=0`)? As well 0.15V below the max (= 0.73V), like for the other RPi models (aside of RPi 1)? And what about the SDRAM voltage? I would like to merge the two voltage tables to show the resulting relating voltage for RPi 1, RPi 4 variants, and all others in separate columns. Currently both tables contradict because of RPi 4 variants. Probably it makes even sense to merge all three tables: Even that all voltage integer values are the same on all RPi models, the table could additionally contain the related voltage [V] value, which is different. Having everything in one tables should increase overview and reduce scrolling up and down to find information.