### PR TITLE
camera: Minor clarifications on depth of field

### DIFF
--- a/documentation/asciidoc/accessories/camera/camera_hardware.adoc
+++ b/documentation/asciidoc/accessories/camera/camera_hardware.adoc
@@ -117,9 +117,9 @@ Then, please follow the relevant setup instructions either for xref:camera.adoc#
 |
 |
 
-| Fixed focus
-| 1 m to infinity
-|
+| Depth of field
+| approx. 1 m to infinity
+| adjustable with supplied tool
 | N/A
 
 | Focal length


### PR DESCRIPTION
These are very small corrections, prompted by https://github.com/raspberrypi/documentation/issues/2122.

The table row marked "Fixed focus" is really giving a depth of field, so I've renamed it.

For the v1 sensor I believe "1m to infinity" is about right, but I've added "approx." because there is a significant element of judgement as regards what you believe "in focus" means.

For the v2 sensor I've mentioned that it's adjustable. Because it was previously blank, I think people possibly inferred it to mean "the same as v1", which isn't true. Though in its default configuration, it shouldn't be very different (again, up to a subjective interpretation of what that means!).