### PR TITLE
Fixed typos in config.txt's video section

### DIFF
--- a/documentation/asciidoc/computers/config_txt/video.adoc
+++ b/documentation/asciidoc/computers/config_txt/video.adoc
@@ -1655,9 +1655,8 @@ The `framebuffer_width` command specifies the console framebuffer width in pixel
 ==== `framebuffer_height`
 
 The `framebuffer_height` command specifies the console framebuffer height in pixels. The default is the display height minus the total vertical overscan.
-C4
 
-==== `max_framebuffer_heigh`t, `max_framebuffer_width`
+==== `max_framebuffer_height`, `max_framebuffer_width`
 
 Specifies the maximum dimensions that the internal frame buffer is allowed to be.
 


### PR DESCRIPTION
I think I saw 2 typos:
The letters "C4" at the end of "framebuffer_height", and a ` splitting "heigh-t" :wink:

Seems cleaner now? :smile: