### PR TITLE
Various tweaks and tidyups

### DIFF
--- a/documentation/asciidoc/accessories/build-hat.adoc
+++ b/documentation/asciidoc/accessories/build-hat.adoc
@@ -1,4 +1,3 @@
-
 include::build-hat/introduction.adoc[]
 
 include::build-hat/preparing-build-hat.adoc[]

--- a/documentation/asciidoc/accessories/camera/libcamera_options_common.adoc
+++ b/documentation/asciidoc/accessories/camera/libcamera_options_common.adoc
@@ -261,7 +261,7 @@ Sets the metering mode of the AEC/AGC algorithm. This may one of the following v
 * `average` - average or whole frame metering
 * `custom` - custom metering mode which would have to be defined in the camera tuning file.
 
-For more information on defining a custom metering mode, and also on how to adjust the region weights in the existing metering modes,please refer to the https://datasheets.raspberrypi.com/camera/raspberry-pi-camera-guide.pdf[Tuning guide for the Raspberry Pi cameras and libcamera].
+For more information on defining a custom metering mode, and also on how to adjust the region weights in the existing metering modes, please refer to the https://datasheets.raspberrypi.com/camera/raspberry-pi-camera-guide.pdf[Tuning guide for the Raspberry Pi cameras and libcamera].
 
 Example: `libcamera-still -o test.jpg --metering spot`
 

--- a/documentation/asciidoc/accessories/sense-hat.adoc
+++ b/documentation/asciidoc/accessories/sense-hat.adoc
@@ -1,5 +1,4 @@
 == Installation
-:pp: {plus}{plus}
 
 In order to work correctly, the Sense HAT requires an up-to-date kernel, I2C to be enabled, and a few libraries to get started.
 
@@ -34,7 +33,7 @@ After installation, example code can be found under `/usr/src/sense-hat/examples
 
 These can be copied to the user's home directory by running `cp /usr/src/sense-hat/examples ~/ -a`.
 
-The C/C{pp} examples can be compiled by running `make` in the appropriate directory.
+The C/{cpp} examples can be compiled by running `make` in the appropriate directory.
 
 The RTIMULibDrive11 example comes pre-compiled to help ensure everything works as intended. It can be launched by running `RTIMULibDrive11` and closed by pressing `Ctrl+c`.
 
@@ -46,7 +45,7 @@ Complete documentation can be found at https://pythonhosted.org/sense-hat/[pytho
 
 == Using the RTIMULib Library
 
-https://github.com/RPi-Distro/RTIMULib[RTIMULib] is a C{pp} and Python library that makes it easy to use 9-dof and 10-dof IMUs with embedded Linux systems. A pre-calibrated settings file is provided in `/etc/RTIMULib.ini`, which is also copied and used by `sense-hat`. The included examples look for `RTIMULib.ini` in the current working directory, so you may wish to copy the file there to get more accurate data.
+https://github.com/RPi-Distro/RTIMULib[RTIMULib] is a {cpp} and Python library that makes it easy to use 9-dof and 10-dof IMUs with embedded Linux systems. A pre-calibrated settings file is provided in `/etc/RTIMULib.ini`, which is also copied and used by `sense-hat`. The included examples look for `RTIMULib.ini` in the current working directory, so you may wish to copy the file there to get more accurate data.
 
 == Other Issues
 

--- a/documentation/asciidoc/computers/config_txt/video.adoc
+++ b/documentation/asciidoc/computers/config_txt/video.adoc
@@ -1390,7 +1390,7 @@ These values are valid if `hdmi_group=2` (DMT):
 | reduced blanking
 |===
 
-NOTE: There is a https://forums.raspberrypi.com/viewtopic.php?f=26&t=20155&p=195443#p195443[pixel clock limit].The highest supported mode on models prior to the Raspberry Pi 4 is 1920x1200 at 60Hz with reduced blanking, whilst the Raspberry Pi 4 can support up to 4096x2160 (known as 4k) at 60Hz. Also note that if you are using both HDMI ports of the Raspberry Pi 4 for 4k output, then you are limited to 30Hz on both.
+NOTE: There is a https://forums.raspberrypi.com/viewtopic.php?f=26&t=20155&p=195443#p195443[pixel clock limit]. The highest supported mode on models prior to the Raspberry Pi 4 is 1920x1200 at 60Hz with reduced blanking, whilst the Raspberry Pi 4 can support up to 4096x2160 (known as 4k) at 60Hz. Also note that if you are using both HDMI ports of the Raspberry Pi 4 for 4k output, then you are limited to 30Hz on both.
 
 ==== `hdmi_timings`
 
@@ -1715,7 +1715,7 @@ The options that can be set are:
 
 ==== `max_framebuffers`
 
-This configuration entry sets the maximum number of firmware framebuffers that can be created. Valid options are 0,1, and 2. By default on devices before the Pi4 this is set to 1, so will need to be increased to 2 when using more than one display, for example HDMI and a DSI or DPI display. The Raspberry Pi4 configuration sets this to 2 by default as it has two HDMI ports.
+This configuration entry sets the maximum number of firmware framebuffers that can be created. Valid options are 0, 1, and 2. By default on devices before the Pi4 this is set to 1, so will need to be increased to 2 when using more than one display, for example HDMI and a DSI or DPI display. The Raspberry Pi4 configuration sets this to 2 by default as it has two HDMI ports.
 
 Generally in most cases it is safe to set this to 2, as framebuffers will only be created when an attached device is actually detected.
 

--- a/documentation/asciidoc/computers/configuration/device-tree.adoc
+++ b/documentation/asciidoc/computers/configuration/device-tree.adoc
@@ -232,7 +232,7 @@ make ARCH=arm dtbs
 
 It is interesting to dump the contents of the DTB file to see what the compiler has generated:
 
-[,console]
+[,bash]
 ----
 fdtdump 1st.dtbo
 /dts-v1/;

--- a/documentation/asciidoc/computers/configuration/screensaver.adoc
+++ b/documentation/asciidoc/computers/configuration/screensaver.adoc
@@ -8,12 +8,14 @@ When running without a graphical desktop, Raspberry Pi OS will blank the screen 
 
 The current setting, in seconds, can be displayed using:
 
+[,bash]
 ----
 cat /sys/module/kernel/parameters/consoleblank
 ----
 
 To change the `consoleblank` setting, edit the kernel command line:
 
+[,bash]
 ----
 sudo nano /boot/cmdline.txt
 ----
@@ -28,6 +30,7 @@ Raspberry Pi OS will blank the graphical desktop after 10 minutes without user i
 
 There is also a graphical screensaver available, which can be installed as follows:
 
+[,bash]
 ----
 sudo apt install xscreensaver
 ----
@@ -40,14 +43,14 @@ Once this has been installed, you can find the Screensaver application on the Pr
 
 If you want to switch off the video display entirely, you can use the xref:os.adoc#vcgencmd[vcgencmd] command,
 
-[,shell]
+[,bash]
 ----
 vcgencmd display_power 0
 ----
 
 Video will not come back on until you reboot or switch it back on:
 
-[,shell]
+[,bash]
 ----
 vcgencmd display_power 1
 ----

--- a/documentation/asciidoc/computers/configuration/securing-the-raspberry-pi.adoc
+++ b/documentation/asciidoc/computers/configuration/securing-the-raspberry-pi.adoc
@@ -103,7 +103,9 @@ and change the `pi` entry (or whichever usernames have superuser rights) to:
 pi ALL=(ALL) PASSWD: ALL
 ----
 
-Then save the file: it will be checked for any syntax errors. If no errors were detected, the file will be saved and you will be returned to the shell prompt. If errors were detected, you will be asked 'what now?' Press the 'enter' key on your keyboard: this will bring up a list of options. You will probably want to use 'e' for '(e)dit sudoers file again,' so you can edit the file and fix the problem. *Note that choosing option 'Q' will save the file with any syntax errors still in place, which makes it impossible for _any_ user to use the sudo command.*
+Then save the file: it will be checked for any syntax errors. If no errors were detected, the file will be saved and you will be returned to the shell prompt. If errors were detected, you will be asked 'what now?' Press the 'enter' key on your keyboard: this will bring up a list of options. You will probably want to use 'e' for '(e)dit sudoers file again', so you can edit the file and fix the problem.
+
+NOTE: Choosing option 'Q' will save the file with any syntax errors still in place, which makes it impossible for _any_ user to use the sudo command.
 
 === Updating Raspberry Pi OS
 

--- a/documentation/asciidoc/computers/os/using-gpio.adoc
+++ b/documentation/asciidoc/computers/os/using-gpio.adoc
@@ -1,5 +1,4 @@
 == GPIO and the 40-pin Header
-:pp: {plus}{plus}
 
 A powerful feature of the Raspberry Pi is the row of GPIO (general-purpose input/output) pins along the top edge of the board. A 40-pin GPIO header is found on all current Raspberry Pi boards (unpopulated on Pi Zero and Pi Zero W). Prior to the Pi 1 Model B+ (2014), boards comprised a shorter 26-pin header.
 

--- a/documentation/asciidoc/computers/os/using-python.adoc
+++ b/documentation/asciidoc/computers/os/using-python.adoc
@@ -1,5 +1,4 @@
 == Python
-:pp: {plus}{plus}
 
 Python is a powerful programming language that's easy to use easy to read and write and, with Raspberry Pi, lets you connect your project to the real world. Python syntax is clean, with an emphasis on readability, and uses standard English keywords.
 
@@ -347,7 +346,7 @@ sudo pip3 install simplejson
 
 ===== piwheels
 
-The official Python Package Index (PyPI) hosts files uploaded by package maintainers. Some packages require compilation (compiling C/C{pp} or similar code) in order to install them, which can be a time-consuming task, particlarly on the single-core Raspberry Pi 1 or Pi Zero.
+The official Python Package Index (PyPI) hosts files uploaded by package maintainers. Some packages require compilation (compiling C/{cpp} or similar code) in order to install them, which can be a time-consuming task, particlarly on the single-core Raspberry Pi 1 or Pi Zero.
 
 piwheels is a service providing pre-compiled packages (called _Python wheels_) ready for use on the Raspberry Pi. Raspberry Pi OS is pre-configured to use piwheels for pip. Read more about the piwheels project at https://www.piwheels.org/[www.piwheels.org].
 

--- a/documentation/asciidoc/computers/raspberry-pi.adoc
+++ b/documentation/asciidoc/computers/raspberry-pi.adoc
@@ -1,4 +1,3 @@
-
 include::raspberry-pi/raspberry-pi-schematics.adoc[]
 
 include::raspberry-pi/raspberry-pi-compliance.adoc[]

--- a/documentation/asciidoc/computers/raspberry-pi/peripheral_addresses.adoc
+++ b/documentation/asciidoc/computers/raspberry-pi/peripheral_addresses.adoc
@@ -86,7 +86,7 @@ Link with:
 
 So a simple command line compile might be:
 
-[,shell]
+[,bash]
 ----
 cc myfile.c -I/opt/vc/include -L/opt/vc/lib -lbcm_host -o myfile
 ----

--- a/documentation/asciidoc/computers/remote-access/apache.adoc
+++ b/documentation/asciidoc/computers/remote-access/apache.adoc
@@ -51,7 +51,7 @@ drwxr-xr-x 12 root root 4096 Jan  8 01:28 ..
 -rw-r--r--  1 root root  177 Jan  8 01:29 index.html
 ----
 
-This shows that by default there is one file in `/var/www/html/` called ``index.html``and it is owned by the `root` user (as is the enclosing folder). In order to edit the file, you need to change its ownership to your own username. Change the owner of the file (the default `pi` user is assumed here) using `sudo chown pi: index.html`.
+This shows that by default there is one file in `/var/www/html/` called `index.html` and it is owned by the `root` user (as is the enclosing folder). In order to edit the file, you need to change its ownership to your own username. Change the owner of the file (the default `pi` user is assumed here) using `sudo chown pi: index.html`.
 
 You can now try editing this file and then refreshing the browser to see the web page change. If you know HTML you can put your own HTML files and other assets in this directory and serve them as a website on your local network.
 

--- a/documentation/asciidoc/computers/using_linux/linux-root-user.adoc
+++ b/documentation/asciidoc/computers/using_linux/linux-root-user.adoc
@@ -31,7 +31,7 @@ Note that the user `bob` will be prompted to enter their password when they run 
 . Insert the following contents on a single line: `bob ALL=(ALL) NOPASSWD: ALL`
 . Save the file and exit.
 
-Once you have exited the editor, the file will be checked for any syntax errors. If no errors were detected, the file will be saved and you will be returned to the shell prompt. If errors were detected, you will be asked 'what now?' Press the 'enter' key on your keyboard: this will bring up a list of options. You will probably want to use 'e' for '(e)dit sudoers file again,' so you can edit the file and fix the problem. 
+Once you have exited the editor, the file will be checked for any syntax errors. If no errors were detected, the file will be saved and you will be returned to the shell prompt. If errors were detected, you will be asked 'what now?' Press the 'enter' key on your keyboard: this will bring up a list of options. You will probably want to use 'e' for '(e)dit sudoers file again', so you can edit the file and fix the problem.
 
 NOTE: Choosing option 'Q' will save the file with any syntax errors still in place, which makes it impossible for _any_ user to use the sudo command.
 

--- a/documentation/asciidoc/computers/using_linux/linux-using-commands.adoc
+++ b/documentation/asciidoc/computers/using_linux/linux-using-commands.adoc
@@ -26,7 +26,7 @@ To remove empty directories, use `rmdir`. So, for example, `rmdir oldDir` will r
 
 ==== rm
 
-The command ``rm``removes the specified file (or recursively from a directory when used with `-r`). Be careful with this command: files deleted in this way are mostly gone for good!
+The command `rm` removes the specified file (or recursively from a directory when used with `-r`). Be careful with this command: files deleted in this way are mostly gone for good!
 
 ==== cp
 

--- a/documentation/asciidoc/computers/using_linux/linux-using-text-editors.adoc
+++ b/documentation/asciidoc/computers/using_linux/linux-using-text-editors.adoc
@@ -1,5 +1,4 @@
 == Text Editors
-:pp: {plus}{plus}
 
 On Linux, you have a choice of text editors. Some are easy-to-use but have limited functionality; others require training to use and take a long time to master, but offer incredible functionality.
 
@@ -17,7 +16,7 @@ https://thonny.org/[Thonny] is a Python REPL and IDE, so you can write and edit 
 
 ==== Geany
 
-A fast and lightweight IDE, supporting many different file types, including C/C{pp} and Python. It is installed by default on Raspberry Pi OS.
+A fast and lightweight IDE, supporting many different file types, including C/{cpp} and Python. It is installed by default on Raspberry Pi OS.
 
 === Text Editors in the Terminal
 

--- a/documentation/asciidoc/microcontrollers/c_sdk.adoc
+++ b/documentation/asciidoc/microcontrollers/c_sdk.adoc
@@ -1,4 +1,3 @@
-
 include::c_sdk/sdk_setup.adoc[]
 
 include::c_sdk/official_sdk.adoc[]

--- a/documentation/asciidoc/microcontrollers/c_sdk/official_sdk.adoc
+++ b/documentation/asciidoc/microcontrollers/c_sdk/official_sdk.adoc
@@ -1,5 +1,4 @@
-:pp: {plus}{plus}
-== Raspberry Pi Pico C/C{pp} SDK
+== Raspberry Pi Pico C/{cpp} SDK
 
 Our official C SDK can be used from the command line, or from popular integrated development environments like Visual Studio Code, Eclipse, and CLion. To get started, download our C/C++ SDK and Examples, and take a look at our 'https://datasheets.raspberrypi.com/pico/getting-started-with-pico.pdf[getting started]' documentation to get going. Or for a quick setup see the next section.
 
@@ -7,10 +6,10 @@ Our official C SDK can be used from the command line, or from popular integrated
 
 * The Examples https://github.com/raspberrypi/pico-examples[Github repository]
 
-You can find documentation around the C/C{pp} SDK at;
+You can find documentation around the C/{cpp} SDK at;
 
 https://datasheets.raspberrypi.com/pico/getting-started-with-pico.pdf[Getting started with Raspberry Pi Pico]:: C/C++ development with Raspberry Pi Pico and other RP2040-based microcontroller boards
 
-https://datasheets.raspberrypi.com/pico/raspberry-pi-pico-c-sdk.pdf[Raspberry Pi Pico C/C{pp} SDK]:: Libraries and tools for C/C++ development on RP2040 microcontrollers
+https://datasheets.raspberrypi.com/pico/raspberry-pi-pico-c-sdk.pdf[Raspberry Pi Pico C/{cpp} SDK]:: Libraries and tools for C/C++ development on RP2040 microcontrollers
 
-The API level Doxygen documentation for the Raspberry Pi Pico C/C{pp} SDK is also available https://rptl.io/pico-doxygen[as a micro-site].
+The API level Doxygen documentation for the Raspberry Pi Pico C/{cpp} SDK is also available https://rptl.io/pico-doxygen[as a micro-site].

--- a/documentation/asciidoc/microcontrollers/c_sdk/sdk_setup.adoc
+++ b/documentation/asciidoc/microcontrollers/c_sdk/sdk_setup.adoc
@@ -1,6 +1,5 @@
-:pp: {plus}{plus}
 == SDK Setup
 
-For a full walk-through of how to get going with the C/C{pp} SDK, you should read our 'https://datasheets.raspberrypi.com/pico/getting-started-with-pico.pdf[getting started]' documentation. However, if you are intending to develop for Pico on a xref:../computers/os.adoc[Raspberry Pi], then you can set up the C/C++ toolchain quickly by running our https://raw.githubusercontent.com/raspberrypi/pico-setup/master/pico_setup.sh[setup script] from the command line.
+For a full walk-through of how to get going with the C/{cpp} SDK, you should read our 'https://datasheets.raspberrypi.com/pico/getting-started-with-pico.pdf[getting started]' documentation. However, if you are intending to develop for Pico on a xref:../computers/os.adoc[Raspberry Pi], then you can set up the C/C++ toolchain quickly by running our https://raw.githubusercontent.com/raspberrypi/pico-setup/master/pico_setup.sh[setup script] from the command line.
 
 NOTE: You should make sure the OS on your Raspberry Pi is xref:../computers/os.adoc#updating-and-upgrading-raspberry-pi-os[up to date] before running the setup script.

--- a/documentation/asciidoc/microcontrollers/c_sdk/your_first_binary.adoc
+++ b/documentation/asciidoc/microcontrollers/c_sdk/your_first_binary.adoc
@@ -1,5 +1,4 @@
 == Your First Binaries
-:pp: {plus}{plus}
 
 === Blink an LED
 
@@ -12,11 +11,11 @@ You can blink this on and off by,
 . Download the https://datasheets.raspberrypi.com/soft/blink.uf2[Blink UF2]
 . Push and hold the BOOTSEL button and plug your Pico into the USB port of your Raspberry Pi or other computer.
 . It will mount as a Mass Storage Device called RPI-RP2.
- .Drag and drop the Blink UF2 binary onto the RPI-RP2 volume.
- .Pico will reboot, and the on-board LED should start blinking.
+. Drag and drop the Blink UF2 binary onto the RPI-RP2 volume. Pico will reboot.
+
+You should see the on-board LED blinking.
 
 * Download https://datasheets.raspberrypi.com/soft/blink.uf2[UF2 File]
-
 * See the code https://github.com/raspberrypi/pico-examples/blob/master/blink/blink.c[on Github]
 
 === Say "Hello World"
@@ -28,7 +27,7 @@ image:images/Hello-World-640x360.gif[]
 . Download the https://datasheets.raspberrypi.com/soft/hello_world.uf2['Hello World' UF2].
 . Push and hold the BOOTSEL button and plug your Pico into the USB port of your Raspberry Pi or other computer.
 . It will mount as a Mass Storage Device called RPI-RP2.
-. Drag and drop the 'Hello World' UF2 binary onto the RPI-RP2 volume. Pico will reboot
+. Drag and drop the 'Hello World' UF2 binary onto the RPI-RP2 volume. Pico will reboot.
 . Open a Terminal window and type:
 +
 [source]

--- a/documentation/asciidoc/microcontrollers/microcontroller_docs.adoc
+++ b/documentation/asciidoc/microcontrollers/microcontroller_docs.adoc
@@ -1,6 +1,4 @@
-
 // Included from both rp2040.adoc and raspberry-pi-pico.adoc
-:pp: {plus}{plus}
 
 == Documentation
 
@@ -18,15 +16,15 @@ https://datasheets.raspberrypi.com/pico/pico-datasheet.pdf[Raspberry Pi Pico Dat
 
 https://datasheets.raspberrypi.com/pico/getting-started-with-pico.pdf[Getting started with Raspberry Pi Pico]:: C/C++ development with Raspberry Pi Pico and other RP2040-based microcontroller boards
 
-NOTE: While it is not officially supported there is a https://github.com/ndabas/pico-setup-windows[Pico Setup for Windows] installation tool which automates installation of the C/C{pp} SDK on Windows 10.
+NOTE: While it is not officially supported there is a https://github.com/ndabas/pico-setup-windows[Pico Setup for Windows] installation tool which automates installation of the C/{cpp} SDK on Windows 10.
 
 === Software Development
 
-https://datasheets.raspberrypi.com/pico/raspberry-pi-pico-c-sdk.pdf[Raspberry Pi Pico C/C{pp} SDK]:: Libraries and tools for C/C++ development on RP2040 microcontrollers
+https://datasheets.raspberrypi.com/pico/raspberry-pi-pico-c-sdk.pdf[Raspberry Pi Pico C/{cpp} SDK]:: Libraries and tools for C/C++ development on RP2040 microcontrollers
 
 https://datasheets.raspberrypi.com/pico/raspberry-pi-pico-python-sdk.pdf[Raspberry Pi Pico Python SDK]:: A MicroPython environment for RP2040 microcontrollers
 
-The API level Doxygen documentation for the Raspberry Pi Pico C/C{pp} SDK is also available https://rptl.io/pico-doxygen[as a micro-site].
+The API level Doxygen documentation for the Raspberry Pi Pico C/{cpp} SDK is also available https://rptl.io/pico-doxygen[as a micro-site].
 
 [NOTE]
 ======

--- a/documentation/asciidoc/microcontrollers/micropython.adoc
+++ b/documentation/asciidoc/microcontrollers/micropython.adoc
@@ -1,4 +1,3 @@
-
 include::micropython/what-is-micropython.adoc[]
 
 include::micropython/drag-and-drop.adoc[]

--- a/documentation/asciidoc/microcontrollers/raspberry-pi-pico.adoc
+++ b/documentation/asciidoc/microcontrollers/raspberry-pi-pico.adoc
@@ -1,4 +1,3 @@
-
 include::raspberry-pi-pico/about_pico.adoc[]
 
 include::microcontroller_docs.adoc[]

--- a/documentation/asciidoc/microcontrollers/raspberry-pi-pico/about_pico.adoc
+++ b/documentation/asciidoc/microcontrollers/raspberry-pi-pico/about_pico.adoc
@@ -1,6 +1,4 @@
-
 == Technical Specification
-:pp: {plus}{plus}
 
 Raspberry Pi Pico is a low-cost, high-performance microcontroller board with flexible digital interfaces. Key features include:
 

--- a/documentation/asciidoc/microcontrollers/raspberry-pi-pico/utilities.adoc
+++ b/documentation/asciidoc/microcontrollers/raspberry-pi-pico/utilities.adoc
@@ -1,9 +1,8 @@
 == Software Utilities
-:pp: {plus}{plus}
 
 === What is on your Pico?
 
-If you have forgotten what has been programmed into your Raspberry Pi Pico, and the program was built using our Pico C/C{pp} SDK, it will usually have a name and other useful information embedded into the binary. You can use the https://github.com/raspberrypi/picotool[Picotool] command line utility to find out these details. Full instructions on how to use Picotool to do this are available in our 'https://datasheets.raspberrypi.com/pico/getting-started-with-pico.pdf[getting started]' documentation.
+If you have forgotten what has been programmed into your Raspberry Pi Pico, and the program was built using our Pico C/{cpp} SDK, it will usually have a name and other useful information embedded into the binary. You can use the https://github.com/raspberrypi/picotool[Picotool] command line utility to find out these details. Full instructions on how to use Picotool to do this are available in our 'https://datasheets.raspberrypi.com/pico/getting-started-with-pico.pdf[getting started]' documentation.
 
 * Go to the https://github.com/raspberrypi/picotool[Picotool Github repository].
 

--- a/documentation/asciidoc/microcontrollers/rp2040.adoc
+++ b/documentation/asciidoc/microcontrollers/rp2040.adoc
@@ -1,4 +1,3 @@
-
 include::rp2040/about_rp2040.adoc[]
 
 include::rp2040/technical_specification.adoc[]


### PR DESCRIPTION
 * Use the {cpp} macro consistently https://docs.asciidoctor.org/asciidoc/latest/attributes/character-replacement-ref/
 * Get rid of the redundant :pp: definitions
 * Get rid of leading blank lines
 * Add missing spaces in a few places
 * Fix bullet-points in the Pico "Blink an LED" example
 * Change [,shell] and [,console] to [,bash] for consistency