### PR TITLE
Update secure-shell-passwordless.adoc

### DIFF
--- a/documentation/asciidoc/computers/remote-access/secure-shell-passwordless.adoc
+++ b/documentation/asciidoc/computers/remote-access/secure-shell-passwordless.adoc
@@ -120,5 +120,5 @@ Run the following command to store it in your keychain:
 
 [,bash]
 ----
-ssh-add -K ~/.ssh/id_rsa
+ssh-add --apple-use-keychain ~/.ssh/id_rsa
 ----

--- a/documentation/asciidoc/computers/remote-access/secure-shell-passwordless.adoc
+++ b/documentation/asciidoc/computers/remote-access/secure-shell-passwordless.adoc
@@ -120,5 +120,10 @@ Run the following command to store it in your keychain:
 
 [,bash]
 ----
-ssh-add --apple-use-keychain ~/.ssh/id_rsa
+ssh-add -K ~/.ssh/id_rsa
 ----
+
+[NOTE]
+====
+From macOS Monterey onwards the `-K` has been deprecated and have been replaced by the `--apple-use-keychain` flag.
+====


### PR DESCRIPTION
On macOS Monterey 12.0.1 I got this warning and updated the last command in the file:

WARNING: The -K and -A flags are deprecated and have been replaced
         by the --apple-use-keychain and --apple-load-keychain
         flags, respectively.  To suppress this warning, set the
         environment variable APPLE_SSH_ADD_BEHAVIOR as described in
         the ssh-add(1) manual page.