### PR TITLE
Rename Raspberry Pi (Trading) Ltd

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,4 +124,4 @@ which will delete the `build/` and `documentation/html/` directories.
 
 ## Licence
 
-The Raspberry Pi [documentation](./documentation/) is [licensed](https://github.com/raspberrypi/documentation/blob/develop/LICENSE.md) under a Creative Commons Attribution-ShareAlike 4.0 International (CC BY-SA). While the toolchain source code — which is everything outside of the top-level `documentation/` subdirectory — is Copyright © 2021 Raspberry Pi (Trading) Ltd. and licensed under the [BSD 3-Clause](https://opensource.org/licenses/BSD-3-Clause) licence.
+The Raspberry Pi [documentation](./documentation/) is [licensed](https://github.com/raspberrypi/documentation/blob/develop/LICENSE.md) under a Creative Commons Attribution-ShareAlike 4.0 International (CC BY-SA). While the toolchain source code — which is everything outside of the top-level `documentation/` subdirectory — is Copyright © 2021 Raspberry Pi Ltd and licensed under the [BSD 3-Clause](https://opensource.org/licenses/BSD-3-Clause) licence.

--- a/jekyll-assets/_includes/copyright.html
+++ b/jekyll-assets/_includes/copyright.html
@@ -1,6 +1,6 @@
 <div class="legal">
   <div class="legal-inner">
-    <p id="copyright">Raspberry Pi documentation is copyright &copy; 2012-{{ site.time | date: '%Y' }} Raspberry Pi (Trading) Ltd and is licensed under a <a href="https://creativecommons.org/licenses/by-sa/4.0/">Creative Commons Attribution-ShareAlike 4.0 International</a> (CC BY-SA) licence.</p>
+    <p id="copyright">Raspberry Pi documentation is copyright &copy; 2012-{{ site.time | date: '%Y' }} Raspberry Pi Ltd and is licensed under a <a href="https://creativecommons.org/licenses/by-sa/4.0/">Creative Commons Attribution-ShareAlike 4.0 International</a> (CC BY-SA) licence.</p>
     <p id="copyright">Some content originates from the <a href="http://elinux.org/">eLinux wiki</a>, and is licensed under a <a href="http://creativecommons.org/licenses/by-sa/3.0/">Creative Commons Attribution-ShareAlike 3.0 Unported</a> licence.</p>
   </div>
 </div>


### PR DESCRIPTION
As Raspberry Pi (Trading) Ltd is now Raspberry Pi Ltd, update any references to the old name.

See https://find-and-update.company-information.service.gov.uk/company/08207441
