### PR TITLE
Fix typo in "Attaching a Raspberry Pi Camera Module"

### DIFF
--- a/documentation/asciidoc/computers/compute-module/cmio-camera.adoc
+++ b/documentation/asciidoc/computers/compute-module/cmio-camera.adoc
@@ -17,7 +17,7 @@ The camera software is under constant development. Please ensure your system is 
 
 ----
 sudo apt update
-sudp apt full-upgrade
+sudo apt full-upgrade
 ----
 
 === Crypto Chip


### PR DESCRIPTION
In "Updating your System" section
fix  "sudp apt full-upgrade" to "sudo apt full-upgrade"