### PR TITLE
Update camera_auto_detect usage in the camera documentation.

### DIFF
--- a/documentation/asciidoc/accessories/camera/libcamera_apps_getting_started.adoc
+++ b/documentation/asciidoc/accessories/camera/libcamera_apps_getting_started.adoc
@@ -57,6 +57,6 @@ To override the automatic camera detection, _Bullseye_ users will also need to d
 
 `camera_auto_detect=1`
 
-if present.
+if present in the `config.txt` file. If you need to do edit this file then your Raspberry Pi will need to be rebooted. 
 
-If you need to edit this file then the Pi will need to be rebooted.
+NOTE: Setting `camera_auto_detect=0` disables the boot time detection completely. 

--- a/documentation/asciidoc/accessories/camera/libcamera_apps_getting_started.adoc
+++ b/documentation/asciidoc/accessories/camera/libcamera_apps_getting_started.adoc
@@ -57,6 +57,6 @@ To override the automatic camera detection, _Bullseye_ users will also need to d
 
 `camera_auto_detect=1`
 
-if present (or change the `1` to `0`).
+if present.
 
 If you need to edit this file then the Pi will need to be rebooted.


### PR DESCRIPTION
To manually override the automatic overlay detection, we must delete the
camera_auto_detect parameter from config.txt.