### PR TITLE
Remove dependency on legacy stylesheet

### DIFF
--- a/jekyll-assets/_includes/head.html
+++ b/jekyll-assets/_includes/head.html
@@ -11,12 +11,11 @@
 <meta name="twitter:site" content="@Raspberry_Pi">
 <meta name="twitter:title" content="{{ page.title }}">
 <meta name="twitter:description" content="The official documentation for Raspberry Pi computers and microcontrollers">
+<link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com">
-<link rel="preconnect stylesheet" href="https://fonts.googleapis.com/css?family=Rubik:300,500,700|Space+Mono" media="all" type="text/css" crossorigin />
 <link href="https://fonts.googleapis.com/css2?family=Roboto:ital,wght@0,100;0,300;0,400;0,700;1,100;1,300;1,400;1,700&display=swap" rel="stylesheet">
-<link rel="stylesheet" href="https://www.raspberrypi.com/app/themes/mind-control/css/legacy.min.css?ver=1605195698">
-<link rel="stylesheet" href="{{ site.baseurl }}/css/style.css">
-<link rel="stylesheet" href="{{ site.baseurl }}/css/tabs.css">
+<link rel="stylesheet" href="{{ site.baseurl }}/css/style.css?ver=1639579464">
+<link rel="stylesheet" href="{{ site.baseurl }}/css/tabs.css?ver=1639579464">
 <script async src="https://www.googletagmanager.com/gtag/js?id=UA-180927933-8"></script>
 <script>
   window.dataLayer = window.dataLayer || [];

--- a/jekyll-assets/css/style.css
+++ b/jekyll-assets/css/style.css
@@ -40,6 +40,15 @@ body {
   background-color: #f6f6f6;
 }
 
+a {
+  color: var(--pink);
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .toptitle {
   color: #fff;
   text-align: center;
@@ -180,6 +189,7 @@ nav#contents h3,
 nav#mobile-contents h3 {
   font-weight: bold;
   font-size: 0.85em;
+  line-height: 1.5rem;
   color: #343434;
   cursor: pointer;
 }


### PR DESCRIPTION
The site currently loads a legacy stylesheet from the raspberrypi.com WordPress theme because it was previously required to render the shared site footer correctly. Since we switched to an entirely self-contained footer with the launch of raspberrypi.com, there's no need to depend on this stylesheet.

Remove it along with an unused web font from Google Fonts (again, previously required by the old site footer) and add in any styles we were implicitly inheriting from the old stylesheet, namely:

1. Links should be Raspberry Red and only have an underline on hover
2. Subheadings in the table of contents should have a line height of 24px (1.5 times the base font size of 16px)

We add a timestamp when loading our stylesheets to bust any existing browser caches otherwise anyone with cached versions of these styles will not see the aforementioned updated styles.
