### PR TITLE
Update Raspberry Pi Red

### DIFF
--- a/jekyll-assets/_includes/head.html
+++ b/jekyll-assets/_includes/head.html
@@ -14,8 +14,8 @@
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com">
 <link href="https://fonts.googleapis.com/css2?family=Roboto:ital,wght@0,100;0,300;0,400;0,700;1,100;1,300;1,400;1,700&display=swap" rel="stylesheet">
-<link rel="stylesheet" href="{{ site.baseurl }}/css/style.css?ver=1639579464">
-<link rel="stylesheet" href="{{ site.baseurl }}/css/tabs.css?ver=1639579464">
+<link rel="stylesheet" href="{{ site.baseurl }}/css/style.css?ver=1639581228">
+<link rel="stylesheet" href="{{ site.baseurl }}/css/tabs.css?ver=1639581228">
 <script async src="https://www.googletagmanager.com/gtag/js?id=UA-180927933-8"></script>
 <script>
   window.dataLayer = window.dataLayer || [];

--- a/jekyll-assets/css/style.css
+++ b/jekyll-assets/css/style.css
@@ -1,5 +1,5 @@
 :root {
-  --pink: #c51d4a;
+  --red: #cd2355;
 }
 
 /* overrides for the old theme */
@@ -41,7 +41,7 @@ body {
 }
 
 a {
-  color: var(--pink);
+  color: var(--red);
   text-decoration: none;
 }
 
@@ -115,7 +115,7 @@ ul#results-container {
   margin-left: auto;
   margin-right: auto;
   border: 1px solid #343434;
-  color: var(--pink);
+  color: var(--red);
   font-size: 12px;
   padding: 10px 10px 10px 30px;
 }
@@ -134,7 +134,7 @@ ul#results-container li:last-of-type {
 
 ul#results-container li,
 ul#results-container li::marker {
-  color: var(--pink);
+  color: var(--red);
 }
 
 #container {
@@ -261,7 +261,7 @@ ul#tocify-header1 > ul.tocify-subheader {
 #content h1 {
   font-weight: 700;
   font-size: 34px;
-  color: var(--pink);
+  color: var(--red);
   margin-bottom: 40px;
   position: relative;
   margin-left: -1rem;
@@ -346,7 +346,7 @@ h3:hover .anchor,
 h4:hover .anchor, 
 h5:hover .anchor, 
 h6:hover .anchor {
-  color: var(--pink);
+  color: var(--red);
   visibility: visible;
 }
 
@@ -522,12 +522,12 @@ div.admonitionblock tr {
 }
 
 div.admonitionblock td div.title {
-  color: var(--pink);
+  color: var(--red);
   text-transform: uppercase;
 }
 
 div.admonitionblock td.content {
-  border: 2px solid var(--pink);
+  border: 2px solid var(--red);
   padding: 10px;
   margin-top: 10px;
   width: 100%;

--- a/jekyll-assets/css/tabs.css
+++ b/jekyll-assets/css/tabs.css
@@ -26,7 +26,7 @@ ul#tab-container li {
 }
 
 ul#tab-container li.selected {
-  border-bottom-color: #c61931;
+  border-bottom-color: var(--red);
 }
 
 ul#tab-container li a {


### PR DESCRIPTION
The brand red is being slightly tweaked to match an existing Pantone (to make it easier to match for product packaging) so update the documentation site for consistency:

* Red goes from #c51d4a to #cd2355 (Pantone 7636C)
