### PR TITLE
Navigate to parent directory before pip install

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ $ bundle install
 ```
 (which may take several minutes), followed by,
 ```
+$ cd ..
 $ pip3 install --user -r requirements.txt
 ```
 


### PR DESCRIPTION
Guide instructed users to navigate to the `documentation` folder, but forgot to have users `cd` to the parent folder before instructing pip to install `requirements.txt`.