### PR TITLE
Simple Medium Linear Motor has an updated revision

### DIFF
--- a/documentation/asciidoc/accessories/build-hat/compat.adoc
+++ b/documentation/asciidoc/accessories/build-hat/compat.adoc
@@ -21,7 +21,7 @@ SPIKE Prime Expansion Set | 45678, 45680 | Motor | Active | 30
 
 | Distance Sensor | White/Black	| 6302968 | Yes | Yes | | https://www.bricklink.com/v2/catalog/catalogitem.page?P=37316c01&idColor=11#T=C&C=11[Link] | SPIKE Prime Set, Mindstorms Robot Inventor | 45678, 51515  |DistanceSensor | Active | 3E
 
-| System medium motor | White/Grey | 6138854 | Yes | Yes | | | Wedo 2.0, LEGO Ideas Piano, App controlled Batmobile | 76112 | | Passive | 1
+| System medium motor | White/Grey | 45303,6138854,6290182 | Yes | Yes | | | Wedo 2.0, LEGO Ideas Piano, App controlled Batmobile | 76112 | | Passive | 1
 
 | Force Sensor | White/Black | 6254354 | Yes | Yes | 45606 | https://www.bricklink.com/v2/catalog/catalogitem.page?P=37312c01&idColor=11#T=C&C=11[Link] | SPIKE Prime Set | 45678 | ForceSensor | Active | 3F
 


### PR DESCRIPTION
"System medium motor" 6138854 is listed as being in "App controlled batmobile" (Set 76112), but when searching for replacement pieces on Lego Bricks & Pieces (B&P), set 76112 lis listed as containing "LPF2.0 MEDIUM MOTOR" Element 6290182, Design ID 21980.

The PDF instructions for set 76112 list the part as 6215354.

Searches for 6138854 on lego.com point to set 45303 "Simple Medium Linear Motor."  Looking up the parts for set 45303 in B&P returns element 6290182.  B&P lists set 21323 (Grand Piano) as containing 6290182 and the PDF instructions list the part as 6290182.

The PDF instructions for 42129 "Zetros Trial Truck" list it as containing 6290182 and is from 2021.
The Grand Piano is from 2020.
The Batmobile is from 2018.

Based on this it seems that the element 6138854 has been replaced with 6290182, also known as set 45303: "Simple Medium Linear Motor."