### PR TITLE
Check that all internal links and anchors are valid. Fixes #2332

### DIFF
--- a/documentation/asciidoc/accessories/build-hat/preparing-build-hat.adoc
+++ b/documentation/asciidoc/accessories/build-hat/preparing-build-hat.adoc
@@ -1,6 +1,6 @@
 == Preparing your Build HAT
 
-NOTE: Before starting to work with your Raspberry Pi Build HAT you should xref:../computers/getting-started.adoc#setting-up-your-raspberry-pi[set up] your Raspberry Pi, xref:../computers/getting-started.html#installing-the-operating-system[install] the latest version of the operating system using https://www.raspberrypi.com/downloads/[Raspberry Pi Imager].
+NOTE: Before starting to work with your Raspberry Pi Build HAT you should xref:../computers/getting-started.adoc#setting-up-your-raspberry-pi[set up] your Raspberry Pi, xref:../computers/getting-started.adoc#installing-the-operating-system[install] the latest version of the operating system using https://www.raspberrypi.com/downloads/[Raspberry Pi Imager].
 
 Attach 9mm spacers to the bottom of the board. Seat the Raspberry Pi Build HAT onto your Raspberry Pi. Make sure you put it on the right way up. Unlike other HATs, all the components are on the bottom, leaving room for a breadboard or LEGO® elements on top.  
 

--- a/documentation/asciidoc/accessories/camera/camera_usage.adoc
+++ b/documentation/asciidoc/accessories/camera/camera_usage.adoc
@@ -32,7 +32,7 @@ Reasons to consider staying with an older OS and using the legacy _Raspicam_ sta
 * It may perform better on Raspberry Pi 2 and Raspberry Pi Zero devices, as it offloads more to the GPU and is less dependent on the ARM cores.
 * `libcamera` is still missing certain features, most notably Python bindings. Whilst this work is in progress, users who need a Python interface (such as _Picamera_) will have to stay with the legacy stack for the time being.
 
-Apart from some general information on setting up the camera, most of this documentation is divided into sections on xref:camera.adoc#libcamera-and-libcamera-apps[libcamera and the libcamera-apps], and the xref:camera.adoc#raspicam-commands[legacy _Raspicam_ apps]. Once you've xref:camera.adoc#installing-a-raspberrypi-pi-camera[installed your camera module], please click on one of these two links.
+Apart from some general information on setting up the camera, most of this documentation is divided into sections on xref:camera.adoc#libcamera-and-libcamera-apps[libcamera and the libcamera-apps], and the xref:camera.adoc#raspicam-commands[legacy _Raspicam_ apps]. Once you've xref:camera.adoc#installing-a-raspberry-pi-camera[installed your camera module], please click on one of these two links.
 
 video::E7KPSc_Xr24[youtube]
 

--- a/documentation/asciidoc/accessories/camera/libcamera_detect.adoc
+++ b/documentation/asciidoc/accessories/camera/libcamera_detect.adoc
@@ -14,7 +14,7 @@ Detect objects with the given `<name>`. The name should be taken from the model'
 
 Wait at least this many frames after a capture before performing another. This is necessary because the neural network does not run on every frame, so it is best to give it a few frames to run again before considering another capture.
 
-Please refer to the xref:camera.adoc#object-detect-tf-stage[TensorFlow Lite object detector] section for more general information on how to obtain and use this model. But as an example, you might spy secretly on your cats while you are away with:
+Please refer to the xref:camera.adoc#object_detect_tf-stage[TensorFlow Lite object detector] section for more general information on how to obtain and use this model. But as an example, you might spy secretly on your cats while you are away with:
 
 [,bash]
 ----

--- a/documentation/asciidoc/computers/config_txt/common.adoc
+++ b/documentation/asciidoc/computers/config_txt/common.adoc
@@ -36,13 +36,13 @@ The `dtoverlay` option requests the firmware to load a named Device Tree overlay
 
 As a special case, if called with no value - `dtoverlay=` - it marks the end of a list of overlay parameters. If used before any other `dtoverlay` or `dtparam` setting it prevents the loading of any HAT overlay.
 
-For more details, see xref:configuration.html#part3.1[DTBs, overlays and config.txt].
+For more details, see xref:configuration.adoc#part3.1[DTBs, overlays and config.txt].
 
 ==== `dtparam`
 
 Device Tree configuration files for Raspberry Pis support a number of parameters for such things as enabling I2C and SPI interfaces. Many DT overlays are configurable via the use of parameters. Both types of parameters can be supplied using the `dtparam` setting. In addition, overlay parameters can be appended to the `dtoverlay` option, separated by commas, but beware the line length limit - previously 78 characters, now 98 characters.
 
-For more details, see xref:configuration.html#part3.1[DTBs, overlays and config.txt].
+For more details, see xref:configuration.adoc#part3.1[DTBs, overlays and config.txt].
 
 ==== `arm_boost` (Raspberry Pi 4 Only)
 

--- a/documentation/asciidoc/computers/configuration/headless.adoc
+++ b/documentation/asciidoc/computers/configuration/headless.adoc
@@ -53,4 +53,4 @@ network={
 
 NOTE: Some older Raspberry Pi boards and some USB wireless dongles do not support 5GHz networks.
 
-NOTE: With no keyboard or monitor, you will need some way of xref:remote-access.adoc#remote-access[remotely accessing] your headless Raspberry Pi. For headless setup, SSH can be enabled by placing a file named `ssh`, without any extension, onto the boot folder of the SD Card. For more information see the section on xref:remote-access.adoc#ssh[setting up an SSH server].
+NOTE: With no keyboard or monitor, you will need some way of xref:remote-access.adoc[remotely accessing] your headless Raspberry Pi. For headless setup, SSH can be enabled by placing a file named `ssh`, without any extension, onto the boot folder of the SD Card. For more information see the section on xref:remote-access.adoc#ssh[setting up an SSH server].

--- a/documentation/asciidoc/computers/raspberry-pi/bcm2711-bootloader.adoc
+++ b/documentation/asciidoc/computers/raspberry-pi/bcm2711-bootloader.adoc
@@ -414,7 +414,7 @@ The primary purpose of `boot_ramdisk` is to support `secure-boot`, however, unsi
 * The maximum size for a ramdisk file is 96MB.
 * `boot.img` files are raw disk `.img` files. The recommended format is a plain FAT32 partition with no MBR.
 * The memory for the ramdisk filesystem is released before the operating system is started.
-* If xref:raspberrypi.adoc#fail-safe-os-updates-tryboot[TRYBOOT] is selected then the bootloader will search for `tryboot.img` instead of `boot.img`.
+* If xref:raspberry-pi.adoc#fail-safe-os-updates-tryboot[TRYBOOT] is selected then the bootloader will search for `tryboot.img` instead of `boot.img`.
 
 For more information about `secure-boot` and creating `boot.img` files please see the https://github.com/raspberrypi/usbboot/blob/master/Readme.md[USBBOOT Readme]
 

--- a/documentation/asciidoc/computers/remote-access/secure-shell.adoc
+++ b/documentation/asciidoc/computers/remote-access/secure-shell.adoc
@@ -20,7 +20,7 @@ Raspberry Pi OS has the SSH server disabled by default. It can be enabled manual
 . Select `Enabled` next to `SSH`
 . Click `OK`
 
-Alternatively you can enable it from the terminal using the xref:configuration.adoc#the-raspi-config-tool[raspi-config] application,
+Alternatively you can enable it from the terminal using the xref:configuration.adoc#raspi-config[raspi-config] application,
 
 . Enter `sudo raspi-config` in a terminal window
 . Select `Interfacing Options`

--- a/documentation/asciidoc/computers/remote-access/vnc.adoc
+++ b/documentation/asciidoc/computers/remote-access/vnc.adoc
@@ -38,7 +38,7 @@ You can do this graphically or at the command line.
 
 ==== Enabling VNC Server at the command line
 
-You can enable VNC Server at the command line using xref:configuration.adoc#the-raspi-config-tool[raspi-config]:
+You can enable VNC Server at the command line using xref:configuration.adoc#raspi-config[raspi-config]:
 
 [,bash]
 ----


### PR DESCRIPTION
WRT the "slipping through the net" - some of these were genuine typos, and some were because in the old MarkDown version of the documentation, each H1 (top heading on the page) was a valid anchor, whereas now only H2 and below are valid anchors.

The link-checking is done as part of the "build nav-menu" script, which means any future link-typos will cause the build to fail, and be caught by the CI.