### PR TITLE
accessories/camera : correct words

### DIFF
--- a/documentation/asciidoc/accessories/camera/libcamera_options_common.adoc
+++ b/documentation/asciidoc/accessories/camera/libcamera_options_common.adoc
@@ -215,7 +215,7 @@ This option is identical to the `--mode` option except that it applies only duri
 	--lores-height			Low resolution image height <height>
 ----
 
-`libcamera` allows the possibility of delivering a second lower resolution image stream from the the camera system to the application. This stream is available in both the preview and the video modes (i.e. `libcamera-hello` and the preview phase of `libcamera-still`, and `libcamera-vid`), and can be used, among other things, for image analysis. For stills captures, the low resolution image stream is not available.
+`libcamera` allows the possibility of delivering a second lower resolution image stream from the camera system to the application. This stream is available in both the preview and the video modes (i.e. `libcamera-hello` and the preview phase of `libcamera-still`, and `libcamera-vid`), and can be used, among other things, for image analysis. For stills captures, the low resolution image stream is not available.
 
 The low resolution stream has the same field of view as the other image streams. If a different aspect ratio is specified for the low resolution stream, then those images will be squashed so that the pixels are no longer square.
 

--- a/documentation/asciidoc/accessories/camera/libcamera_options_common.adoc
+++ b/documentation/asciidoc/accessories/camera/libcamera_options_common.adoc
@@ -215,7 +215,7 @@ This option is identical to the `--mode` option except that it applies only duri
 	--lores-height			Low resolution image height <height>
 ----
 
-`libcamera` allows the possibiliy of delivering a second lower resolution image stream from the the camera system to the application. This stream is available in both the preview and the video modes (i.e. `libcamera-hello` and the preview phase of `libcamera-still`, and `libcamera-vid`), and can be used, among other things, for image analysis. For stills captures, the low resolution image stream is not available.
+`libcamera` allows the possibility of delivering a second lower resolution image stream from the the camera system to the application. This stream is available in both the preview and the video modes (i.e. `libcamera-hello` and the preview phase of `libcamera-still`, and `libcamera-vid`), and can be used, among other things, for image analysis. For stills captures, the low resolution image stream is not available.
 
 The low resolution stream has the same field of view as the other image streams. If a different aspect ratio is specified for the low resolution stream, then those images will be squashed so that the pixels are no longer square.
 

--- a/documentation/asciidoc/accessories/camera/libcamera_options_still.adoc
+++ b/documentation/asciidoc/accessories/camera/libcamera_options_still.adoc
@@ -48,7 +48,7 @@ Example: `libcamera-still --datetime`
 	--timestamp			Use system timestamps for the output file names
 ----
 
-Uses the current system timestamp (the number of seconds since the start of 1970) as the the output file name. (`libcamera-still` only.)
+Uses the current system timestamp (the number of seconds since the start of 1970) as the output file name. (`libcamera-still` only.)
 
 Example: `libcamera-still --timestamp`
 


### PR DESCRIPTION
`the the` -> `the`
`possibiliy` -> `possibility`