### PR TITLE
computers/raspberry-pi/bcm2711-bootloader.adoc, computers/os/graphics-utilities.adoc : catch small typo

### DIFF
--- a/documentation/asciidoc/computers/os/graphics-utilities.adoc
+++ b/documentation/asciidoc/computers/os/graphics-utilities.adoc
@@ -289,7 +289,7 @@ To determine if a specific display ID is on or off, use -1 as the first paramete
 
 === vcdbg
 
-`vcdbg` is an application to help with debugging the VideoCore GPU from Linux running on the the ARM. It needs to be run as root. This application is mostly of use to Raspberry Pi engineers, although there are some commands that general users may find useful.
+`vcdbg` is an application to help with debugging the VideoCore GPU from Linux running on the ARM. It needs to be run as root. This application is mostly of use to Raspberry Pi engineers, although there are some commands that general users may find useful.
 
 `sudo vcdbg help` will give a list of available commands.
 

--- a/documentation/asciidoc/computers/raspberry-pi/bcm2711-bootloader.adoc
+++ b/documentation/asciidoc/computers/raspberry-pi/bcm2711-bootloader.adoc
@@ -207,7 +207,7 @@ In earlier releases the client GUID (Option97) was just the serial number repeat
 the concatenation of the fourcc for RPi4 (0x34695052 - little endian), the board revision (e.g. 0x00c03111) (4-bytes), the least significant 4 bytes of the mac address and the 4-byte serial number.
 This is intended to be unique but also provide structured information to the DHCP server, allowing Raspberry Pi4 computers to be identified without relying upon the Ethernet MAC OUID.
 
-Specify DHCP_OPTION97=0 to revert the the old behaviour or a non-zero hex-value to specify a custom 4-byte prefix.
+Specify DHCP_OPTION97=0 to revert the old behaviour or a non-zero hex-value to specify a custom 4-byte prefix.
 
 Default: `0x34695052`
 

--- a/documentation/asciidoc/computers/raspberry-pi/bcm2711-bootloader.adoc
+++ b/documentation/asciidoc/computers/raspberry-pi/bcm2711-bootloader.adoc
@@ -232,7 +232,7 @@ Default: ""
 [[GATEWAY]]
 ===== GATEWAY
 
-The gateway address to use if the TFTP server is on a differenet subnet e.g. `192.168.0.1`
+The gateway address to use if the TFTP server is on a different subnet e.g. `192.168.0.1`
 
 Default: ""
 


### PR DESCRIPTION
the the -> the
differenet -> different