### PR TITLE
Add Thin clients to the site footer

### DIFF
--- a/jekyll-assets/_includes/footer.html
+++ b/jekyll-assets/_includes/footer.html
@@ -151,11 +151,12 @@
         </ul>
       </div>
       <div class="__rptl-footer-column">
-        <div class="__rptl-footer-heading">For Industry</div>
+        <div class="__rptl-footer-heading">For industry</div>
         <ul class="__rptl-footer-list">
-          <li class="__rptl-footer-item"><a href="/for-industry/" class="__rptl-footer-link">Raspberry Pi For Industry</a></li>
+          <li class="__rptl-footer-item"><a href="/for-industry/" class="__rptl-footer-link">Raspberry Pi for industry</a></li>
+          <li class="__rptl-footer-item"><a href="/for-industry/thin-clients/" class="__rptl-footer-link">Thin clients</a></li>
           <li class="__rptl-footer-item"><a href="/for-industry/integrator-programme/" class="__rptl-footer-link">Powered by Raspberry Pi</a></li>
-          <li class="__rptl-footer-item"><a href="/for-industry/design-partners/" class="__rptl-footer-link">Design Partners</a></li>
+          <li class="__rptl-footer-item"><a href="/for-industry/design-partners/" class="__rptl-footer-link">Design partners</a></li>
         </ul>
         <div class="__rptl-footer-heading">Hardware</div>
         <ul class="__rptl-footer-list">


### PR DESCRIPTION
While updating the "For industry" section of the footer with a new page, use sentence case more consistently.
