### PR TITLE
Override DocSearch colours with Raspberry Pi brand

### DIFF
--- a/jekyll-assets/_includes/head.html
+++ b/jekyll-assets/_includes/head.html
@@ -14,10 +14,10 @@
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com">
 <link href="https://fonts.googleapis.com/css2?family=Roboto:ital,wght@0,100;0,300;0,400;0,700;1,100;1,300;1,400;1,700&display=swap" rel="stylesheet">
-<link rel="stylesheet" href="{{ site.baseurl }}/css/style.css?ver=1639581228">
-<link rel="stylesheet" href="{{ site.baseurl }}/css/tabs.css?ver=1639581228">
 <link rel="preconnect" href="https://IHWGNTJ1NP-dsn.algolia.net" crossorigin>
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@docsearch/css@alpha"/>
+<link rel="stylesheet" href="{{ site.baseurl }}/css/style.css?ver=1643709895">
+<link rel="stylesheet" href="{{ site.baseurl }}/css/tabs.css?ver=1639581228">
 <script async src="https://www.googletagmanager.com/gtag/js?id=UA-180927933-8"></script>
 <script>
   window.dataLayer = window.dataLayer || [];

--- a/jekyll-assets/css/style.css
+++ b/jekyll-assets/css/style.css
@@ -1,5 +1,8 @@
 :root {
   --red: #cd2355;
+  --red-tint: #d75a64;
+  --docsearch-primary-color: var(--red);
+  --docsearch-logo-color: var(--red-tint);
 }
 
 /* overrides for the old theme */


### PR DESCRIPTION
To make sure the Algolia DocSearch widget matches our brand colours, update it to use Raspberry Red as its primary colour and use our red tint for the Algolia logo.
