### PR TITLE
Update references to rpi-update to official location

### DIFF
--- a/documentation/asciidoc/computers/os/updating.adoc
+++ b/documentation/asciidoc/computers/os/updating.adoc
@@ -6,7 +6,7 @@ The second reason, related to the first, is that the software you are running on
 
 === Using APT
 
-The easiest way to manage installing, upgrading, and removing software is using APT (Advanced Packaging Tool) from Debian. To update software in Raspberry Pi OS, you can use the `apt` tool from a Terminal window. 
+The easiest way to manage installing, upgrading, and removing software is using APT (Advanced Packaging Tool) from Debian. To update software in Raspberry Pi OS, you can use the `apt` tool from a Terminal window.
 
 ==== Keeping your Operating System up to Date
 
@@ -120,13 +120,13 @@ sudo apt purge tree
 
 WARNING: Pre-release versions of software are not guaranteed to work. You should not use `rpi-update` on any system unless recommended to do so by a Raspberry Pi engineer. It may leave your system unreliable or even completely broken. It should not be used as part of any regular update process.
 
-The `rpi-update` script is supplied by a third party, "Hexxeh", and also supported by Raspberry Pi engineers. The script source can be found on GitHub at https://github.com/Hexxeh/rpi-update
+The `rpi-update` script was originally written by https://github.com/Hexxeh[Hexxeh], but is now supported by Raspberry Pi engineers. The script source is in the https://github.com/raspberrypi/rpi-update[rpi-update repository].
 
 ==== What it does
 
 `rpi-update` will download the latest pre-release version of the linux kernel, its matching modules, device tree files, along with the latest versions of the VideoCore firmware. It will then install these files to relevant locations on the SD card, overwriting any previous versions.
 
-All the source data used by `rpi-update` comes from the GitHub repo https://github.com/Hexxeh/rpi-firmware. This repository simply  contains a subset of the data from the https://github.com/raspberrypi/firmware[official firmware repository], as not all the data from that repo is required.
+All the source data used by `rpi-update` comes from the https://github.com/raspberrypi/rpi-firmware[rpi-firmware repository]. This repository simply  contains a subset of the data from the https://github.com/raspberrypi/firmware[official firmware repository], as not all the data from that repo is required.
 
 ==== Running `rpi-update`
 
@@ -139,7 +139,7 @@ sudo rpi-update
 sudo reboot
 ----
 
-It has a number of options, which are documented at the Hexxeh GitHub repository at https://github.com/Hexxeh/rpi-update
+It has a number of options documented in the https://github.com/raspberrypi/rpi-update[rpi-update repository].
 
 ==== How to get back to safety
 


### PR DESCRIPTION
`rpi-update` moved to a [repository under the official Raspberry Pi GitHub organization](https://github.com/raspberrypi/rpi-update). I don't know the context, I just noticed it when following the link in the documentation.

Related PR: https://github.com/Hexxeh/rpi-update/pull/321

CC: @Hexxeh - I put an attribution to you, if it seems proper.