### PR TITLE
Add codespell

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,0 +1,6 @@
+[codespell]
+skip = Gemfile,Gemfile.lock,jekyll-assets,build
+# For a list of available built-in dictionaries, see:
+#  https://github.com/codespell-project/codespell/tree/master/codespell_lib/data
+builtin = clear,rare,informal
+ignore-words-list = technic,ba,hist

--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -1,0 +1,21 @@
+---
+name: Check for common misspellings
+
+on:
+  push:
+  pull_request:
+    branches: [develop]
+
+jobs:
+  codespell:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Check spelling with codespell
+        # Configuration should be handled in .codespellrc as much as possible so
+        # that it runs similarly locally
+        uses: codespell-project/actions-codespell@master
+        with:
+          # Annotate the build, but don't fail it
+          only_warn: 1


### PR DESCRIPTION
This PR adds code spell in a mode where it will annotate what it thinks are
typos on the PR (but not fail the build). It's configured with very conservative
options that I believe should result in a low number of false positives. 

The typo fixes have been split into #2426 by request

This was discussed in #2047 - there was general opposition to the idea _in
principle_. I offer this PR in the hopes that it will illustrate how a slightly
different approach answers the (very valid) objections:

1. Codespell doesn't do a dictionary whitelist based approach (i.e. whatever I
   don't have in my dictionary is wrong), but rather maintains a map of common
   misspellings. In technical documentation, this should cut down on false
   positives greatly
2. Codespell merely annotates the PR when it thinks that a word is wrong, and
   this leaves the option to fix the word (if it's right), add the word to the
   exemption list, or even just ignore the warning and take no action (perhaps
   cleaned up later)
3. If it identified 18 spellings errors (15 distinct words), and had only 3
   false positives (excluding the unorthodox brand spelling "Technic") that had
   to be exempted, I think that suggests a pretty good ratio. If we included the
   words caught in past `codespell`-fixing PRs (#364, 
   #329), the ratio would be even higher. 

Finally, there are **20** merged that mention "spelling," and **171** that
mention "typo." I can't say that codespell could've prevented all of them, but
it's reasonable to expect it could've caught some of them. 