### PR TITLE
Raspberry-pi-industrial.adoc : remove duplicated words

### DIFF
--- a/documentation/asciidoc/computers/raspberry-pi/raspberry-pi-industrial.adoc
+++ b/documentation/asciidoc/computers/raspberry-pi/raspberry-pi-industrial.adoc
@@ -21,7 +21,7 @@ Also, from 36 to 43 (inclusive), there are eight rows of 32 bits available for t
 
 To program these bits, you will need to use the vcmailbox. This is a Linux driver interface to the firmware which will handle the programming of the rows. To do this, please refer to the https://github.com/raspberrypi/firmware/wiki/Mailbox-property-interface[documentation], and the vcmailbox https://github.com/raspberrypi/userland/blob/master/host_applications/linux/apps/vcmailbox/vcmailbox.c[example application].
 
-The vcmailbox application can be used directly from the command line on a Raspberry Pi Raspberry Pi OS build. An example usage would be:
+The vcmailbox application can be used directly from the command line on a Raspberry Pi OS build. An example usage would be:
 
 [,bash]
 ----

--- a/documentation/asciidoc/computers/raspberry-pi/raspberry-pi-industrial.adoc
+++ b/documentation/asciidoc/computers/raspberry-pi/raspberry-pi-industrial.adoc
@@ -21,7 +21,7 @@ Also, from 36 to 43 (inclusive), there are eight rows of 32 bits available for t
 
 To program these bits, you will need to use the vcmailbox. This is a Linux driver interface to the firmware which will handle the programming of the rows. To do this, please refer to the https://github.com/raspberrypi/firmware/wiki/Mailbox-property-interface[documentation], and the vcmailbox https://github.com/raspberrypi/userland/blob/master/host_applications/linux/apps/vcmailbox/vcmailbox.c[example application].
 
-The vcmailbox application can be used directly from the command line on a Raspberry Pi OS build. An example usage would be:
+The vcmailbox application can be used directly from the command line on Raspberry Pi OS. An example usage would be:
 
 [,bash]
 ----


### PR DESCRIPTION
I think this is a typo. If that's not the case, please close it.