### PR TITLE
Clarify extra pins on the 7" display.

### DIFF
--- a/documentation/asciidoc/accessories/display/display_intro.adoc
+++ b/documentation/asciidoc/accessories/display/display_intro.adoc
@@ -12,7 +12,9 @@ The following image shows how to attach the Raspberry Pi to the back of the Touc
 
 image::images/GPIO_power-500x333.jpg[DSI Display Connections]
 
-The other three pins should be left disconnected, unless connecting the display to a Raspberry Pi 1 Model A/B. See: xref:display.adoc#legacy-support[Legacy support for Raspberry Pi 1 Model A/B]
+The other three pins should be left disconnected, unless connecting the display to an original model Raspberry Pi. See the section on xref:display.adoc#legacy-support[legacy support] for more information on connecting the display to an original Raspberry Pi.
+
+NOTE:  An original Rapsberry Pi can be easily identified from other models, it is the only model with a 26-pin rather than 40-pin GPIO header connector.
 
 === Screen Orientation
 

--- a/documentation/asciidoc/accessories/display/display_intro.adoc
+++ b/documentation/asciidoc/accessories/display/display_intro.adoc
@@ -14,7 +14,7 @@ image::images/GPIO_power-500x333.jpg[DSI Display Connections]
 
 The other three pins should be left disconnected, unless connecting the display to an original model Raspberry Pi. See the section on xref:display.adoc#legacy-support[legacy support] for more information on connecting the display to an original Raspberry Pi.
 
-NOTE:  An original Rapsberry Pi can be easily identified from other models, it is the only model with a 26-pin rather than 40-pin GPIO header connector.
+NOTE:  An original Raspberry Pi can be easily identified from other models, it is the only model with a 26-pin rather than 40-pin GPIO header connector.
 
 === Screen Orientation
 

--- a/documentation/asciidoc/accessories/display/display_intro.adoc
+++ b/documentation/asciidoc/accessories/display/display_intro.adoc
@@ -12,7 +12,7 @@ The following image shows how to attach the Raspberry Pi to the back of the Touc
 
 image::images/GPIO_power-500x333.jpg[DSI Display Connections]
 
-The other three pins should be left disconnected, unless connecting the display to an original model Raspberry Pi. See the section on xref:display.adoc#legacy-support[legacy support] for more information on connecting the display to an original Raspberry Pi.
+The other three pins should be left disconnected, unless connecting the display to an original model Raspberry Pi 1 Model A or B. See the section on xref:display.adoc#legacy-support[legacy support] for more information on connecting the display to an original Raspberry Pi.
 
 NOTE:  An original Raspberry Pi can be easily identified from other models, it is the only model with a 26-pin rather than 40-pin GPIO header connector.
 

--- a/documentation/asciidoc/accessories/display/display_intro.adoc
+++ b/documentation/asciidoc/accessories/display/display_intro.adoc
@@ -9,6 +9,7 @@ The DSI display is designed to work with all models of Raspberry Pi, however ear
 === Physical Installation
 
 The following image shows how to attach the Raspberry Pi to the back of the Touch Display (if required), and how to connect both the data (ribbon cable) and power (red/black wires) from the Raspberry Pi to the display. If you are not attaching the Raspberry Pi to the back of the display, take extra care when attaching the ribbon cable to ensure it is the correct way round. The black and red power wires should be attached to the GND and 5v pins respectively.
+
 image::images/GPIO_power-500x333.jpg[DSI Display Connections]
 
 The other three pins should be left disconnected, unless connecting the display to a Raspberry Pi 1 Model A/B. See: xref:display.adoc#legacy-support[Legacy support for Raspberry Pi 1 Model A/B]

--- a/documentation/asciidoc/accessories/display/display_intro.adoc
+++ b/documentation/asciidoc/accessories/display/display_intro.adoc
@@ -9,10 +9,9 @@ The DSI display is designed to work with all models of Raspberry Pi, however ear
 === Physical Installation
 
 The following image shows how to attach the Raspberry Pi to the back of the Touch Display (if required), and how to connect both the data (ribbon cable) and power (red/black wires) from the Raspberry Pi to the display. If you are not attaching the Raspberry Pi to the back of the display, take extra care when attaching the ribbon cable to ensure it is the correct way round. The black and red power wires should be attached to the GND and 5v pins respectively.
-
 image::images/GPIO_power-500x333.jpg[DSI Display Connections]
 
-xref:display.adoc#legacy-support[Legacy support for Raspberry Pi 1 Model A/B]
+The other three pins should be left disconnected, unless connecting the display to a Raspberry Pi 1 Model A/B. See: xref:display.adoc#legacy-support[Legacy support for Raspberry Pi 1 Model A/B]
 
 === Screen Orientation
 

--- a/documentation/asciidoc/accessories/display/legacy.adoc
+++ b/documentation/asciidoc/accessories/display/legacy.adoc
@@ -1,6 +1,6 @@
 == Legacy Support
 
-NOTE: These instructions are for the original Raspberry Pi Model A and B boards only. You can identify an original board as it is the only model with a 26-pin GPIO header, all other models have the now standard 40-pin connector.
+NOTE: These instructions are for the original Raspberry Pi Model A and B boards only. You can identify an original board as it is the only model with a 26-pin GPIO header, all other models have the now-standard 40-pin connector.
 
 The DSI connector on the Model A/B boards does not have the I2C connections required to talk to the touchscreen controller and DSI controller. You can work around this by using the additional set of jumper cables provided with the display kit to wire up the I2C bus on the GPIO pins to the display controller board.
 

--- a/documentation/asciidoc/accessories/display/legacy.adoc
+++ b/documentation/asciidoc/accessories/display/legacy.adoc
@@ -1,6 +1,6 @@
 == Legacy Support
 
-NOTE: These instructions are for the original (Raspberry Pi 1) Model A and B boards.
+NOTE: These instructions are for the original Raspberry Pi Model A and B boards only. You can identify an original board as it is the only model with a 26-pin GPIO header, all other models have the now standard 40-pin connector.
 
 The DSI connector on the Model A/B boards does not have the I2C connections required to talk to the touchscreen controller and DSI controller. You can work around this by using the additional set of jumper cables provided with the display kit to wire up the I2C bus on the GPIO pins to the display controller board.
 

--- a/documentation/asciidoc/accessories/display/legacy.adoc
+++ b/documentation/asciidoc/accessories/display/legacy.adoc
@@ -1,6 +1,6 @@
 == Legacy Support
 
-NOTE: These instructions are for the original Model A and B boards.
+NOTE: These instructions are for the original (Raspberry Pi 1) Model A and B boards.
 
 The DSI connector on the Model A/B boards does not have the I2C connections required to talk to the touchscreen controller and DSI controller. You can work around this by using the additional set of jumper cables provided with the display kit to wire up the I2C bus on the GPIO pins to the display controller board.
 


### PR DESCRIPTION
A number of posts made by users on the Raspberry Pi forums indicate that the documentation does not make it clear that the extra pins are only for legacy Pi 1 models (and should not be connected to later models, as this would bridge the two I²C buses and potentially cause issues). This pull request makes it clear that these pins do not need to be connected.