### PR TITLE
Minor : Fix Build HAT Python docs: "while" is not capitalized

### DIFF
--- a/documentation/asciidoc/accessories/build-hat/py-motors.adoc
+++ b/documentation/asciidoc/accessories/build-hat/py-motors.adoc
@@ -54,7 +54,7 @@ from buildhat import Motor
 
 motor_a = Motor('A')
 
-While True:
+while True:
     print("Position: ", motor_a.get_aposition())
 ----
 


### PR DESCRIPTION
Easy one for you:
I got an error when working through the Build HAT tutorial. Turns out that "While" was capitalized in the example code.

Lastly: Thanks for the Raspberry Pi and for the Build HAT!
