### PR TITLE
Fix Python sensors sample

### DIFF
--- a/documentation/asciidoc/accessories/build-hat/py-sensors.adoc
+++ b/documentation/asciidoc/accessories/build-hat/py-sensors.adoc
@@ -18,12 +18,16 @@ from buildhat import ForceSensor, ColorSensor
 button = ForceSensor('C')
 cs = ColorSensor('B')
 
-def handle_pressed():
+def handle_pressed(force):
     cs.on()
-    print(c.get_color())
+    print(cs.get_color())
 
-def handle_released():
+def handle_released(force):
     cs.off()
+
+button.when_pressed = handle_pressed
+button.when_released = handle_released
+pause()
 ----
 
 Run it and hold a coloured object (LEGO® elements are ideal) in front of the colour sensor and press the Force sensor plunger. The sensor’s LED should switch on and the name of the closest colour should be displayed in the thonny REPL. 


### PR DESCRIPTION
The Python sensors code doesn't compile and is incomplete. 
This PR fixes it while staying as true to the original source as possible.

(In particular, the existing source code does not hook up the pressed and released handlers and references `c` instead of `cs`, leading to a compile-time error.)