### PR TITLE
Access-point-routed.adoc : add private IP address range

### DIFF
--- a/documentation/asciidoc/computers/configuration/access-point-routed.adoc
+++ b/documentation/asciidoc/computers/configuration/access-point-routed.adoc
@@ -152,6 +152,8 @@ address=/gw.wlan/192.168.4.1
 
 The Raspberry Pi will deliver IP addresses between `192.168.4.2` and `192.168.4.20`, with a lease time of 24 hours, to wireless DHCP clients. You should be able to reach the Raspberry Pi under the name `gw.wlan` from wireless clients.
 
+NOTE: In the personal IP network range ,There are three types: `10.0.0.0 to 10.255.255.255`,`172.16.0.0 to 172.31.255.255` and `192.168.0.0 to 192.168.255.255`. Adjust the range accordingly and use it.
+
 There are many more options for `dnsmasq`; see the default configuration file (`/etc/dnsmasq.conf`) or the http://www.thekelleys.org.uk/dnsmasq/doc.html[online documentation] for details.
 
 [[wifi-cc-rfkill]]

--- a/documentation/asciidoc/computers/configuration/access-point-routed.adoc
+++ b/documentation/asciidoc/computers/configuration/access-point-routed.adoc
@@ -152,7 +152,7 @@ address=/gw.wlan/192.168.4.1
 
 The Raspberry Pi will deliver IP addresses between `192.168.4.2` and `192.168.4.20`, with a lease time of 24 hours, to wireless DHCP clients. You should be able to reach the Raspberry Pi under the name `gw.wlan` from wireless clients.
 
-NOTE: In the personal IP network range ,There are three types: `10.0.0.0 to 10.255.255.255`,`172.16.0.0 to 172.31.255.255` and `192.168.0.0 to 192.168.255.255`. Adjust the range accordingly and use it.
+NOTE: In the personal IP network range, There are three types: `10.0.0.0 to 10.255.255.255`,`172.16.0.0 to 172.31.255.255` and `192.168.0.0 to 192.168.255.255`. Adjust the range accordingly and use it.
 
 There are many more options for `dnsmasq`; see the default configuration file (`/etc/dnsmasq.conf`) or the http://www.thekelleys.org.uk/dnsmasq/doc.html[online documentation] for details.
 

--- a/documentation/asciidoc/computers/configuration/access-point-routed.adoc
+++ b/documentation/asciidoc/computers/configuration/access-point-routed.adoc
@@ -152,7 +152,7 @@ address=/gw.wlan/192.168.4.1
 
 The Raspberry Pi will deliver IP addresses between `192.168.4.2` and `192.168.4.20`, with a lease time of 24 hours, to wireless DHCP clients. You should be able to reach the Raspberry Pi under the name `gw.wlan` from wireless clients.
 
-NOTE: In the personal IP network range, There are three types: `10.0.0.0 to 10.255.255.255`,`172.16.0.0 to 172.31.255.255` and `192.168.0.0 to 192.168.255.255`. Adjust the range accordingly and use it.
+NOTE: There are three IP address blocks set aside for private networks. There is the Class A block, from `10.0.0.0` to `10.255.255.255`, a Class B block from `172.16.0.0` to `172.31.255.255`, and probably the most frequently used, a Class C block from `192.168.0.0` to 192.168.255.255`.
 
 There are many more options for `dnsmasq`; see the default configuration file (`/etc/dnsmasq.conf`) or the http://www.thekelleys.org.uk/dnsmasq/doc.html[online documentation] for details.
 


### PR DESCRIPTION
If the external and internal IP ranges are the same, add a Private IP range that can be config.

If it's not suitable for the discussion, I'd appreciate it if you could close it. thanks