### PR TITLE
Update the Build HAT .NET instructions

### DIFF
--- a/documentation/asciidoc/accessories/build-hat/net-installing-software.adoc
+++ b/documentation/asciidoc/accessories/build-hat/net-installing-software.adoc
@@ -12,19 +12,21 @@ $ wget -O - https://raw.githubusercontent.com/pjgpetecodes/dotnet5pi/master/inst
 ----
 
 After installing the .NET framework you can create your project:
+
 [.bash]
 ----
 $ dotnet new console --name buildhat
----
+----
 
 This creates a default program in the `buildhat` directory, so we go into that directory and run the program.
 It should print `Hello World!`
+
 [.bash]
----
+----
 $ cd buildhat
 $ dotnet run
 Hello World!
----
+----
 
 You will now need to install the following nuget packages:
 [.bash]

--- a/documentation/asciidoc/accessories/build-hat/net-installing-software.adoc
+++ b/documentation/asciidoc/accessories/build-hat/net-installing-software.adoc
@@ -48,17 +48,4 @@ Hello World!
 === Editing C# Code
 In the instructions below, you will be editing the file `buildhat/Program.cs`, the C# program which was generated when you ran the above commands.
 
-Any text editor will work to edit C# code, including Geany, the IDE/Text Editor that comes pre-installed in Raspbian. However, https://code.visualstudio.com/[Visual Studio Code] (often called "VS Code") is a popular alternative. It can be installed by running:
-
-[.bash]
-----
-$ sudo apt get install code
-----
-
-Once installed, you can open your current folder in VS Code by running:
-
-[.bash]
-----
-$ code .
-----
-
+Any text editor will work to edit C# code, including Geany, the IDE/Text Editor that comes pre-installed. https://code.visualstudio.com/docs/setup/raspberry-pi/[Visual Studio Code] (often called "VS Code") is also a popular alternative.

--- a/documentation/asciidoc/accessories/build-hat/net-installing-software.adoc
+++ b/documentation/asciidoc/accessories/build-hat/net-installing-software.adoc
@@ -11,12 +11,25 @@ WARNING: The installation script is run as `root`. You should read it first and 
 $ wget -O - https://raw.githubusercontent.com/pjgpetecodes/dotnet5pi/master/install.sh | sudo bash
 ----
 
-After installing the .NET framework you also need to install the nuget packages:
-
+After installing the .NET framework you can create your project:
 [.bash]
 ----
-$ dotnet add package System.Device.Gpio --source https://pkgs.dev.azure.com/dotnet/IoT/_packaging/nightly_iot_builds/nuget/v3/index.json
-$ dotnet add package Iot.Device.Bindings --source https://pkgs.dev.azure.com/dotnet/IoT/_packaging/nightly_iot_builds/nuget/v3/index.json
+$ dotnet new console --name buildhat
+---
+
+This creates a default program in the `buildhat` directory, so we go into that directory and run the program.
+It should print `Hello World!`
+[.bash]
+---
+$ cd buildhat
+$ dotnet run
+Hello World!
+---
+
+You will now need to install the following nuget packages:
+[.bash]
+----
+$ dotnet add package System.Device.Gpio --version 2.1.0
+$ dotnet add package Iot.Device.Bindings --version 2.1.0
 ----
 
-You can now create a project and edit it.

--- a/documentation/asciidoc/accessories/build-hat/net-installing-software.adoc
+++ b/documentation/asciidoc/accessories/build-hat/net-installing-software.adoc
@@ -18,14 +18,11 @@ After installing the .NET framework you can create your project:
 $ dotnet new console --name buildhat
 ----
 
-This creates a default program in the `buildhat` directory, so we go into that directory and run the program.
-It should print `Hello World!`
+This creates a default program in the `buildhat` subdirectory, and we need to be in that directory in order to continue:
 
 [.bash]
 ----
 $ cd buildhat
-$ dotnet run
-Hello World!
 ----
 
 You will now need to install the following nuget packages:
@@ -33,5 +30,35 @@ You will now need to install the following nuget packages:
 ----
 $ dotnet add package System.Device.Gpio --version 2.1.0
 $ dotnet add package Iot.Device.Bindings --version 2.1.0
+----
+
+=== Running C# Code
+
+You can run the program with the `dotnet run` command. Let's try it now to make sure everything works. 
+It should print "Hello World!"
+
+[.bash]
+----
+$ dotnet run
+Hello World!
+----
+
+(When instructed to "run the program" in the instructions that follow, you will simply rerun `dotnet run`) 
+
+=== Editing C# Code
+In the instructions below, you will be editing the file `buildhat/Program.cs`, the C# program which was generated when you ran the above commands.
+
+Any text editor will work to edit C# code, including Geany, the IDE/Text Editor that comes pre-installed in Raspbian. However, https://code.visualstudio.com/[Visual Studio Code] (often called "VS Code") is a popular alternative. It can be installed by running:
+
+[.bash]
+----
+$ sudo apt get install code
+----
+
+Once installed, you can open your current folder in VS Code by running:
+
+[.bash]
+----
+$ code .
 ----
 


### PR DESCRIPTION
The previous instructions appeared to make assumptions that the reader had created a donet program before. 
This change clarifies:
* How to create a dotnet project
* How to run it and ensure that things are oworking
* That you should be in the project directory in order to add the nuget packages
* That the nuget packages should not point to the nightly IoT build, but to version 2.1.0 (otherwise in its current state there are errors upon installation)


(I'm still working my way through these instructions and have a few more improvements before this PR is ready)