### PR TITLE
Support Asciidoctor table alignment operators

### DIFF
--- a/jekyll-assets/_includes/head.html
+++ b/jekyll-assets/_includes/head.html
@@ -16,7 +16,7 @@
 <link href="https://fonts.googleapis.com/css2?family=Roboto:ital,wght@0,100;0,300;0,400;0,700;1,100;1,300;1,400;1,700&display=swap" rel="stylesheet">
 <link rel="preconnect" href="https://IHWGNTJ1NP-dsn.algolia.net" crossorigin>
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@docsearch/css@alpha"/>
-<link rel="stylesheet" href="{{ site.baseurl }}/css/style.css?ver=1643709895">
+<link rel="stylesheet" href="{{ site.baseurl }}/css/style.css?ver=1646652613">
 <link rel="stylesheet" href="{{ site.baseurl }}/css/tabs.css?ver=1639581228">
 <script async src="https://www.googletagmanager.com/gtag/js?id=UA-180927933-8"></script>
 <script>

--- a/jekyll-assets/css/style.css
+++ b/jekyll-assets/css/style.css
@@ -413,6 +413,36 @@ h6 .anchor::before {
   margin-bottom: 0;
 }
 
+#content table.tableblock th.halign-left,
+#content table.tableblock td.halign-left {
+  text-align: left;
+}
+
+#content table.tableblock th.halign-right,
+#content table.tableblock td.halign-right {
+  text-align: right;
+}
+
+#content table.tableblock th.halign-center,
+#content table.tableblock td.halign-center {
+  text-align: center;
+}
+
+#content table.tableblock th.valign-top,
+#content table.tableblock td.valign-top {
+  vertical-align: top;
+}
+
+#content table.tableblock th.valign-bottom,
+#content table.tableblock td.valign-bottom {
+  vertical-align: bottom;
+}
+
+#content table.tableblock th.valign-middle,
+#content table.tableblock td.valign-middle {
+  vertical-align: middle;
+}
+
 #content td.icon {
   font-weight: bold;
   color: #343434;


### PR DESCRIPTION
GitHub: https://github.com/raspberrypi/documentation/pull/2466

In order to support AsciiDoctor's table alignment operators (see https://docs.asciidoctor.org/asciidoc/latest/tables/align-by-column/), we need to port across the relevant CSS rules from the default stylesheet.

As we already override the default text alignment for table headers, we increase the specificity of each rule so that alignment operators will take precedence.
