### PR TITLE
Update installing-from-chromeos.adoc

### DIFF
--- a/documentation/asciidoc/computers/getting-started/installing-from-chromeos.adoc
+++ b/documentation/asciidoc/computers/getting-started/installing-from-chromeos.adoc
@@ -3,11 +3,12 @@
 The easiest way to write images to an SD card and USB drives with Chrome OS is to use the official https://chrome.google.com/webstore/detail/chromebook-recovery-utili/jndclpdbaamdhonoechobihbbiimdgai[Chromebook Recovery Utility]. It can be used to create Chromebook Recovery media, and it will also accept `.zip` files containing images.
 
 * Download the https://chrome.google.com/webstore/detail/chromebook-recovery-utili/pocpnlppkickgojjlmhdmidojbmbodfm[Chromebook Recovery Utility].
-* Download the https://www.raspberrypi.com/software/operating-systems/#raspberry-pi-os-32-bit[Raspberry Pi OS] zip archive.
+* Download the https://www.raspberrypi.com/software/operating-systems/#raspberry-pi-os-32-bit[Raspberry Pi OS] zip or xz archive.
+* If you download a xz archive, you will need to first convert it to a zip archive to proceed with the remainder of these steps.
 * Launch the *Recovery Utility*
 * Click on the *Settings Gears* icon in the upper right-hand corner, next to the window close icon.
 * Select the *Use Local Image* option.
-* Choose the `.zip` file you downloaded.
+* Choose the `.zip` file archive.
 * Insert the SD card and click *Continue*.
 * Read the warning and click the *Create now* button.
 * Wait for the progress bar to complete twice (for unpacking and writing). This might take a few minutes. Once the process is complete, a big green checkmark will be shown.


### PR DESCRIPTION
As of the 2022-04-07 linked archive, the Raspberry Pi OS images are in XZ format and no longer in Zip format. There appears to be a bug in the Recovery Utility where it recognizes XZ files as image archives, but then the next screen blinks by quickly to the "success" screen without actually writing the image to the device. A workaround until the Recovery Utility is fixed is to first convert the XZ archive to Zip format by 'unxz'ing the original archive and then 'zip'ing a new archive. The Recovery Utility correctly writes the new zip archived image to the device. I tested this workaround with the raspios_full_armhf-2022-04-07 archive.