### PR TITLE
computers/processors/bcm2835: fix dead links

### DIFF
--- a/documentation/asciidoc/computers/processors/bcm2835.adoc
+++ b/documentation/asciidoc/computers/processors/bcm2835.adoc
@@ -1,12 +1,11 @@
 == BCM2835
 
-The BCM2835 is the Broadcom chip used in the Raspberry Pi 1 Models A, A+, B, B+, the Raspberry Pi Zero, the Raspberry Pi Zero W, and the Raspberry Pi Compute Module 1. Some details of the chip can be found in the https://datasheets.raspberrypi.com/bcm2835/bcm2835-peripherals.pdf[Peripheral specification] document.
+The BCM2835 is the Broadcom chip used in the Raspberry Pi 1 Models A, A+, B, B+, the Raspberry Pi Zero, the Raspberry Pi Zero W, and the Raspberry Pi Compute Module 1. Some details of the chip can be found in the https://datasheets.raspberrypi.com/bcm2835/bcm2835-peripherals.pdf[Peripheral specification] document. It contains a single core ARM1176JZF-S processor.
 
 NOTE: This document contains a number of errors. However there is a list of currently known https://elinux.org/BCM2835_datasheet_errata[errata].
 
 Other information regarding the processor can be found in the following documents;
 
 * https://docs.broadcom.com/docs/12358545[GPU documentation] and https://docs.broadcom.com/docs/12358546[open-source driver]
-* https://www.arm.com/products/processors/classic/arm11/arm1176.php[ARM1176 processor]
-* http://infocenter.arm.com/help/index.jsp?topic=/com.arm.doc.ddi0301h/index.html[ARM1176JZF-S]
+* https://developer.arm.com/documentation/ddi0301[ARM1176JZF-S]
 


### PR DESCRIPTION
Fixes #2486

1st dead link: removed
2nd dead link: updated to new URL