### PR TITLE
Fix sensor name in maximum exposure table

### DIFF
--- a/documentation/asciidoc/accessories/camera/camera_hardware.adoc
+++ b/documentation/asciidoc/accessories/camera/camera_hardware.adoc
@@ -225,7 +225,7 @@ The maximum exposure times of the three official Raspberry Pi cameras are given 
 | V2 (IMX219)
 | 10
 
-| HQ (IMX417)
+| HQ (IMX477)
 | 230
 |===
 


### PR DESCRIPTION
Sensor name is incorrect in the maximum exposure time table.