### PR TITLE
video.adoc: Document requirement for overclock for certain 4K modes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ html: run_ninja
 
 # Build the html output files and additionally run a small webserver for local previews
 serve_html: run_ninja
-	$(JEKYLL_CMD) serve --host=0.0.0.0
+	$(JEKYLL_CMD) serve
 
 # Delete all the files created by the 'html' target
 clean_html:

--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ html: run_ninja
 
 # Build the html output files and additionally run a small webserver for local previews
 serve_html: run_ninja
-	$(JEKYLL_CMD) serve
+	$(JEKYLL_CMD) serve --host=0.0.0.0
 
 # Delete all the files created by the 'html' target
 clean_html:

--- a/documentation/asciidoc/computers/config_txt/video.adoc
+++ b/documentation/asciidoc/computers/config_txt/video.adoc
@@ -826,13 +826,13 @@ These values are valid if `hdmi_group=1` (CEA):
 | 4096x2160
 | 50Hz
 | 256:135
-| Pi 4<<super1>>
+| Pi 4<<needsoverclock>>
 
 | 102
 | 4096x2160
 | 60Hz
 | 256:135
-| Pi 4<<super1>>
+| Pi 4<<needsoverclock>>
 
 | 103
 | 2160p
@@ -865,7 +865,7 @@ These values are valid if `hdmi_group=1` (CEA):
 | Pi 4
 |===
 
-[[super1,^**1**^]] **1.** Only available with an overclocked core:set `core_freq_min=600` and `core_freq=600`. See xref:config_txt.adoc#overclocking[overclocking].
+[[needsoverclock,^**1**^]] **1.** Only available with an overclocked core frequency: set `core_freq_min=600` and `core_freq=600`. See xref:config_txt.adoc#overclocking[overclocking].
 
 Pixel doubling and quadrupling indicates a higher clock rate, with each pixel repeated two or four times respectively.
 

--- a/documentation/asciidoc/computers/config_txt/video.adoc
+++ b/documentation/asciidoc/computers/config_txt/video.adoc
@@ -826,13 +826,13 @@ These values are valid if `hdmi_group=1` (CEA):
 | 4096x2160
 | 50Hz
 | 256:135
-| Pi 4
+| Pi 4<sup>1</sup>
 
 | 102
 | 4096x2160
 | 60Hz
 | 256:135
-| Pi 4
+| Pi 4<sup>1</sup>
 
 | 103
 | 2160p
@@ -864,6 +864,8 @@ These values are valid if `hdmi_group=1` (CEA):
 | 64:27
 | Pi 4
 |===
+
+1. Only available with an overclocked core:set `core_freq_min=600` and `core_freq=600`. See xref:config_txt.adoc#overclocking[overclocking].
 
 Pixel doubling and quadrupling indicates a higher clock rate, with each pixel repeated two or four times respectively.
 

--- a/documentation/asciidoc/computers/config_txt/video.adoc
+++ b/documentation/asciidoc/computers/config_txt/video.adoc
@@ -826,13 +826,13 @@ These values are valid if `hdmi_group=1` (CEA):
 | 4096x2160
 | 50Hz
 | 256:135
-| Pi 4^1^
+| Pi 4<<super1>>
 
 | 102
 | 4096x2160
 | 60Hz
 | 256:135
-| Pi 4^1^
+| Pi 4<<super1>>
 
 | 103
 | 2160p
@@ -865,7 +865,7 @@ These values are valid if `hdmi_group=1` (CEA):
 | Pi 4
 |===
 
-1. Only available with an overclocked core:set `core_freq_min=600` and `core_freq=600`. See xref:config_txt.adoc#overclocking[overclocking].
+[[super1,^**1**^]] **1.** Only available with an overclocked core:set `core_freq_min=600` and `core_freq=600`. See xref:config_txt.adoc#overclocking[overclocking].
 
 Pixel doubling and quadrupling indicates a higher clock rate, with each pixel repeated two or four times respectively.
 

--- a/documentation/asciidoc/computers/config_txt/video.adoc
+++ b/documentation/asciidoc/computers/config_txt/video.adoc
@@ -826,13 +826,13 @@ These values are valid if `hdmi_group=1` (CEA):
 | 4096x2160
 | 50Hz
 | 256:135
-| Pi 4<sup>1</sup>
+| Pi 4^1^
 
 | 102
 | 4096x2160
 | 60Hz
 | 256:135
-| Pi 4<sup>1</sup>
+| Pi 4^1^
 
 | 103
 | 2160p


### PR DESCRIPTION
https://github.com/raspberrypi/linux/pull/5038 makes certain 4K modes (and anything beyond) conditional on the BCM2711 core being overclocked to at least 600MHz - document this requirement.