### PR TITLE
video.adoc: Pi 4-related fix up

### DIFF
--- a/documentation/asciidoc/computers/config_txt/video.adoc
+++ b/documentation/asciidoc/computers/config_txt/video.adoc
@@ -1606,7 +1606,7 @@ Setting `hdmi_force_hotplug` to `1` pretends that the HDMI hotplug signal is ass
 
 ==== `hdmi_ignore_hotplug`
 
-Setting `hdmi_ignore_hotplug` to `1` pretends that the HDMI hotplug signal is not asserted, so it appears that a HDMI display is not attached. The HDMI output will therefore be disabled, even if a monitor is connected.
+Setting `hdmi_ignore_hotplug` to `1` pretends that the HDMI hotplug signal is not asserted, so it appears that a HDMI display is not attached. HDMI output will therefore be disabled, even if a monitor is connected.
 
 ==== `overscan_left`
 

--- a/documentation/asciidoc/computers/config_txt/video.adoc
+++ b/documentation/asciidoc/computers/config_txt/video.adoc
@@ -1606,7 +1606,7 @@ Setting `hdmi_force_hotplug` to `1` pretends that the HDMI hotplug signal is ass
 
 ==== `hdmi_ignore_hotplug`
 
-Setting `hdmi_ignore_hotplug` to `1` pretends that the HDMI hotplug signal is not asserted, so it appears that a HDMI display is not attached. In other words, composite output mode will be used, even if an HDMI monitor is detected.
+Setting `hdmi_ignore_hotplug` to `1` pretends that the HDMI hotplug signal is not asserted, so it appears that a HDMI display is not attached. The HDMI output will therefore be disabled, even if a monitor is connected.
 
 ==== `overscan_left`
 


### PR DESCRIPTION
Pi 4 does not enable composite when HDMI is disabled.