### PR TITLE
[doc] Pointed out that default `pi` user is now removed

### DIFF
--- a/documentation/asciidoc/computers/remote-access/secure-shell-from-unix.adoc
+++ b/documentation/asciidoc/computers/remote-access/secure-shell-from-unix.adoc
@@ -14,7 +14,9 @@ NOTE: If you receive a `connection timed out` error it is likely that you have e
 
 WARNING: In the event your Raspberry Pi has taken the IP address of a device to which your computer has connected before (even if this was on another network), you may be given a warning and asked to clear the record from your list of known devices. Following this instruction and trying the `ssh` command again should be successful.
 
-Next you will be prompted for the password for the `pi` login: the default password on Raspberry Pi OS is `raspberry`. 
+Next you will be prompted for the password for the `pi` login: the default password on Raspberry Pi OS is `raspberry`.
+
+NOTE: Since April the Bullseye version of Raspbery Pi OS no longer has the default `pi` user configured - for details read https://www.raspberrypi.com/news/raspberry-pi-bullseye-update-april-2022/[An update to Raspberry Pi OS Bullseye].
 
 For security reasons it is highly recommended to change the default password on the Raspberry Pi (also, you can not login through ssh if the password is blank). You should now be able to see the Raspberry Pi prompt, which will be identical to the one found on the Raspberry Pi itself.
 


### PR DESCRIPTION
Linked to: https://www.raspberrypi.com/news/raspberry-pi-bullseye-update-april-2022/