### PR TITLE
Conditional filters: update for CM4S

### DIFF
--- a/documentation/asciidoc/computers/config_txt/conditional.adoc
+++ b/documentation/asciidoc/computers/config_txt/conditional.adoc
@@ -35,7 +35,7 @@ The conditional model filters are applied according to the following table.
 | Pi 400
 
 | [cm4]
-| Compute Module 4
+| Compute Module 4<<cm4clarification>>
 
 | [pi0]
 | Zero, Zero W, Zero 2 W
@@ -47,11 +47,13 @@ The conditional model filters are applied according to the following table.
 | Zero 2 W
 
 | [board-type=Type]
-| Filter by `Type` number - see xref:raspberry-pi.adoc#raspberry-pi-revision-codes[Raspberry Pi Revision Codes] E.g `[board-type=0x14]` would match CM4.
+| Filter by `Type` number - see xref:raspberry-pi.adoc#raspberry-pi-revision-codes[Raspberry Pi Revision Codes]. For example, `[board-type=0x13]` would match Raspberry Pi 400.
 
 |===
 
-These are particularly useful for defining different `kernel`, `initramfs`, and `cmdline` settings, as the Raspberry Pi 1 and Raspberry Pi 2 require different kernels. They can also be useful to define different overclocking settings, as the Raspberry Pi 1 and Raspberry Pi 2 have different default speeds. For example, to define separate `initramfs` images for each:
+[[cm4clarification,^**1**^]] **1.** Does not include CM4S. To filter for CM4S, use `[board-type=0x15]`.
+
+Filters are particularly useful for defining different `kernel`, `initramfs`, and `cmdline` settings, as the Raspberry Pi 1 and Raspberry Pi 2 require different kernels. They can also be useful to define different overclocking settings, as the Raspberry Pi 1 and Raspberry Pi 2 have different default speeds. For example, to define separate `initramfs` images for each:
 
 ----
  [pi1]


### PR DESCRIPTION
Recently a forum user (see https://forums.raspberrypi.com/viewtopic.php?t=338978) requested how to use a `config.txt` filter for CM4S boards. The solution is not currently well documented, so add this. Also clarify that the `[cm4]` filter does not apply to the CM4S, and fix a minor grammar fault. I also had to change a word in the paragraph beneath the table, since inserting the footnote to the table means the following paragraph needs the first sentence to be more specific.