### PR TITLE
Update references to outdated default username and password

### DIFF
--- a/documentation/asciidoc/computers/configuration/headless.adoc
+++ b/documentation/asciidoc/computers/configuration/headless.adoc
@@ -1,6 +1,6 @@
 == Setting up a Headless Raspberry Pi
 
-For people who run their Raspberry Pi headless and therefore cannot work through xref:getting-started.adoc#configuration-on-first-boot[the first-boot wizard], the Raspberry Pi Imager tool allows you to preconfigure an image with a user account; when an image created like this is first booted, it will come straight up in the desktop, logged in as the user created in the Imager.
+For people who run their Raspberry Pi headless and therefore cannot work through xref:getting-started.adoc#configuration-on-first-boot[the first-boot wizard], the Raspberry Pi Imager tool allows you to preconfigure an image with a username and password.
 
 To preconfigure an image like this, when you have selected the source image and destination in Imager, click the “settings” button – the picture of a cogwheel – before clicking “Write”, and use the Advanced options menu to enter a username and password, along with any other preconfiguration you want.
 

--- a/documentation/asciidoc/computers/configuration/headless.adoc
+++ b/documentation/asciidoc/computers/configuration/headless.adoc
@@ -1,10 +1,22 @@
 == Setting up a Headless Raspberry Pi
 
-If you do not use a monitor or keyboard to run your Raspberry Pi (known as headless), but you still need to do some wireless setup, there is a facility to enable wireless networking and SSH when creating an image.
+For people who run their Raspberry Pi headless and therefore cannot work through xref:getting-started.adoc#configuration-on-first-boot[the first-boot wizard], the Raspberry Pi Imager tool allows you to preconfigure an image with a user account; when an image created like this is first booted, it will come straight up in the desktop, logged in as the user created in the Imager.
 
-Once an image is created on an SD card, by inserting it into a card reader on a Linux or Windows machines the xref:configuration.adoc#the-boot-folder[boot folder] can be accessed. Adding certain files to this folder will activate certain setup features on the first boot of the Raspberry Pi.
+To preconfigure an image like this, when you have selected the source image and destination in Imager, click the “settings” button – the picture of a cogwheel – before clicking “Write”, and use the Advanced options menu to enter a username and password, along with any other preconfiguration you want.
 
-IMPORTANT: If you are installing Raspberry Pi OS, and intend to run it headless, you will need to create a new user account. Since you will not be able to create the user account xref:getting-started.adoc#configuration-on-first-boot[using the first-boot wizard] as it requires both a monitor and a keyboard, you *MUST* add a `userconf.txt` file to the boot folder to create a user on first boot or configure the OS with a user account using the xref:getting-started.adoc#advanced-options[Advanced Menu] in the Raspberry Pi Imager.
+image::../getting-started/images/rpi_imager.png[width="80%"]
+
+There are also mechanisms to preconfigure an image without using Imager. To set up a user on first boot and bypass the wizard completely, create a file called userconf or userconf.txt in the boot partition of the SD card; this is the part of the SD card which can be seen when it is mounted in a Windows or MacOS computer.
+
+This file should contain a single line of text, consisting of username:encrypted- password – so your desired username, followed immediately by a colon, followed immediately by an encrypted representation of the password you want to use.
+
+To generate the encrypted password, the easiest way is to use OpenSSL on a Raspberry Pi that is already running – open a terminal window and enter
+
+```bash
+echo 'mypassword' | openssl passwd -6 -stdin
+```
+
+This will produce what looks like a string of random characters, which is actually an encrypted version of the supplied password.
 
 === Configuring Networking
 

--- a/documentation/asciidoc/computers/configuration/headless.adoc
+++ b/documentation/asciidoc/computers/configuration/headless.adoc
@@ -6,21 +6,25 @@ To preconfigure an image like this, when you have selected the source image and 
 
 image::../getting-started/images/rpi_imager.png[width="80%"]
 
+=== Configuring a User without Imager
+
 There are also mechanisms to preconfigure an image without using Imager. To set up a user on first boot and bypass the wizard completely, create a file called userconf or userconf.txt in the boot partition of the SD card; this is the part of the SD card which can be seen when it is mounted in a Windows or MacOS computer.
 
-This file should contain a single line of text, consisting of username:encrypted- password – so your desired username, followed immediately by a colon, followed immediately by an encrypted representation of the password you want to use.
+This file should contain a single line of text, consisting of `username:password` – so your desired username, followed immediately by a colon, followed immediately by an *encrypted* representation of the password you want to use.
 
-To generate the encrypted password, the easiest way is to use OpenSSL on a Raspberry Pi that is already running – open a terminal window and enter
+To generate the encrypted password, the easiest way is to use OpenSSL on a Raspberry Pi that is already running – open a terminal window and enter:
 
-```bash
-echo 'mypassword' | openssl passwd -6 -stdin
-```
+----
+openssl passwd -6
+----
 
-This will produce what looks like a string of random characters, which is actually an encrypted version of the supplied password.
+This will prompt you to enter your password, and verify it. It will then produce what looks like a string of random characters, which is actually an encrypted version of the supplied password.
+
+WARNING: If you are creating this file on Microsoft Windows you should ensure that you do not add a newline to the end of the file. In Windows, lines end with both the line feed and carriage return ASCII characters, but Unix uses only a line feed and treats the additional carriage return character as part of the password hash.
 
 === Configuring Networking
 
-You will need to define a `wpa_supplicant.conf` file for your particular wireless network. Put this file onto the boot folder of the SD card. When the Raspberry Pi boots for the first time, it will copy that file into the correct location in the Linux root file system and use those settings to start up wireless networking.
+Unless defined in the Advanced options menu of the Imager tool, you will need to create a `wpa_supplicant.conf` file for your particular wireless network. Put this file onto the boot folder of the SD card. When the Raspberry Pi boots for the first time, it will copy that file into the correct location in the Linux root file system and use those settings to start up wireless networking.
 
 The Raspberry Pi's IP address will not be visible immediately after power on, so this step is crucial to connect to it headlessly. Depending on the OS and editor you are creating this on, the file could have incorrect newlines or the wrong file extension so make sure you use an editor that accounts for this. Linux expects the line feed (LF) newline character. 
 
@@ -68,19 +72,3 @@ network={
 NOTE: Some older Raspberry Pi boards and some USB wireless dongles do not support 5GHz networks.
 
 NOTE: With no keyboard or monitor, you will need some way of xref:remote-access.adoc[remotely accessing] your headless Raspberry Pi. For headless setup, SSH can be enabled by placing a file named `ssh`, without any extension, onto the boot folder of the SD Card. For more information see the section on xref:remote-access.adoc#ssh[setting up an SSH server].
-
-=== Configuring a User
-
-You will need to add a `userconf.txt` in the boot partition of the SD card; this is the part of the SD card which can be seen when it is mounted in a Windows or MacOS computer.
-
-This file should contain a single line of text, consisting of `username:password` – so your desired username, followed immediately by a colon, followed immediately by an *encrypted* representation of the password you want to use.
-
-To generate the encrypted password, the easiest way is to use OpenSSL on a Raspberry Pi that is already running – open a terminal window and enter:
-
-----
-openssl passwd -6
-----
-
-This will prompt you to enter your password, and verify it. It will then produce what looks like a string of random characters, which is actually an encrypted version of the supplied password.
-
-WARNING: If you are creating this file on Microsoft Windows you should ensure that you do not add a newline to the end of the file. In Windows, lines end with both the line feed and carriage return ASCII characters, but Unix uses only a line feed and treats the additional carriage return character as part of the password hash.

--- a/documentation/asciidoc/computers/remote-access/secure-shell-from-unix.adoc
+++ b/documentation/asciidoc/computers/remote-access/secure-shell-from-unix.adoc
@@ -2,21 +2,29 @@
 
 You can use SSH to connect to your Raspberry Pi from a Linux desktop, another Raspberry Pi, or from an Apple Mac without installing additional software.
 
-Open a terminal window on your computer replacing `<IP>` with the IP address of the Raspberry Pi you're trying to connect to,
+Open a terminal window on your computer replacing `<USERNAME>` with the user name you wish to log into on the Raspberry Pi and `<IP>` with the IP address of the Raspberry Pi you're trying to connect to,
 
 ----
-ssh pi@<IP>
+ssh <USERNAME>@<IP>
+----
+
+For example, if the username is `pi` and the IP address of the Raspberry Pi is `192.168.1.5`, the command would be:
+
+----
+ssh pi@192.168.1.5
 ----
 
 When the connection works you will see a security/authenticity warning. Type `yes` to continue. You will only see this warning the first time you connect.
 
 NOTE: If you receive a `connection timed out` error it is likely that you have entered the wrong IP address for the Raspberry Pi.
 
+NOTE: If you have not logged onto the Raspberry Pi before, with a montior and keyboard plugged in follow xref:getting-started.adoc#configuration-on-first-boot[the first-boot wizard]. If the Raspberry Pi cannot be accessed with a keyboard and a monitor, please refer to xref:configuration.adoc#headless[Setting up a Headless Raspberry Pi]
+
 WARNING: In the event your Raspberry Pi has taken the IP address of a device to which your computer has connected before (even if this was on another network), you may be given a warning and asked to clear the record from your list of known devices. Following this instruction and trying the `ssh` command again should be successful.
 
-Next you will be prompted for the password for the `pi` login: the default password on Raspberry Pi OS is `raspberry`. 
+Next you will be prompted for the password for the user login. The password is not visible while being typed, press enter to submit.
 
-For security reasons it is highly recommended to change the default password on the Raspberry Pi (also, you can not login through ssh if the password is blank). You should now be able to see the Raspberry Pi prompt, which will be identical to the one found on the Raspberry Pi itself.
+You should now be able to see the Raspberry Pi prompt, which will be identical to the one found on the Raspberry Pi itself.
 
 If you have set up another user on the Raspberry Pi, you can connect to it in the same way, replacing the username with your own, e.g. `eben@192.168.1.5`
 

--- a/documentation/asciidoc/computers/remote-access/secure-shell-from-unix.adoc
+++ b/documentation/asciidoc/computers/remote-access/secure-shell-from-unix.adoc
@@ -2,7 +2,7 @@
 
 You can use SSH to connect to your Raspberry Pi from a Linux desktop, another Raspberry Pi, or from an Apple Mac without installing additional software.
 
-Open a terminal window on your computer replacing `<USERNAME>` with the user name you wish to log into on the Raspberry Pi and `<IP>` with the IP address of the Raspberry Pi you're trying to connect to,
+Open a terminal window on your computer. Enter the below command, replacing `<USERNAME>` with the user name you wish to log into on the Raspberry Pi and `<IP>` with the IP address of the Raspberry Pi you're trying to connect to,
 
 ----
 ssh <USERNAME>@<IP>

--- a/documentation/asciidoc/computers/remote-access/secure-shell-from-windows10.adoc
+++ b/documentation/asciidoc/computers/remote-access/secure-shell-from-windows10.adoc
@@ -2,19 +2,27 @@
 
 You can use SSH to connect to your Raspberry Pi from a Windows 10 computer that is using _October 2018 Update_ or later without having to use third-party clients.
 
-Open a terminal window on your computer replacing `<IP>` with the IP address of the Raspberry Pi you're trying to connect to,
+Open a terminal window on your computer. Enter the below command, replacing `<USERNAME>` with the user name you wish to log into on the Raspberry Pi and `<IP>` with the IP address of the Raspberry Pi you're trying to connect to,
 
 ----
-ssh pi@<IP>
+ssh <USERNAME>@<IP>
+----
+
+For example, if the username is `pi` and the IP address of the Raspberry Pi is `192.168.1.5`, the command would be:
+
+----
+ssh pi@192.168.1.5
 ----
 
 When the connection works you will see a security/authenticity warning. Type `yes` to continue. You will only see this warning the first time you connect.
 
 NOTE: If you receive a `connection timed out` error it is likely that you have entered the wrong IP address for the Raspberry Pi.
 
+NOTE: If you have not logged onto the Raspberry Pi before, with a montior and keyboard plugged in follow xref:getting-started.adoc#configuration-on-first-boot[the first-boot wizard]. If the Raspberry Pi cannot be accessed with a keyboard and a monitor, please refer to xref:configuration.adoc#headless[Setting up a Headless Raspberry Pi]
+
 WARNING: In the event your Raspberry Pi has taken the IP address of a device to which your computer has connected before (even if this was on another network), you may be given a warning and asked to clear the record from your list of known devices. Following this instruction and trying the `ssh` command again should be successful.
 
-Next you will be prompted for the password for the `pi` login: the default password on Raspberry Pi OS is `raspberry`. 
+Next you will be prompted for the password for the user login. The password is not visible while being typed, press enter to submit.
 
 For security reasons it is highly recommended to change the default password on the Raspberry Pi (also, you can not login through ssh if the password is blank). You should now be able to see the Raspberry Pi prompt, which will be identical to the one found on the Raspberry Pi itself.
 

--- a/documentation/asciidoc/computers/remote-access/secure-shell.adoc
+++ b/documentation/asciidoc/computers/remote-access/secure-shell.adoc
@@ -5,6 +5,8 @@ You can access the command line of a Raspberry Pi remotely from another computer
 
 You will only have access to the command line, not the full desktop environment. For a full remote desktop, see xref:remote-access.adoc#vnc[VNC].
 
+NOTE: For headless setup, please refer to xref:configuration.adoc#headless[Setting up a Headless Raspberry Pi]
+
 === Set up your Local Network
 
 Make sure your Raspberry Pi is properly set up and connected. If you are using wireless networking, this can be enabled via the desktop user interface, or using from the command line. If you are not using wireless connectivity, plug your Raspberry Pi directly into the router.
@@ -28,7 +30,5 @@ Alternatively you can enable it from the terminal using the xref:configuration.a
 . Choose `Yes`
 . Select `Ok`
 . Choose `Finish`
-
-NOTE: For headless setup, SSH can be enabled by placing a file named `ssh`, without any extension, onto the boot partition of the SD Card. When the Raspberry Pi boots, it looks for the `ssh` file. If it is found, SSH is enabled and the file is deleted. The content of the file does not matter; it could contain text, or nothing at all.
 
 WARNING: When enabling SSH on a Raspberry Pi that may be connected to the internet, you should ensure that your password is not easily brute forced.

--- a/documentation/asciidoc/computers/remote-access/vnc.adoc
+++ b/documentation/asciidoc/computers/remote-access/vnc.adoc
@@ -77,7 +77,7 @@ Cloud connections are convenient and encrypted end-to-end. They are highly recom
 
 To complete either a direct or cloud connection, you must authenticate to VNC Server.
 
-If you're connecting from the https://www.realvnc.com/download/viewer/[compatible VNC Viewer app] from RealVNC, enter the user name and password you normally use to log in to your user account on the Raspberry Pi. By default, these credentials are `pi` and `raspberry`.
+If you're connecting from the https://www.realvnc.com/download/viewer/[compatible VNC Viewer app] from RealVNC, enter the user name and password you normally use to log in to your user account on the Raspberry Pi.
 
 If you're connecting from a non-RealVNC Viewer app, you'll first need to downgrade VNC Server's authentication scheme, specify a password unique to VNC Server, and then enter that instead.
 


### PR DESCRIPTION
Please help me by double checking that I set the links correctly.

I personally spent a decent chunk of time trying to set up my headless raspberry pi, only to find [this article from April](https://www.raspberrypi.com/news/raspberry-pi-bullseye-update-april-2022/). I would like to prevent others from wasting time as well.

Issue: #2537