### PR TITLE
Correct the git repository where we fetch libcamera

### DIFF
--- a/documentation/asciidoc/accessories/camera/libcamera_apps_building.adoc
+++ b/documentation/asciidoc/accessories/camera/libcamera_apps_building.adoc
@@ -64,11 +64,11 @@ In the `meson` commands below we have enabled the _gstreamer_ plugin. If you _do
 sudo apt install -y libglib2.0-dev libgstreamer-plugins-base1.0-dev
 ----
 
-Now we can check out and build `libcamera` itself.
+Now we can check out and build `libcamera` itself. We check out Raspberry Pi's fork of libcamera which tracks the official repository but lets us control exactly when we pick up new features.
 
 ----
 cd
-git clone git://linuxtv.org/libcamera.git
+git clone https://github.com/raspberrypi/libcamera.git
 cd libcamera
 ----
 

--- a/documentation/asciidoc/accessories/camera/libcamera_apps_intro.adoc
+++ b/documentation/asciidoc/accessories/camera/libcamera_apps_intro.adoc
@@ -21,7 +21,7 @@ Raspberry Pi's `libcamera-apps` are not only command line applications that make
 
 `libcamera` is an open source Linux community project. More information is available at the https://libcamera.org[`libcamera` website].
 
-The `libcamera` source code can be found and checked out from the https://git.linuxtv.org/libcamera.git/[official libcamera repository].
+The `libcamera` source code can be found and checked out from the https://git.linuxtv.org/libcamera.git/[official libcamera repository], although we work from a https://github.com/raspberrypi/libcamera.git[fork] that lets us control when we get _libcamera_ updates.
 
 Underneath the `libcamera` core, Raspberry Pi provides a custom _pipeline handler_, which is the layer that `libcamera` uses to drive the sensor and ISP (Image Signal Processor) on the Raspberry Pi itself. Also part of this is a collection of well-known _control algorithms_, or _IPAs_ (Image Processing Algorithms) in `libcamera` parlance, such as AEC/AGC (Auto Exposure/Gain Control), AWB (Auto White Balance), ALSC (Auto Lens Shading Correction) and so on.
 

--- a/documentation/asciidoc/accessories/camera/libcamera_software.adoc
+++ b/documentation/asciidoc/accessories/camera/libcamera_software.adoc
@@ -62,7 +62,7 @@ We can now check out the code and build _libcamera_ as follows. Note that if you
 
 [,bash]
 ----
-git clone git://linuxtv.org/libcamera.git
+git clone https://github.com/raspberrypi/libcamera.git
 cd libcamera
 meson build
 cd build


### PR DESCRIPTION
For a while now we've been building from a Raspberry Pi fork of
libcamera, just so we can control extactly when it changes. The
documentation should reflect this location, not the official libcamera
repo.