### PR TITLE
Fix typo in vcgencmd measure_clock h264 parameter

### DIFF
--- a/documentation/asciidoc/computers/os/graphics-utilities.adoc
+++ b/documentation/asciidoc/computers/os/graphics-utilities.adoc
@@ -155,7 +155,7 @@ This returns the current frequency of the specified clock. The options are:
 | core
 | GPU core
 
-| H264
+| h264
 | H.264 block
 
 | isp


### PR DESCRIPTION
The h264 parameter was incorrectly listed as uppercase. That's not recognized by vcgencmd.

```
# vcgencmd measure_clock H264
H264 frequency(0)=0
# vcgencmd measure_clock h264
h264 frequency(28)=500000992
```