### PR TITLE
Hint to new userconfig file for ssh servers in headless setups.

### DIFF
--- a/documentation/asciidoc/computers/configuration/headless.adoc
+++ b/documentation/asciidoc/computers/configuration/headless.adoc
@@ -57,6 +57,7 @@ NOTE: Some older Raspberry Pi boards and some USB wireless dongles do not suppor
 
 NOTE: With no keyboard or monitor, you will need some way of xref:remote-access.adoc[remotely accessing] your headless Raspberry Pi. For headless setup, SSH can be enabled by placing a file named `ssh`, without any extension, onto the boot folder of the SD Card. For more information see the section on xref:remote-access.adoc#ssh[setting up an SSH server].
 
+[[configuring-a-user]]
 === Configuring a User
 
 You will need to add a `userconf.txt` in the boot partition of the SD card; this is the part of the SD card which can be seen when it is mounted in a Windows or MacOS computer.

--- a/documentation/asciidoc/computers/remote-access/secure-shell.adoc
+++ b/documentation/asciidoc/computers/remote-access/secure-shell.adoc
@@ -20,7 +20,7 @@ Raspberry Pi OS has the SSH server disabled by default. It can be enabled manual
 . Select `Enabled` next to `SSH`
 . Click `OK`
 
-Alternatively you can enable it from the terminal using the xref:configuration.adoc#configuring-a-user[Configuring a User] application,
+Alternatively you can enable it from the terminal using the xref:configuration.adoc#raspi-config[raspi-config] application,
 
 . Enter `sudo raspi-config` in a terminal window
 . Select `Interfacing Options`

--- a/documentation/asciidoc/computers/remote-access/secure-shell.adoc
+++ b/documentation/asciidoc/computers/remote-access/secure-shell.adoc
@@ -31,4 +31,6 @@ Alternatively you can enable it from the terminal using the xref:configuration.a
 
 NOTE: For headless setup, SSH can be enabled by placing a file named `ssh`, without any extension, onto the boot partition of the SD Card. When the Raspberry Pi boots, it looks for the `ssh` file. If it is found, SSH is enabled and the file is deleted. The content of the file does not matter; it could contain text, or nothing at all.
 
+NOTE: For headless setup, additional to the `ssh`-file, you need a `userconfig`-file, which contains a string `username:encryptedpassword`. This security feature was introduced in april 20222. Please refer to xref:headless.adoc#configuring-a-user[Configuring a User].
+
 WARNING: When enabling SSH on a Raspberry Pi that may be connected to the internet, you should ensure that your password is not easily brute forced.

--- a/documentation/asciidoc/computers/remote-access/secure-shell.adoc
+++ b/documentation/asciidoc/computers/remote-access/secure-shell.adoc
@@ -20,7 +20,7 @@ Raspberry Pi OS has the SSH server disabled by default. It can be enabled manual
 . Select `Enabled` next to `SSH`
 . Click `OK`
 
-Alternatively you can enable it from the terminal using the xref:configuration.adoc#raspi-config[raspi-config] application,
+Alternatively you can enable it from the terminal using the xref:configuration.adoc#configuring-a-user[Configuring a User] application,
 
 . Enter `sudo raspi-config` in a terminal window
 . Select `Interfacing Options`
@@ -31,6 +31,6 @@ Alternatively you can enable it from the terminal using the xref:configuration.a
 
 NOTE: For headless setup, SSH can be enabled by placing a file named `ssh`, without any extension, onto the boot partition of the SD Card. When the Raspberry Pi boots, it looks for the `ssh` file. If it is found, SSH is enabled and the file is deleted. The content of the file does not matter; it could contain text, or nothing at all.
 
-NOTE: For headless setup, additional to the `ssh`-file, you need a `userconfig`-file, which contains a string `username:encryptedpassword`. Please refer to xref:headless.adoc#configuring-a-user[Configuring a User].
+NOTE: For headless setup, additional to the `ssh`-file, you need a `userconfig`-file, which contains a string `username:encryptedpassword`. Please refer to xref:configuration.adoc#headless[Setting up a Headless Raspberry Pi].
 
 WARNING: When enabling SSH on a Raspberry Pi that may be connected to the internet, you should ensure that your password is not easily brute forced.

--- a/documentation/asciidoc/computers/remote-access/secure-shell.adoc
+++ b/documentation/asciidoc/computers/remote-access/secure-shell.adoc
@@ -31,6 +31,6 @@ Alternatively you can enable it from the terminal using the xref:configuration.a
 
 NOTE: For headless setup, SSH can be enabled by placing a file named `ssh`, without any extension, onto the boot partition of the SD Card. When the Raspberry Pi boots, it looks for the `ssh` file. If it is found, SSH is enabled and the file is deleted. The content of the file does not matter; it could contain text, or nothing at all.
 
-NOTE: For headless setup, additional to the `ssh`-file, you need a `userconfig`-file, which contains a string `username:encryptedpassword`. This security feature was introduced in april 20222. Please refer to xref:headless.adoc#configuring-a-user[Configuring a User].
+NOTE: For headless setup, additional to the `ssh`-file, you need a `userconfig`-file, which contains a string `username:encryptedpassword`. Please refer to xref:headless.adoc#configuring-a-user[Configuring a User].
 
 WARNING: When enabling SSH on a Raspberry Pi that may be connected to the internet, you should ensure that your password is not easily brute forced.

--- a/documentation/asciidoc/computers/remote-access/secure-shell.adoc
+++ b/documentation/asciidoc/computers/remote-access/secure-shell.adoc
@@ -31,6 +31,6 @@ Alternatively you can enable it from the terminal using the xref:configuration.a
 
 NOTE: For headless setup, SSH can be enabled by placing a file named `ssh`, without any extension, onto the boot partition of the SD Card. When the Raspberry Pi boots, it looks for the `ssh` file. If it is found, SSH is enabled and the file is deleted. The content of the file does not matter; it could contain text, or nothing at all.
 
-NOTE: For headless setup, additional to the `ssh`-file, you need a `userconfig`-file, which contains a string `username:encryptedpassword`. Please refer to xref:configuration.adoc#configuring-a-user[Configuring a User].
+NOTE: For headless setup in addition to the `ssh`-file you need a `userconfig`-file, which contains a string `username:encryptedpassword`. Please refer to the section on xref:configuration.adoc#configuring-a-user[configuring a user] in the discussions around headless setup of a Raspberry Pi.
 
 WARNING: When enabling SSH on a Raspberry Pi that may be connected to the internet, you should ensure that your password is not easily brute forced.

--- a/documentation/asciidoc/computers/remote-access/secure-shell.adoc
+++ b/documentation/asciidoc/computers/remote-access/secure-shell.adoc
@@ -31,6 +31,6 @@ Alternatively you can enable it from the terminal using the xref:configuration.a
 
 NOTE: For headless setup, SSH can be enabled by placing a file named `ssh`, without any extension, onto the boot partition of the SD Card. When the Raspberry Pi boots, it looks for the `ssh` file. If it is found, SSH is enabled and the file is deleted. The content of the file does not matter; it could contain text, or nothing at all.
 
-NOTE: For headless setup, additional to the `ssh`-file, you need a `userconfig`-file, which contains a string `username:encryptedpassword`. Please refer to xref:configuration.adoc#headless[Setting up a Headless Raspberry Pi].
+NOTE: For headless setup, additional to the `ssh`-file, you need a `userconfig`-file, which contains a string `username:encryptedpassword`. Please refer to xref:configuration.adoc#configuring-a-user[Configuring a User].
 
 WARNING: When enabling SSH on a Raspberry Pi that may be connected to the internet, you should ensure that your password is not easily brute forced.


### PR DESCRIPTION
The new headless setup was introduced into the documentation.
But this hint was missing in the ssh-server section. 

A user just looking into the ssh-server part does not know about this new feature, which was introduced april 2022.