### PR TITLE
device-tree.adoc: clarify which built-in USB controller

### DIFF
--- a/documentation/asciidoc/computers/configuration/device-tree.adoc
+++ b/documentation/asciidoc/computers/configuration/device-tree.adoc
@@ -842,7 +842,7 @@ The UTC build time for the EEPROM bootloader.
 
 `capabilities` - 32-bit integer
 
-This bit field describes the features supported by the current bootloader; it may be used to check whether a feature is supported before enabling it in the bootloader EEPROM config.
+This bit field indicates the features supported by the current bootloader; it may be used to check whether a feature is supported before enabling it in the bootloader EEPROM config.
 
 |===
 | Bit | Feature

--- a/documentation/asciidoc/computers/configuration/device-tree.adoc
+++ b/documentation/asciidoc/computers/configuration/device-tree.adoc
@@ -860,7 +860,7 @@ This bit field, which describes the features supported by the current bootloader
 | xref:raspberry-pi.adoc#fail-safe-os-updates-tryboot[TRYBOOT]
 
 | 4
-| xref:raspberry-pi.adoc#usb-mass-storage-boot[USB boot] using the BCM2711 USB host controller.
+| xref:raspberry-pi.adoc#usb-mass-storage-boot[USB boot] using the built-in xHCI USB host controller.
 
 | 5
 | xref:raspberry-pi.adoc#boot_ramdisk[RAM disk - boot.img]

--- a/documentation/asciidoc/computers/configuration/device-tree.adoc
+++ b/documentation/asciidoc/computers/configuration/device-tree.adoc
@@ -842,7 +842,7 @@ The UTC build time for the EEPROM bootloader.
 
 `capabilities` - 32-bit integer
 
-This bit field, which describes the features supported by the current bootloader. This may be used to check whether a feature (e.g. USB boot) is supported before enabling it in the bootloader EEPROM config.
+This bit field describes the features supported by the current bootloader; it may be used to check whether a feature is supported before enabling it in the bootloader EEPROM config.
 
 |===
 | Bit | Feature

--- a/documentation/asciidoc/computers/configuration/device-tree.adoc
+++ b/documentation/asciidoc/computers/configuration/device-tree.adoc
@@ -860,7 +860,7 @@ This bit field, which describes the features supported by the current bootloader
 | xref:raspberry-pi.adoc#fail-safe-os-updates-tryboot[TRYBOOT]
 
 | 4
-| xref:raspberry-pi.adoc#usb-mass-storage-boot[USB boot] using the built-in xHCI USB host controller.
+| xref:raspberry-pi.adoc#usb-mass-storage-boot[USB boot] using the BCM2711's built-in xHCI host controller.
 
 | 5
 | xref:raspberry-pi.adoc#boot_ramdisk[RAM disk - boot.img]


### PR DESCRIPTION
BCM2711 contains two USB controllers, so be more specific about which one we're talking about.