### PR TITLE
Add note for libcamera2 in GPU mem section

### DIFF
--- a/documentation/asciidoc/computers/config_txt/memory.adoc
+++ b/documentation/asciidoc/computers/config_txt/memory.adoc
@@ -24,8 +24,10 @@ The recommended maximum values are as follows:
 | `384`
 
 | 1GB or greater
-| `512`, `256` on the Raspberry Pi 4
+| `512`, `76` on the Raspberry Pi 4
 |===
+
+IMPORTANT: The default camera stack (libcamera2) on Raspberry Pi OS - Bullseye uses Linux CMA memory to allocate buffers instead of GPU memory so there is no benefit in increasing the GPU memory size.
 
 It is possible to set `gpu_mem` to larger values, however this should be avoided since it can cause problems, such as preventing Linux from booting. The minimum value is `16`, however this disables certain GPU features.
 


### PR DESCRIPTION
Note that libcamera2 doesn't use GPU memory so there really is no point in increasing the GPU memory size.