### PR TITLE
doc: update pinout availability in lite OS

### DIFF
--- a/documentation/asciidoc/computers/os/using-gpio.adoc
+++ b/documentation/asciidoc/computers/os/using-gpio.adoc
@@ -40,7 +40,7 @@ As well as simple input and output devices, the GPIO pins can be used with a var
 
 === GPIO pinout
 
-A handy reference can be accessed on the Raspberry Pi by opening a terminal window and running the command `pinout`. This tool is provided by the https://gpiozero.readthedocs.io/[GPIO Zero] Python library, which is installed by default on the Raspberry Pi OS desktop image, but not on Raspberry Pi OS Lite.
+A handy reference can be accessed on the Raspberry Pi by opening a terminal window and running the command `pinout`. This tool is provided by the https://gpiozero.readthedocs.io/[GPIO Zero] Python library, which is installed by default on the Raspberry Pi OS.
 
 image::images/gpiozero-pinout.png[]
 


### PR DESCRIPTION
Just installed the latest version of the Lite OS as of this writing, didn't install anything extra (going through this guide for the first time) and the GPIO Zero and `pinout` were already available ;)