### PR TITLE
Fix link to Pico W blink example in github.

### DIFF
--- a/documentation/asciidoc/microcontrollers/c_sdk/your_first_binary.adoc
+++ b/documentation/asciidoc/microcontrollers/c_sdk/your_first_binary.adoc
@@ -17,7 +17,7 @@ You can blink this on and off by,
 
 You should see the on-board LED blinking.
 
-You can see the code on Github for the https://github.com/raspberrypi/pico-examples/blob/master/blink/blink.c[Raspberry Pi Pico] and https://github.com/raspberrypi/pico-examples/blob/master/pico_w/blink/picow_blink.c[Pico W] versions.
+You can see the code on Github for the https://github.com/raspberrypi/pico-examples/blob/master/blink/blink.c[Raspberry Pi Pico] and https://github.com/raspberrypi/pico-examples/blob/master/pico_w/wifi/blink/picow_blink.c[Pico W] versions.
 
 === Say "Hello World"
 


### PR DESCRIPTION
This file was moved to a "wifi" subfolder.