### PR TITLE
Check Python dependency updates with Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,11 @@ updates:
     target-branch: "develop"
   - package-ecosystem: "github-actions"
     directory: "/"
-    schedule: 
-      interval: weekly
-    target-branch: develop
+    schedule:
+      interval: "weekly"
+    target-branch: "develop"
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    target-branch: "develop"


### PR DESCRIPTION
As we install Python dependencies using a requirements.txt, add this to our Dependabot configuration so GitHub can alert us to new versions.
