### PR TITLE
Add explanation of datetime options in libcamera apps post processing using opencv_annotate stage

### DIFF
--- a/documentation/asciidoc/computers/camera/libcamera_apps_post_processing_opencv.adoc
+++ b/documentation/asciidoc/computers/camera/libcamera_apps_post_processing_opencv.adoc
@@ -71,7 +71,7 @@ image::images/face_detect.jpg[Image showing faces]
 
 This stage allows text to be written into the top corner of images. It allows the same `%` substitutions as the `--info-text` parameter.
 
-Additionally to the flags of xref::libcamera_options_common.adoc#preview-window-2[`--info-text`] you can provide any token that https://www.man7.org/linux/man-pages/man3/strftime.3.html[strftime] understands to display the current date / time.
+Additionally to the flags of xref:camera_software.adoc#preview-window-2[`--info-text`] you can provide any token that https://www.man7.org/linux/man-pages/man3/strftime.3.html[strftime] understands to display the current date / time.
 The `--info-texttokens are interpreted first and any percentage token left is then interpreted by strftime. To achieve a datetime stamp on the video you can use e.g. `%F %T %z` (%F for the ISO-8601 date (2023-03-07), %T for 24h local time (09:57:12) and %z for the timezone difference to UTC (-0800)).
 
 The stage does not output any metadata, but if it finds metadata under the key "annotate.text" it will write this text in place of anything in the JSON configuration file. This allows other post-processing stages to pass it text strings to be written onto the top of the images.

--- a/documentation/asciidoc/computers/camera/libcamera_apps_post_processing_opencv.adoc
+++ b/documentation/asciidoc/computers/camera/libcamera_apps_post_processing_opencv.adoc
@@ -71,7 +71,7 @@ image::images/face_detect.jpg[Image showing faces]
 
 This stage allows text to be written into the top corner of images. It allows the same `%` substitutions as the `--info-text` parameter.
 
-Additionally to the flags of xref:libcamera_options_common.adoc#preview-window-2[`--info-text`] you can provide any token that https://www.man7.org/linux/man-pages/man3/strftime.3.html[strftime] understands to display the current date / time.
+Additionally to the flags of xref::libcamera_options_common.adoc#preview-window-2[`--info-text`] you can provide any token that https://www.man7.org/linux/man-pages/man3/strftime.3.html[strftime] understands to display the current date / time.
 The `--info-texttokens are interpreted first and any percentage token left is then interpreted by strftime. To achieve a datetime stamp on the video you can use e.g. `%F %T %z` (%F for the ISO-8601 date (2023-03-07), %T for 24h local time (09:57:12) and %z for the timezone difference to UTC (-0800)).
 
 The stage does not output any metadata, but if it finds metadata under the key "annotate.text" it will write this text in place of anything in the JSON configuration file. This allows other post-processing stages to pass it text strings to be written onto the top of the images.

--- a/documentation/asciidoc/computers/camera/libcamera_apps_post_processing_opencv.adoc
+++ b/documentation/asciidoc/computers/camera/libcamera_apps_post_processing_opencv.adoc
@@ -71,6 +71,9 @@ image::images/face_detect.jpg[Image showing faces]
 
 This stage allows text to be written into the top corner of images. It allows the same `%` substitutions as the `--info-text` parameter.
 
+Additionally to the flags of xref:libcamera_options_common.adoc#preview-window-2[`--info-text`] you can provide any token that https://www.man7.org/linux/man-pages/man3/strftime.3.html[strftime] understands to display the current date / time.
+The `--info-texttokens are interpreted first and any percentage token left is then interpreted by strftime. To achieve a datetime stamp on the video you can use e.g. `%F %T %z` (%F for the ISO-8601 date (2023-03-07), %T for 24h local time (09:57:12) and %z for the timezone difference to UTC (-0800)).
+
 The stage does not output any metadata, but if it finds metadata under the key "annotate.text" it will write this text in place of anything in the JSON configuration file. This allows other post-processing stages to pass it text strings to be written onto the top of the images.
 
 The `annotate_cv` stage has the following user-configurable parameters:


### PR DESCRIPTION
Hi there, I've noticed that the libcamera apps documentation was missing the feature to embed time information using opencv on images and videos in a post processing step.
The feature was [added last year in May](https://github.com/raspberrypi/libcamera-apps/commit/6582a730b059f086552414b034c90688cca047eb).
