### PR TITLE
Hide email obfuscator spans

### DIFF
--- a/jekyll-assets/css/style.css
+++ b/jekyll-assets/css/style.css
@@ -643,6 +643,10 @@ p.see span.label {
   margin-right: 5px;
 }
 
+span.obfuscator {
+  display: none;
+}
+
 /* LEGAL */
 
 div.legal {


### PR DESCRIPTION
The doxygen source appears to use some email obfuscator spans. I decided to leave them in the content but hide them via CSS. Fixes #2808 