### PR TITLE
Rank search results in same section more highly

### DIFF
--- a/jekyll-assets/_includes/search.html
+++ b/jekyll-assets/_includes/search.html
@@ -1,9 +1,23 @@
 <script src="https://cdn.jsdelivr.net/npm/@docsearch/js@alpha"></script>
 <script type="text/javascript">
-  docsearch({
-    appId: 'IHWGNTJ1NP',
-    apiKey: '94f8e1d1619229399fe8b33bcf750dfd',
-    indexName: 'raspberrypi',
-    container: '#docsearch'
-  });
+  (function () {
+    var lvl0 = document.querySelector('#tab-menu li.selected'),
+        lvl1 = document.querySelector('#content h1'),
+        searchParameters = { optionalFilters: [] };
+
+    if (lvl0) {
+      searchParameters.optionalFilters.push("hierarchy.lvl0:" + lvl0.innerText);
+    }
+    if (lvl1) {
+      searchParameters.optionalFilters.push("hierarchy.lvl1:" + lvl1.innerText + "<score=2>");
+    }
+
+    docsearch({
+      appId: 'IHWGNTJ1NP',
+      apiKey: '94f8e1d1619229399fe8b33bcf750dfd',
+      indexName: 'raspberrypi',
+      container: '#docsearch',
+      searchParameters: searchParameters
+    });
+  }());
 </script>


### PR DESCRIPTION
Now the documentation site search index contains over 3,000 records, improve the usability of search by ranking results that occur in the same section more highly.

Specifically, we extract the top two levels of the current page's hierarchy as optional filters to our search (see https://www.algolia.com/doc/api-reference/api-parameters/optionalFilters/):

1. The currently selected top-level tab (e.g. "Computers", "Pico C SDK")
2. The title of the current page (e.g. "Getting started", "Hardware APIs")

We use Algolia's filter scoring syntax (see https://www.algolia.com/doc/guides/managing-results/rules/merchandising-and-promoting/in-depth/optional-filters/#filter-scoring) to rank the current page title more highly than the top-level.
