### PR TITLE
Matching previous sdk docs formatting: fixes #2809

### DIFF
--- a/jekyll-assets/css/style.css
+++ b/jekyll-assets/css/style.css
@@ -616,6 +616,10 @@ td.paramname {
   font-weight: bold;
 }
 
+table.memname td, table.memname td.paramname {
+  vertical-align: bottom;
+}
+
 ul.memberdecls {
   list-style-type: none;
   padding-left: 0;


### PR DESCRIPTION
@lurch I went ahead a matched the previous formatting from the sdk docs. Here's how it looked in the old site:

<img width="1103" alt="Screen Shot 2023-03-14 at 10 14 02 AM" src="https://user-images.githubusercontent.com/812739/225085310-389ae48a-1acb-4ce6-99a0-da3a376a531b.png">

And here's the new formatting in this PR:

<img width="877" alt="Screen Shot 2023-03-14 at 10 14 11 AM" src="https://user-images.githubusercontent.com/812739/225085410-522f29e2-e6f1-406a-9db5-c468af1ebbba.png">
