### PR TITLE
Hide sass deprecation warnings until minima release

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -36,6 +36,7 @@ destination: documentation/html
 
 sass:
     sass_dir: css
+    quiet_deps: true
 
 # Exclude from processing.
 # The following items will not be processed, by default. Create a custom list


### PR DESCRIPTION
This suppresses the sass deprecation warnings mentioned in #2825 . They should get resolved once minima makes their next release, so we should keep an eye on that and might be able to remove this line in the jekyll config once we upgrade.