### PR TITLE
boot-eeprom-rpi4.adoc  Clarify that "Compute Module 4" also includes Compute Module 4S

### DIFF
--- a/documentation/asciidoc/computers/raspberry-pi/boot-eeprom-rpi4.adoc
+++ b/documentation/asciidoc/computers/raspberry-pi/boot-eeprom-rpi4.adoc
@@ -1,6 +1,6 @@
 == Raspberry Pi 4 Boot EEPROM
 
-Raspberry Pi 4, 400 and Compute Module 4 computers use an EEPROM to boot the system. All other models of Raspberry Pi computer use the `bootcode.bin` file located in the boot filesystem.
+Raspberry Pi 4, 400, Compute Module 4, and Compute Module 4S computers use an EEPROM to boot the system. All other models of Raspberry Pi computer use the `bootcode.bin` file located in the boot filesystem.
 
 NOTE: The scripts and pre-compiled binaries used to create the `rpi-eeprom` package which is used to update the Raspberry Pi 4 bootloader and VLI USB controller EEPROMs is available https://github.com/raspberrypi/rpi-eeprom/[on Github].
 


### PR DESCRIPTION
The way this is currently worded, it is ambiguous as to whether this feature is also available on the CM4S.  This edit makes that explicit to remove the ambiguity.