### PR TITLE
Update arm_64bit documentation to match reality

### DIFF
--- a/documentation/asciidoc/computers/config_txt/boot.adoc
+++ b/documentation/asciidoc/computers/config_txt/boot.adoc
@@ -41,7 +41,11 @@ Set the `disable_commandline_tags` command to `1` to stop `start.elf` from filli
 
 === `arm_64bit`
 
-If set to non-zero, forces the kernel loading system to assume a 64-bit kernel, starts the processors up in 64-bit mode, and sets `kernel8.img` to be the kernel image loaded, unless there is an explicit `kernel` option defined in which case that is used instead. Defaults to 0 on all platforms. 
+If set to 1, the kernel will be started in 64-bit mode. Setting to 0 selects 32-bit mode.
+
+In 64-bit mode, the firmware will choose an appropriate kernel (e.g. `kernel8.img`), unless there is an explicit `kernel` option defined, in which case that is used instead.
+
+Defaults to 1 on Pi 4s (Pi 4B Pi 400, CM4 and CM4S), and 0 on all other platforms. However, if the name given in an explicit `kernel` option matches one of the known kernels then `arm_64bit` will be set accordingly.
 
 NOTE: 64-bit kernels may be uncompressed image files or a gzip archive of an image (which can still be called kernel8.img; the bootloader will recognize the archive from the signature bytes at the beginning).
 


### PR DESCRIPTION
Current firmware defaults Pi 4s to arm_64bit=1, so the documentation needs updating.