### PR TITLE
Correct UART capabilities

### DIFF
--- a/documentation/asciidoc/computers/configuration/uart.adoc
+++ b/documentation/asciidoc/computers/configuration/uart.adoc
@@ -224,6 +224,7 @@ The particular deficiencies of the mini UART compared to a PL011 are :
 * No framing errors detection
 * No parity bit
 * No receive timeout interrupt
-* No DCD, DSR, DTR or RI signals
+
+Neither tbe mini UART nor the BCM2835 implementation of the PL011 have DCD, DSR, DTR or RI signals.
 
 Further documentation on the mini UART can be found in the https://datasheets.raspberrypi.com/bcm2835/bcm2835-peripherals.pdf[SoC peripherals document].


### PR DESCRIPTION
The SoC documentation contrasts the mini UART capabilities with that of a fully-featured UART, but the onboard PL011 is not one of them, as explained elsewhere in the PL011 section of the SoC.