### PR TITLE
Add note regarding cut-down firmware

### DIFF
--- a/documentation/asciidoc/computers/config_txt/boot.adoc
+++ b/documentation/asciidoc/computers/config_txt/boot.adoc
@@ -7,7 +7,7 @@ These options specify the firmware files transferred to the VideoCore GPU prior 
 `start_file` specifies the VideoCore firmware file to use.
 `fixup_file` specifies the file used to fix up memory locations used in the `start_file` to match the GPU memory split. Note that the `start_file` and the `fixup_file` are a matched pair - using unmatched files will stop the board from booting. This is an advanced option, so we advise that you use `start_x` and `start_debug` rather than this option.
 
-Note that the cut-down firmware (`start*cd.elf` and `fixup*cd.dat`) cannot be selected this way - the system will fail to boot.  The only way to enable the cut-down firmware is to specify `gpu_mem=16`.
+NOTE: Cut-down firmware (`start*cd.elf` and `fixup*cd.dat`) cannot be selected this way - the system will fail to boot.  The only way to enable the cut-down firmware is to specify `gpu_mem=16`.
 
 === `start_x`, `start_debug`
 

--- a/documentation/asciidoc/computers/config_txt/boot.adoc
+++ b/documentation/asciidoc/computers/config_txt/boot.adoc
@@ -7,7 +7,7 @@ These options specify the firmware files transferred to the VideoCore GPU prior 
 `start_file` specifies the VideoCore firmware file to use.
 `fixup_file` specifies the file used to fix up memory locations used in the `start_file` to match the GPU memory split. Note that the `start_file` and the `fixup_file` are a matched pair - using unmatched files will stop the board from booting. This is an advanced option, so we advise that you use `start_x` and `start_debug` rather than this option.
 
-NOTE: Cut-down firmware (`start*cd.elf` and `fixup*cd.dat`) cannot be selected this way - the system will fail to boot.  The only way to enable the cut-down firmware is to specify `gpu_mem=16`.
+NOTE: Cut-down firmware (`start*cd.elf` and `fixup*cd.dat`) cannot be selected this way - the system will fail to boot.  The only way to enable the cut-down firmware is to specify `gpu_mem=16`. The cut-down firmware removes support for cameras, codecs and (deprecated, firmware side) 3D as well as limiting the initial early-boot simple framebuffer to 1080p @  16bpp - although KMS can replace this with up-to 32bpp 4K framebuffer(s) at a later stage as with any firmware.
 
 === `start_x`, `start_debug`
 

--- a/documentation/asciidoc/computers/config_txt/boot.adoc
+++ b/documentation/asciidoc/computers/config_txt/boot.adoc
@@ -7,6 +7,8 @@ These options specify the firmware files transferred to the VideoCore GPU prior 
 `start_file` specifies the VideoCore firmware file to use.
 `fixup_file` specifies the file used to fix up memory locations used in the `start_file` to match the GPU memory split. Note that the `start_file` and the `fixup_file` are a matched pair - using unmatched files will stop the board from booting. This is an advanced option, so we advise that you use `start_x` and `start_debug` rather than this option.
 
+Note that the cut-down firmware (`start*cd.elf` and `fixup*cd.dat`) cannot be selected this way - the system will fail to boot.  The only way to enable the cut-down firmware is to specify `gpu_mem=16`.
+
 === `start_x`, `start_debug`
 
 These provide a shortcut to some alternative `start_file` and `fixup_file` settings, and are the recommended methods for selecting firmware configurations.

--- a/documentation/asciidoc/computers/config_txt/boot.adoc
+++ b/documentation/asciidoc/computers/config_txt/boot.adoc
@@ -7,7 +7,7 @@ These options specify the firmware files transferred to the VideoCore GPU prior 
 `start_file` specifies the VideoCore firmware file to use.
 `fixup_file` specifies the file used to fix up memory locations used in the `start_file` to match the GPU memory split. Note that the `start_file` and the `fixup_file` are a matched pair - using unmatched files will stop the board from booting. This is an advanced option, so we advise that you use `start_x` and `start_debug` rather than this option.
 
-NOTE: Cut-down firmware (`start*cd.elf` and `fixup*cd.dat`) cannot be selected this way - the system will fail to boot.  The only way to enable the cut-down firmware is to specify `gpu_mem=16`. The cut-down firmware removes support for cameras, codecs and (deprecated, firmware side) 3D as well as limiting the initial early-boot simple framebuffer to 1080p @  16bpp - although KMS can replace this with up-to 32bpp 4K framebuffer(s) at a later stage as with any firmware.
+NOTE: Cut-down firmware (`start*cd.elf` and `fixup*cd.dat`) cannot be selected this way - the system will fail to boot.  The only way to enable the cut-down firmware is to specify `gpu_mem=16`. The cut-down firmware removes support for cameras, codecs and 3D as well as limiting the initial early-boot framebuffer to 1080p @  16bpp - although KMS can replace this with up-to 32bpp 4K framebuffer(s) at a later stage as with any firmware.
 
 === `start_x`, `start_debug`
 


### PR DESCRIPTION
As per https://github.com/raspberrypi/firmware/issues/1809.

I was wondering whether `gpu_mem` in this change should be a link to https://www.raspberrypi.com/documentation/computers/config_txt.html#gpu_mem, but I couldn't figure out how to represent this is asciidoc markup (and even then, I'm not sure it would work within backticks?).

I've assumed that `start*cd.elf` is preferable to `start?cd.elf` (I think this representation is used elsewhere in the docs).