### PR TITLE
Clarify shared conditional filter documentation

### DIFF
--- a/documentation/asciidoc/computers/config_txt/conditional.adoc
+++ b/documentation/asciidoc/computers/config_txt/conditional.adoc
@@ -47,7 +47,7 @@ The conditional model filters are applied according to the following table.
 | Zero W (also sees `[pi0]` contents)
 
 | `[pi02]`
-| Zero 2 W (also sees `[pi0]` contents)
+| Zero 2 W (also sees `[pi0w]` and `[pi0]` contents)
 
 | `[board-type=Type]`
 | Filter by `Type` number - see xref:raspberry-pi.adoc#raspberry-pi-revision-codes[Raspberry Pi Revision Codes] E.g `[board-type=0x14]` would match CM4.
@@ -66,7 +66,7 @@ These are particularly useful for defining different `kernel`, `initramfs`, and 
 
 Remember to use the `[all]` filter at the end, so that any subsequent settings aren't limited to Raspberry Pi 2 hardware only.
 
-NOTE: A Raspberry Pi Zero W will see the contents of `[pi0w]` *and* `[pi0]`. Likewise, Raspberry Pi 3B+ see `[pi3+]` *and* `[pi3]` sections, Raspberry Pi 400 see `[pi400]` *and* `[pi4]` sections, Raspberry Pi Compute Module 4 see `[cm4]` *and* `[pi4]` sections and Raspberry Pi Compute Module 4S see `[cm4s]` *and* `[pi4]` sections. If you want a setting to apply _only_ to a Raspberry Pi Zero, Raspberry Pi 3B, or Raspberry Pi 4B then you need to follow it - the ordering is significant - with a setting in a `[pi0w]`, `[pi3+]`, `[pi400]`, `[cm4]` or `[cm4s]` section which reverts the shared setting.
+NOTE: A Raspberry Pi Zero W will see the contents of `[pi0w]` *and* `[pi0]` sections (and a Zero 2 W will see any `[pi02]` sections also). Likewise, Raspberry Pi 3B+ see `[pi3+]` *and* `[pi3]` sections, Raspberry Pi 400 see `[pi400]` *and* `[pi4]` sections, Raspberry Pi Compute Module 4 see `[cm4]` *and* `[pi4]` sections and Raspberry Pi Compute Module 4S see `[cm4s]` *and* `[pi4]` sections. If you want a setting to apply _only_ to a Raspberry Pi Zero, Raspberry Pi Zero W, Raspberry Pi 3B, or Raspberry Pi 4B then you need to follow it - the ordering is significant - with a setting in a `[pi0w]`, `[pi02]`, `[pi3+]`, `[pi400]`, `[cm4]` or `[cm4s]` section which reverts the shared setting.
 
 === The `[none]` filter
 

--- a/documentation/asciidoc/computers/config_txt/conditional.adoc
+++ b/documentation/asciidoc/computers/config_txt/conditional.adoc
@@ -66,7 +66,7 @@ These are particularly useful for defining different `kernel`, `initramfs`, and 
 
 Remember to use the `[all]` filter at the end, so that any subsequent settings aren't limited to Raspberry Pi 2 hardware only.
 
-NOTE: Some models of Raspberry Pi (Zero W, Zero 2 W, Model 3B+, Pi 400, Compute Module 4 and Compute Module 4S) see the settings for multiple filters (as listed in the table above). This means that if want a setting to apply only to, e.g., a Model 4B without _also_ applying that setting to a Pi 400, then the setting in the `[pi4]` section would need to be reverted by an alternate setting in a following `[pi400]` section - the ordering of such sections is significant. Alternatively, you could use a `[board-type=0x11]` filter which has a one-to-one mapping to different hardware products.
+NOTE: Some models of Raspberry Pi (Zero W, Zero 2 W, Model 3B+, Pi 400, Compute Module 4 and Compute Module 4S) see the settings for multiple filters (as listed in the table above). This means that if you want a setting to apply only to (e.g.) a Model 4B without _also_ applying that setting to a Pi 400 then the setting in the `[pi4]` section would need to be reverted by an alternate setting in a following `[pi400]` section - the ordering of such sections is significant. Alternatively, you could use a `[board-type=0x11]` filter which has a one-to-one mapping to different hardware products.
 
 === The `[none]` filter
 

--- a/documentation/asciidoc/computers/config_txt/conditional.adoc
+++ b/documentation/asciidoc/computers/config_txt/conditional.adoc
@@ -66,7 +66,7 @@ These are particularly useful for defining different `kernel`, `initramfs`, and 
 
 Remember to use the `[all]` filter at the end, so that any subsequent settings aren't limited to Raspberry Pi 2 hardware only.
 
-NOTE: A Raspberry Pi Zero W will see the contents of `[pi0w]` *and* `[pi0]` sections (and a Zero 2 W will see any `[pi02]` sections also). Likewise, Raspberry Pi 3B+ see `[pi3+]` *and* `[pi3]` sections, Raspberry Pi 400 see `[pi400]` *and* `[pi4]` sections, Raspberry Pi Compute Module 4 see `[cm4]` *and* `[pi4]` sections and Raspberry Pi Compute Module 4S see `[cm4s]` *and* `[pi4]` sections. If you want a setting to apply _only_ to a Raspberry Pi Zero, Raspberry Pi Zero W, Raspberry Pi 3B, or Raspberry Pi 4B then you need to follow it - the ordering is significant - with a setting in a `[pi0w]`, `[pi02]`, `[pi3+]`, `[pi400]`, `[cm4]` or `[cm4s]` section which reverts the shared setting.
+NOTE: Some models of Raspberry Pi (Zero W, Zero 2 W, Model 3B+, Pi 400, Compute Module 4 and Compute Module 4S) see the settings for multiple filters (as listed in the table above). This means that if want a setting to apply only to, e.g., a Model 4B without _also_ applying that setting to a Pi 400, then the setting in the `[pi4]` section would need to be reverted by an alternate setting in a following `[pi400]` section - the ordering of such sections is significant. Alternatively, you could use a `[board-type=0x11]` filter which has a one-to-one mapping to different hardware products.
 
 === The `[none]` filter
 

--- a/documentation/asciidoc/computers/config_txt/conditional.adoc
+++ b/documentation/asciidoc/computers/config_txt/conditional.adoc
@@ -66,7 +66,7 @@ These are particularly useful for defining different `kernel`, `initramfs`, and 
 
 Remember to use the `[all]` filter at the end, so that any subsequent settings aren't limited to Raspberry Pi 2 hardware only.
 
-NOTE: Some models of Raspberry Pi (Zero W, Zero 2 W, Model 3B+, Pi 400, Compute Module 4 and Compute Module 4S) see the settings for multiple filters (as listed in the table above). This means that if you want a setting to apply only to (e.g.) a Model 4B without _also_ applying that setting to a Pi 400 then the setting in the `[pi4]` section would need to be reverted by an alternate setting in a following `[pi400]` section - the ordering of such sections is significant. Alternatively, you could use a `[board-type=0x11]` filter which has a one-to-one mapping to different hardware products.
+NOTE: Some models of Raspberry Pi (Zero W, Zero 2 W, Model 3B+, Pi 400, Compute Module 4 and Compute Module 4S) see the settings for multiple filters (as listed in the table above). This means that if you want a setting to apply only to (e.g.) a Model 4B without _also_ applying that setting to a Pi 400, then the setting in the `[pi4]` section would need to be reverted by an alternate setting in a following `[pi400]` section - the ordering of such sections is significant. Alternatively, you could use a `[board-type=0x11]` filter which has a one-to-one mapping to different hardware products.
 
 === The `[none]` filter
 

--- a/documentation/asciidoc/computers/config_txt/conditional.adoc
+++ b/documentation/asciidoc/computers/config_txt/conditional.adoc
@@ -16,40 +16,40 @@ The conditional model filters are applied according to the following table.
 |===
 | Filter | Applicable model(s)
 
-| [pi1]
+| `[pi1]`
 | Model 1A, Model 1B, Model 1A+, Model 1B+, Compute Module 1
 
-| [pi2]
+| `[pi2]`
 | Model 2B (BCM2836- or BCM2837-based)
 
-| [pi3]
+| `[pi3]`
 | Model 3B, Model 3B+, Model 3A+, Compute Module 3, Compute Module 3+
 
-| [pi3+]
-| Model 3A+, Model 3B+
+| `[pi3+]`
+| Model 3A+, Model 3B+ (also sees `[pi3]` contents)
 
-| [pi4]
+| `[pi4]`
 | Model 4B, Pi 400, Compute Module 4, Compute Module 4S
 
-| [pi400]
-| Pi 400
+| `[pi400]`
+| Pi 400 (also sees `[pi4]` contents)
 
-| [cm4]
-| Compute Module 4
+| `[cm4]`
+| Compute Module 4 (also sees `[pi4]` contents)
 
-| [cm4s]
-| Compute Module 4S
+| `[cm4s]`
+| Compute Module 4S (also sees `[pi4]` contents)
 
-| [pi0]
+| `[pi0]`
 | Zero, Zero W, Zero 2 W
 
-| [pi0w]
-| Zero W
+| `[pi0w]`
+| Zero W (also sees `[pi0]` contents)
 
-| [pi02]
-| Zero 2 W
+| `[pi02]`
+| Zero 2 W (also sees `[pi0]` contents)
 
-| [board-type=Type]
+| `[board-type=Type]`
 | Filter by `Type` number - see xref:raspberry-pi.adoc#raspberry-pi-revision-codes[Raspberry Pi Revision Codes] E.g `[board-type=0x14]` would match CM4.
 
 |===
@@ -66,7 +66,7 @@ These are particularly useful for defining different `kernel`, `initramfs`, and 
 
 Remember to use the `[all]` filter at the end, so that any subsequent settings aren't limited to Raspberry Pi 2 hardware only.
 
-It is important to note that the Raspberry Pi Zero W will see the contents of `[pi0w]` AND `[pi0]`. Likewise, a Raspberry Pi 3B+ sees `[pi3+]` AND `[pi3]`, and a Raspberry Pi 400 sees `[pi400]` AND `[pi4]`. If you want a setting to apply only to Raspberry Pi Zero, Raspberry Pi 3B or Raspberry Pi 4B, you need to follow it (order is important) with a setting in the `[pi0w]`, `[pi3+]` or `[pi400]` section that reverts it.
+NOTE: A Raspberry Pi Zero W will see the contents of `[pi0w]` *and* `[pi0]`. Likewise, Raspberry Pi 3B+ see `[pi3+]` *and* `[pi3]` sections, Raspberry Pi 400 see `[pi400]` *and* `[pi4]` sections, Raspberry Pi Compute Module 4 see `[cm4]` *and* `[pi4]` sections and Raspberry Pi Compute Module 4S see `[cm4s]` *and* `[pi4]` sections. If you want a setting to apply _only_ to a Raspberry Pi Zero, Raspberry Pi 3B, or Raspberry Pi 4B then you need to follow it - the ordering is significant - with a setting in a `[pi0w]`, `[pi3+]`, `[pi400]`, `[cm4]` or `[cm4s]` section which reverts the shared setting.
 
 === The `[none]` filter
 


### PR DESCRIPTION
Minor reformat for readability and clarity.

Things to confirm/follow-up updates:

* Does the CM4S also process `[cm4]` sections?
* Does the Zero 2 W also process `[pi0w]` sections?

I don't have access to the necessary hardware to verify...