### PR TITLE
Upgrade to Docsearch v3

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,6 +38,8 @@ jobs:
           version: 1.10.2
       - name: Install arm-none-eabi-gcc GNU Arm Embedded Toolchain
         uses: carlosperate/arm-none-eabi-gcc-action@v1.6.0
+        env:
+          NODE_TLS_REJECT_UNAUTHORIZED: 0
       - name: Install Doxygen
         run: |
           wget https://www.doxygen.nl/files/doxygen-1.9.6.linux.bin.tar.gz

--- a/jekyll-assets/_includes/head.html
+++ b/jekyll-assets/_includes/head.html
@@ -15,7 +15,7 @@
 <link rel="preconnect" href="https://fonts.gstatic.com">
 <link href="https://fonts.googleapis.com/css2?family=Roboto:ital,wght@0,100;0,300;0,400;0,700;1,100;1,300;1,400;1,700&display=swap" rel="stylesheet">
 <link rel="preconnect" href="https://IHWGNTJ1NP-dsn.algolia.net" crossorigin>
-<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@docsearch/css@alpha"/>
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@docsearch/css@3"/>
 <link rel="stylesheet" href="{{ site.baseurl }}/css/style.css?ver=1646652613">
 <link rel="stylesheet" href="{{ site.baseurl }}/css/tabs.css?ver=1639581228">
 <script async src="https://www.googletagmanager.com/gtag/js?id=UA-180927933-8"></script>

--- a/jekyll-assets/_includes/search.html
+++ b/jekyll-assets/_includes/search.html
@@ -1,4 +1,4 @@
-<script src="https://cdn.jsdelivr.net/npm/@docsearch/js@alpha"></script>
+<script src="https://cdn.jsdelivr.net/npm/@docsearch/js@3"></script>
 <script type="text/javascript">
   (function () {
     var lvl0 = document.querySelector('#tab-menu li.selected'),


### PR DESCRIPTION
Algolia have now released a stable version of DocSearch so we no longer need to use the alpha version, see https://docsearch.algolia.com/docs/DocSearch-v3#stable-version
