### PR TITLE
Re-enable SSL verification for developer.arm.com

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,8 +38,6 @@ jobs:
           version: 1.10.2
       - name: Install arm-none-eabi-gcc GNU Arm Embedded Toolchain
         uses: carlosperate/arm-none-eabi-gcc-action@v1.6.1
-        env:
-          NODE_TLS_REJECT_UNAUTHORIZED: 0
       - name: Install Doxygen
         run: |
           wget https://www.doxygen.nl/files/doxygen-1.9.6.linux.bin.tar.gz


### PR DESCRIPTION
It looks like developer.arm.com has fixed its SSL certificate chain (see https://github.com/carlosperate/arm-none-eabi-gcc-action/issues/38#issuecomment-1534749820) so we no longer need to disable verification during the build.

This reverts commit 695a91f46935735379337dd8d02aa29903808d78.
