### PR TITLE
Building libcamera now requires cmake

### DIFF
--- a/documentation/asciidoc/computers/camera/libcamera_apps_building.adoc
+++ b/documentation/asciidoc/computers/camera/libcamera_apps_building.adoc
@@ -60,6 +60,7 @@ sudo apt install -y libboost-dev
 sudo apt install -y libgnutls28-dev openssl libtiff5-dev
 sudo apt install -y qtbase5-dev libqt5core5a libqt5gui5 libqt5widgets5
 sudo apt install -y meson
+sudo apt install -y cmake
 sudo pip3 install pyyaml ply
 sudo pip3 install --upgrade meson
 ----


### PR DESCRIPTION
Fairly self-explanatory, I hope! This has actually been true for a while now...