### PR TITLE
Google Analytics 4

### DIFF
--- a/jekyll-assets/_includes/head.html
+++ b/jekyll-assets/_includes/head.html
@@ -24,4 +24,6 @@
   function gtag(){dataLayer.push(arguments);}
   gtag('js', new Date());
   gtag('config', 'UA-180927933-8', { 'anonymize_ip': true });
+  gtag('config', 'G-V8TFXM3BKJ');
+  gtag('config', 'G-22FD70LWDS');
 </script>


### PR DESCRIPTION
TRELLO: https://trello.com/c/g6sySuWG/1069-migrate-to-google-analytics-4

Configure new GA4 properties and keep pushing data to the old property until Google stops processing it. Once Google retires Universal Analytics the `UA-` tag will be removed.
