### PR TITLE
Rename the raspi-config 'nonint' anchors to prevent duplicate-anchor build warnings

### DIFF
--- a/documentation/asciidoc/computers/configuration/raspi-config.adoc
+++ b/documentation/asciidoc/computers/configuration/raspi-config.adoc
@@ -313,7 +313,7 @@ sudo raspi-config nonint do_audio <N>
 - `1` - vc4-hdmi-0
 - `2` - vc4-hdmi-1
 
-[[change-user-password]]
+[[change-user-password-nonint]]
 ===== Password
 
 You can change the 'default' user password.
@@ -326,7 +326,7 @@ sudo raspi-config nonint do_change_pass
 
 NOTE: This does not check for the interactive flag and will show full-screen messages.
 
-[[hostname]]
+[[hostname-nonint]]
 ===== Hostname
 
 Set the visible name for this Raspberry Pi on a network.
@@ -335,7 +335,7 @@ Set the visible name for this Raspberry Pi on a network.
 sudo raspi-config nonint do_hostname <hostname>
 ----
 
-[[boot-options]]
+[[boot-options-nonint]]
 ===== Network at Boot
 
 Use this option to wait for a network connection before letting boot proceed.
@@ -371,7 +371,7 @@ sudo raspi-config nonint do_leds <0/1>
 
 ==== Display Options
 
-[[resolution]]
+[[resolution-nonint]]
 ===== Resolution
 
 Define the default HDMI/DVI video resolution to use when the system boots without a TV or monitor being connected. This can have an effect on RealVNC if the VNC option is enabled.
@@ -383,7 +383,7 @@ sudo raspi-config nonint do_resolution <group> <mode>
 Group: `2` = DMT, otherwise = CEA
 Mode: `0` = Default Automatic
 
-[[underscan]]
+[[underscan-nonint]]
 ===== Underscan
 
 Old TV sets had a significant variation in the size of the picture they produced; some had cabinets that overlapped the screen. TV pictures were therefore given a black border so that none of the picture was lost; this is called overscan. Modern TVs and monitors don't need the border, and the signal doesn't allow for it. If the initial text shown on the screen disappears off the edge, you need to enable overscan to bring the border back.
@@ -399,7 +399,7 @@ sudo raspi-config nonint do_overscan <0/1>
 `0` - Enable overscan
 `1` - Disable overscan
 
-[[pixel-doubling]]
+[[pixel-doubling-nonint]]
 ===== Pixel Doubling
 
 Enable/disable 2x2 pixel mapping.
@@ -433,12 +433,12 @@ sudo raspi-config nonint do_blanking <0/1>
 `0` - Enable screen blanking
 `1` - Disable screen blanking
 
-[[interfacing-options]]
+[[interfacing-options-nonint]]
 ==== Interfacing Options
 
 In this submenu there are the following options to enable/disable: Camera, SSH, VNC, SPI, I2C, Serial, 1-wire, and Remote GPIO.
 
-[[camera]]
+[[camera-nonint]]
 ===== Camera
 
 Enable/disable the CSI camera interface.
@@ -450,7 +450,7 @@ sudo raspi-config nonint do_camera <0/1>
 `0` - Enable camera
 `1` - Disable camera
 
-[[ssh]]
+[[ssh-nonint]]
 ===== SSH
 
 Enable/disable remote command line access to your Raspberry Pi using SSH.
@@ -464,7 +464,7 @@ sudo raspi-config nonint do_ssh <0/1>
 `0` - Enable SSH
 `1` - Disable SSH
 
-[[VNC]]
+[[VNC-nonint]]
 ===== VNC
 
 Enable/disable the RealVNC virtual network computing server.
@@ -476,7 +476,7 @@ sudo raspi-config nonint do_vnc <0/1>
 `0` - Enable VNC
 `1` - Disable VNC
 
-[[spi]]
+[[spi-nonint]]
 ===== SPI
 
 Enable/disable SPI interfaces and automatic loading of the SPI kernel module, needed for products such as PiFace.
@@ -488,7 +488,7 @@ sudo raspi-config nonint do_spi <0/1>
 `0` - Enable SPI
 `1` - Disable SPI
 
-[[i2c]]
+[[i2c-nonint]]
 ===== I2C
 
 Enable/disable I2C interfaces and automatic loading of the I2C kernel module.
@@ -500,7 +500,7 @@ sudo raspi-config nonint do_i2c <0/1>
 `0` - Enable I2C
 `1` - Disable I2C
 
-[[serial]]
+[[serial-nonint]]
 ===== Serial
 
 Enable/disable shell and kernel messages on the serial connection.
@@ -513,7 +513,7 @@ sudo raspi-config nonint do_serial <0/1/2>
 `1` - Disable serial port
 `2` - Enable serial port
 
-[[one-wire]]
+[[one-wire-nonint]]
 ===== 1-wire
 
 Enable/disable the Dallas 1-wire interface. This is usually used for DS18B20 temperature sensors.
@@ -538,7 +538,7 @@ sudo raspi-config nonint do_rgpio <0/1>
 
 ==== Performance Options
 
-[[overclock]]
+[[overclock-nonint]]
 ==== Overclock
 
 On some models it is possible to overclock your Raspberry Pi's CPU using this tool. The overclocking you can achieve will vary; overclocking too high may result in instability. Selecting this option shows the following warning:
@@ -556,7 +556,7 @@ Setting is one of:
  - `High` - Overclock to 100% of the maximum
  - `Turbo` - Overclock to 125% of the maximum
 
-[[memory-split]]
+[[memory-split-nonint]]
 ===== GPU Memory
 
 Change the amount of memory made available to the GPU.
@@ -591,12 +591,12 @@ GPIO defaults to `14`.
 
 `onTemp` defaults to `80` °C.
 
-[[localisation-options]]
+[[localisation-options-nonint]]
 ==== Localisation Options
 
 The localisation submenu gives you these options to choose from: keyboard layout, time zone, locale, and wireless LAN country code.
 
-[[change-locale]]
+[[change-locale-nonint]]
 ===== Locale
 
 Select a locale, for example `en_GB.UTF-8 UTF-8`.
@@ -605,7 +605,7 @@ Select a locale, for example `en_GB.UTF-8 UTF-8`.
 sudo raspi-config nonint do_change_locale <locale>
 ----
 
-[[change-timezone]]
+[[change-timezone-nonint]]
 ===== Time Zone
 
 Select your local time zone, starting with the region, e.g. Europe, then selecting a city, e.g. London. Type a letter to skip down the list to that point in the alphabet.
@@ -615,7 +615,7 @@ sudo raspi-config nonint do_change_timezone <timezone>
 sudo raspi-config nonint do_change_timezone America/Los_Angeles
 ----
 
-[[change-keyboard-layout]]
+[[change-keyboard-layout-nonint]]
 ===== Keyboard
 
 This option opens another menu which allows you to select your keyboard layout. It will take a long time to display while it reads all the keyboard types. Changes usually take effect immediately, but may require a reboot.
@@ -634,10 +634,10 @@ sudo raspi-config nonint do_wifi_country <country>
 sudo raspi-config nonint do_wifi_country US
 ----
 
-[[advanced-options]]
+[[advanced-options-nonint]]
 ==== Advanced Options
 
-[[expand-filesystem]]
+[[expand-filesystem-nonint]]
 ===== Expand Filesystem
 
 This option will expand your installation to fill the whole SD card, giving you more space to use for files. You will need to reboot the Raspberry Pi to make this available. 
@@ -648,22 +648,22 @@ WARNING: There is no confirmation: selecting the option begins the partition exp
 sudo raspi-config nonint do_expand_rootfs
 ----
 
-[[GL-driver]]
+[[GL-driver-nonint]]
 ===== GL Driver
 
 Enable/disable the experimental GL desktop graphics drivers.
 
-[[GL-full-KMS]]
+[[GL-full-KMS-nonint]]
 ====== GL (Full KMS)
 
 Enable/disable the experimental OpenGL Full KMS (kernel mode setting) desktop graphics driver.
 
-[[GL-fake-KMS]]
+[[GL-fake-KMS-nonint]]
 ====== GL (Fake KMS)
 
 Enable/disable the experimental OpenGL Fake KMS desktop graphics driver.
 
-[[legacy]]
+[[legacy-nonint]]
 ====== Legacy
 
 Enable/disable the original legacy non-GL VideoCore desktop graphics driver.
@@ -707,7 +707,7 @@ sudo raspi-config nonint do_boot_order <B1/B2/B3>
 
 On the Raspberry Pi 4, you can tell the system to use the very latest boot ROM software, or revert to the factory default if the latest version causes problems.
 
-[[update]]
+[[update-nonint]]
 ==== Update
 
 Update this tool to the latest version.


### PR DESCRIPTION
#2827 added a bunch of duplicate anchors. This PR fixes that.