### PR TITLE
update cut cmd to grab last 8 of serial

### DIFF
--- a/documentation/asciidoc/computers/remote-access/network-boot-raspberry-pi.adoc
+++ b/documentation/asciidoc/computers/remote-access/network-boot-raspberry-pi.adoc
@@ -68,7 +68,7 @@ To find the serial number:
 
 [,bash]
 ----
-grep Serial /proc/cpuinfo | cut -d ' ' -f 2 | cut -c 8-16
+grep Serial /proc/cpuinfo | cut -d ' ' -f 2 | cut -c 9-16
 ----
 
 === Server Configuration


### PR DESCRIPTION
Current command is incorrect 'cut -c 8-16' grabs 9 characters. This pull request fixes that.

Or, if you prefer an alternative using sed...

sed -n "s/^Serial.*\(.\{8\}$\)/\1/p" /proc/cpuinfo