### PR TITLE
Add missing comma

### DIFF
--- a/documentation/asciidoc/computers/getting-started/setting-up.adoc
+++ b/documentation/asciidoc/computers/getting-started/setting-up.adoc
@@ -31,7 +31,7 @@ NOTE: The Raspberry Pi 4 has two micro HDMI connectors, which require a good-qua
 If you're using your Raspberry Pi with a monitor with built-in speakers and are connecting to it using an HDMI cable, you can also use it to output sound. For monitors with a DVI port, you can use an HDMI-to-DVI cable or an HDMI cable with a DVI adapter. In addition, you can use an HDMI-to-VGA adapter for older monitors that only support VGA. 
 
 
-NOTE: Unlike HDMI the DVI and VGA standards do not support audio.
+NOTE: Unlike HDMI, the DVI and VGA standards do not support audio.
 
 Finally, some models of Raspberry Pi have a composite out port for connecting to analog devices, but the type of connector varies depending on the model. The original Raspberry Pi used an RCA connector, and a standard RCA composite video lead will work. Other models (Raspberry Pi B+ and later) combine the audio and composite out onto the same 3.5mm jack. This requires a particular type of lead, with audio left on the tip, audio right on ring 1, ground on ring 2, and video on the sleeve. This is the same as leads used on the Zune and on Apple devices.
 


### PR DESCRIPTION
The introductory "Unlike HDMI" in the "Connecting a Display" section should have a comma following it, both for grammar reasons and to help with readability. I know it's a minor change, but I thought it was worth fixing.