### PR TITLE
Adding NOTE about building 32-bit kernel

### DIFF
--- a/documentation/asciidoc/computers/linux_kernel/building.adoc
+++ b/documentation/asciidoc/computers/linux_kernel/building.adoc
@@ -12,7 +12,7 @@ The instructions below are divided into native builds and cross-compilation; cho
 
 === Building the Kernel Locally
 
-IMPORTANT: If you are build a 32-bit kernel on the 32-bit distribution of Raspberry Pi OS you should be aware that while the user land in this distribution is 32-bit, the kernel itself is a 64-bit kernel. You therefore need to follow the <<cross-compiling-the-kernel,instructions for cross-compiling the kernel>>.  
+IMPORTANT: Building the 64-bit kernel on the 32-bit distribution of Raspberry Pi OS is a cross-compilation exercise because it requires the installation of the cross-compiler (`gcc-aarch64-linux-gnu`). Building the 32-bit kernel on the 32-bit distribution of Raspberry Pi OS — which has a 32-bit userland, and 64-bit kernel — you should set `ARCH=arm`, although it's likely that this may already be set as `arm_64bit=0` will have been set. Instructions for <<cross-compiling-the-kernel,cross-compiling the kernel>> can be found later on this page.  
 
 On a Raspberry Pi, first install the latest version of https://www.raspberrypi.com/software/operating-systems/#raspberry-pi-os-32-bit[Raspberry Pi OS]. Then boot your Raspberry Pi, log in, and ensure you're connected to the internet to give you access to the sources.
 

--- a/documentation/asciidoc/computers/linux_kernel/building.adoc
+++ b/documentation/asciidoc/computers/linux_kernel/building.adoc
@@ -12,6 +12,8 @@ The instructions below are divided into native builds and cross-compilation; cho
 
 === Building the Kernel Locally
 
+IMPORTANT: If you are build a 32-bit kernel on the 32-bit distribution of Raspberry Pi OS you should be aware that while the user land in this distribution is 32-bit, the kernel itself is a 64-bit kernel. You therefore need to follow the <<cross-compiling-the-kernel,instructions for cross-compiling the kernel>>.  
+
 On a Raspberry Pi, first install the latest version of https://www.raspberrypi.com/software/operating-systems/#raspberry-pi-os-32-bit[Raspberry Pi OS]. Then boot your Raspberry Pi, log in, and ensure you're connected to the internet to give you access to the sources.
 
 First install Git and the build dependencies:


### PR DESCRIPTION
If you are attempting to compile a 32-bit kernel on the 32-bit distribution of Raspberry Pi OS you should be aware that while the userland in this distribution is 32-bit, the kernel is a 64-bit kernel. You should therefore follow the instructions for cross-compiling the kernel.

Closes #3019 when merged.