### PR TITLE
Custom template for integrating book links

### DIFF
--- a/jekyll-assets/_templates/helpers.rb
+++ b/jekyll-assets/_templates/helpers.rb
@@ -1,0 +1,37 @@
+module Slim::Helpers
+  def book_link
+    puts (self.attr 'booktype')
+    puts (document.attr 'booktype')
+    case (self.attr 'booktype')
+    when 'free'
+      %("FREEEEEEE")
+    when 'buy'
+      %("BUY TEXT")
+    when 'donate'
+      %("DONATE")
+    else
+      %("NONE")
+    end
+  end
+
+  def section_title
+    if caption
+      captioned_title
+    elsif numbered && level <= (document.attr :sectnumlevels, 3).to_i
+      if level < 2 && document.doctype == 'book'
+        case sectname
+        when 'chapter'
+          %(#{(signifier = document.attr 'chapter-signifier') ? signifier.to_s + ' ' : ''}#{sectnum} #{title})
+        when 'part'
+          %(#{(signifier = document.attr 'part-signifier') ? signifier.to_s + ' ' : ''}#{sectnum nil, ':'} #{title})
+        else
+          %(#{sectnum} #{title})
+        end
+      else
+        %(#{sectnum} #{title})
+      end
+    else
+      title
+    end
+  end
+end

--- a/jekyll-assets/_templates/helpers.rb
+++ b/jekyll-assets/_templates/helpers.rb
@@ -1,16 +1,14 @@
 module Slim::Helpers
   def book_link
-    puts (self.attr 'booktype')
-    puts (document.attr 'booktype')
     case (self.attr 'booktype')
     when 'free'
-      %("FREEEEEEE")
+      %(You can <a href="#{self.attr 'link'}" target="_blank">download this book</a> as a PDF file for free, it has been released under a Creative Commons <a href="https://creativecommons.org/licenses/by-nc-sa/3.0/" target="_blank">Attribution-NonCommercial-ShareAlike</a> 3.0 Unported (CC BY NC-SA) licence.)
     when 'buy'
-      %("BUY TEXT")
+      %(You can <a href="#{self.attr 'link'}" target="_blank">buy this book</a> on the Raspberry Pi Press site.)
     when 'donate'
-      %("DONATE")
+      %(You can <a href="#{document.attr 'link'}" target="_blank">download this book</a> for an optional donation on the Raspberry Pi Press site.)
     else
-      %("NONE")
+      return
     end
   end
 

--- a/jekyll-assets/_templates/helpers.rb
+++ b/jekyll-assets/_templates/helpers.rb
@@ -6,10 +6,17 @@ module Slim::Helpers
     when 'buy'
       %(You can <a href="#{self.attr 'link'}" target="_blank">buy this book</a> on the Raspberry Pi Press site.)
     when 'donate'
-      %(You can <a href="#{document.attr 'link'}" target="_blank">download this book</a> for an optional donation on the Raspberry Pi Press site.)
+      %(You can <a href="#{self.attr 'link'}" target="_blank">download this book</a> for an optional donation on the Raspberry Pi Press site.)
     else
       return
     end
+  end
+
+  def book_image
+    src = (self.attr 'image').dup
+    src = src.gsub(/^image::/, "")
+    src = src.gsub(/\[.*?\]$/, "")
+    return src
   end
 
   def section_title

--- a/jekyll-assets/_templates/section.html.slim
+++ b/jekyll-assets/_templates/section.html.slim
@@ -1,0 +1,32 @@
+- sect0 = level == 0
+- if sect0
+  *{tag: %(h#{level + 1}), id: id, class: ('sect0' if sect0)}
+    - if id && (document.attr? :sectanchors)
+      a.anchor href="##{id}"
+      =section_title
+    - elsif id && (document.attr? :sectlinks)
+      a.link href="##{id}" =section_title
+    - else
+      =section_title
+  =content
+- else
+  div class=[%(sect#{level}), role]
+    *{tag: %(h#{level + 1}), id: id, class: ('sect0' if sect0)}
+      - if id && (document.attr? :sectanchors)
+        a.anchor href="##{id}"
+        =section_title
+      - elsif id && (document.attr? :sectlinks)
+        a.link href="##{id}" =section_title
+      - else
+        =section_title
+    - if level == 1
+      .sectionbody 
+        =content
+        p "Heyo!"
+        - if role? 'booklink'
+          p =book_link
+    - else
+      =content
+      p "Heyo!"
+      - if role? 'booklink'
+        p =book_link

--- a/jekyll-assets/_templates/section.html.slim
+++ b/jekyll-assets/_templates/section.html.slim
@@ -21,10 +21,30 @@
         =section_title
     - if level == 1
       .sectionbody 
-        =content
-        - if role? 'booklink'
-          p =book_link
-    - else
-      =content
       - if role? 'booklink'
-        p =book_link
+        div class="openblock float-group"
+          div class="content"
+            - if attr 'image'
+              div class="imageblock related thumb right"
+                div class="content"
+                  a href=(attr 'link') target='_blank' class='image'
+                    img src=(book_image)
+            =content
+            div class="paragraph"
+              p =book_link
+      - else
+        =content
+    - else
+      - if role? 'booklink'
+        div class="openblock float-group"
+          div class="content"
+            - if attr 'image'
+              div class="imageblock related thumb right"
+                div class="content"
+                  a href=(attr 'link') target='_blank' class='image'
+                    img src=(book_image)
+            =content
+            div class="paragraph"
+              p =book_link
+      - else
+        =content

--- a/jekyll-assets/_templates/section.html.slim
+++ b/jekyll-assets/_templates/section.html.slim
@@ -22,11 +22,9 @@
     - if level == 1
       .sectionbody 
         =content
-        p "Heyo!"
         - if role? 'booklink'
           p =book_link
     - else
       =content
-      p "Heyo!"
       - if role? 'booklink'
         p =book_link


### PR DESCRIPTION
This creates some special handling for sections that are intended to link to a book. You should be able to use this same format for sections of any level. You can include any type of content inside your section, as usual, and a final paragraph will automatically be appended to the section, linking to the book with text that corresponds to the type of book. The following attributes are required:

- `.booklink`
- `booktype` (options are: `free`, `buy`, or `donate`)
- `link` to the book, buy page, or donate page
- `image` of the book cover (can be either included in the repo or a url). Note that in order for it to be picked up by the toolchain, the `image` attribute must be formatted the same way you'd format a regular asciidoc image, including both the `image::` and trailing `[]`; see below for an example.

```
[.booklink, booktype="free", link=https://pip.raspberrypi.com/categories/685-whitepapers-app-notes/documents/RP-003471-WP/Using-a-DPI-display.pdf, image=image::images/simple-electronics-with-gpio-zero.jpg[]]
==== Going further

You can find more information on how to program electronics connected to your Raspberry Pi with the GPIO Zero Python library in the Raspberry Pi Press book https://github.com/raspberrypipress/released-pdfs/raw/main/simple-electronics-with-gpio-zero.pdf[Simple Electronics with GPIO Zero]. Written by Phil King, it is part of the MagPi Essentials series published by Raspberry Pi Press. The book gets you started with the GPIO Zero library, and walks you through how to use it by building a series of projects. 
```

See #3035 