### PR TITLE
Update legacy OS references

### DIFF
--- a/documentation/asciidoc/computers/camera/libcamera_apps_getting_help.adoc
+++ b/documentation/asciidoc/computers/camera/libcamera_apps_getting_help.adoc
@@ -2,9 +2,7 @@
 
 For further help with `libcamera` and the `libcamera-apps`, the first port of call will usually be the https://forums.raspberrypi.com/viewforum.php?f=43[Raspberry Pi Camera Forum]. Before posting, it's helpful to:
 
-* Ensure your xref:../computers/os.adoc#using-apt[software is up to date].
-
-* If you are using _Buster_ please upgrade to the latest OS, as `libcamera-apps` is no longer supported there.
+* Make sure your xref:../computers/os.adoc#using-apt[operating system is up to date] as some legacy versions of the Raspberry Pi OS do not support `libcamera-apps`.
 
 * Make a note of your operating system version (`uname -a`).
 

--- a/documentation/asciidoc/computers/camera/libcamera_apps_getting_help.adoc
+++ b/documentation/asciidoc/computers/camera/libcamera_apps_getting_help.adoc
@@ -2,8 +2,6 @@
 
 For further help with `libcamera` and the `libcamera-apps`, the first port of call will usually be the https://forums.raspberrypi.com/viewforum.php?f=43[Raspberry Pi Camera Forum]. Before posting, it's helpful to:
 
-* Make sure your xref:../computers/os.adoc#using-apt[operating system is up to date] as some legacy versions of the Raspberry Pi OS do not support `libcamera-apps`.
-
 * Make a note of your operating system version (`uname -a`).
 
 * Make a note of your `libcamera` and `libcamera-apps` versions (`libcamera-hello --version`).

--- a/documentation/asciidoc/computers/configuration/configuring-networking.adoc
+++ b/documentation/asciidoc/computers/configuration/configuring-networking.adoc
@@ -86,7 +86,7 @@ On the Raspberry Pi 3B+ and Raspberry Pi 4B, you will also need to set the count
 country=GB
 ----
 
-Note that with the latest Buster Raspberry Pi OS release, you must ensure that the `wpa_supplicant.conf` file contains the following information at the top:
+Note that with the latest Raspberry Pi OS release, you must ensure that the `wpa_supplicant.conf` file contains the following information at the top:
 
 ----
 ctrl_interface=DIR=/var/run/wpa_supplicant GROUP=netdev

--- a/documentation/asciidoc/computers/legacy_config_txt/memory.adoc
+++ b/documentation/asciidoc/computers/legacy_config_txt/memory.adoc
@@ -28,7 +28,7 @@ The recommended maximum values are as follows:
 | `512`, `76` on the Raspberry Pi 4
 |===
 
-IMPORTANT: The default camera stack (libcamera) on Raspberry Pi OS - Bullseye uses Linux CMA memory to allocate buffers instead of GPU memory so there is no benefit in increasing the GPU memory size.
+IMPORTANT: The default camera stack (libcamera) on Raspberry Pi OS uses Linux CMA memory to allocate buffers instead of GPU memory so there is no benefit in increasing the GPU memory size.
 
 It is possible to set `gpu_mem` to larger values, however this should be avoided since it can cause problems, such as preventing Linux from booting. The minimum value is `16`, however this disables certain GPU features.
 

--- a/documentation/asciidoc/computers/legacy_config_txt/memory.adoc
+++ b/documentation/asciidoc/computers/legacy_config_txt/memory.adoc
@@ -28,7 +28,7 @@ The recommended maximum values are as follows:
 | `512`, `76` on the Raspberry Pi 4
 |===
 
-IMPORTANT: The default camera stack (libcamera) on Raspberry Pi OS uses Linux CMA memory to allocate buffers instead of GPU memory so there is no benefit in increasing the GPU memory size.
+IMPORTANT: The camera stack (libcamera) on Raspberry Pi OS uses Linux CMA memory to allocate buffers instead of GPU memory so there is no benefit in increasing the GPU memory size.
 
 It is possible to set `gpu_mem` to larger values, however this should be avoided since it can cause problems, such as preventing Linux from booting. The minimum value is `16`, however this disables certain GPU features.
 

--- a/documentation/asciidoc/computers/os/updating.adoc
+++ b/documentation/asciidoc/computers/os/updating.adoc
@@ -28,7 +28,7 @@ sudo apt full-upgrade
 
 Note that `full-upgrade` is used in preference to a simple `upgrade`, as it also picks up any dependency changes that may have been made.
 
-Generally speaking, doing this regularly will keep your installation up to date for the particular major Raspberry Pi OS release you are using (e.g. Buster). It will not update from one major release to another, for example, Stretch to Buster or Buster to Bullseye.
+Generally speaking, doing this regularly will keep your installation up to date for the particular major Raspberry Pi OS release you are using (e.g. Bookworm). It will not update from one major release to another, for example, Buster to Bullseye or Bullseye to Bookworm.
 
 However, there are occasional changes made in the Raspberry Pi OS image that require manual intervention, for example a newly introduced package. These are not installed with an upgrade, as this command only updates the packages you already have installed.
 
@@ -42,9 +42,9 @@ When running `sudo apt full-upgrade`, it will show how much data will be downloa
 
 ==== Upgrading from Previous Operating System Versions
 
-WARNING: Upgrading an existing image is possible, but is not guaranteed to work in every circumstance and we do not recommend it. If you do wish to try upgrading your operating system version, we strongly suggest making a backup first -- we can accept no responsibility for loss of data from a failed update.
+WARNING: Upgrading an existing image is sometimes possible, but is not guaranteed to work in every circumstance and we do not recommend it. If you do wish to try upgrading your operating system version, we strongly suggest making a backup first. We accept no responsibility for the loss of any data during a failed update.
 
-The latest version of Raspberry Pi OS is based on https://www.raspberrypi.com/news/raspberry-pi-os-debian-bullseye/[Debian Bullseye]. The previous version was based on https://www.raspberrypi.com/news/buster-the-new-version-of-raspbian/[Buster]. If you want to perform an in-place upgrade from Buster to Bullseye (and you're aware of the risks) see the https://forums.raspberrypi.com/viewtopic.php?t=323279[instructions in the forums].
+The latest version of Raspberry Pi OS is based on https://link.tbd[Debian Bookworm]. The previous version was based on https://www.raspberrypi.com/news/raspberry-pi-os-debian-bullseye/[Debian Bullseye].
 
 ==== Searching for Software
 

--- a/documentation/asciidoc/computers/os/updating.adoc
+++ b/documentation/asciidoc/computers/os/updating.adoc
@@ -44,7 +44,7 @@ When running `sudo apt full-upgrade`, it will show how much data will be downloa
 
 WARNING: Upgrading an existing image is sometimes possible, but is not guaranteed to work in every circumstance and we do not recommend it. If you do wish to try upgrading your operating system version, we strongly suggest making a backup first. We accept no responsibility for the loss of any data during a failed update.
 
-The latest version of Raspberry Pi OS is based on https://link.tbd[Debian Bookworm]. The previous version was based on https://www.raspberrypi.com/news/raspberry-pi-os-debian-bullseye/[Debian Bullseye].
+The latest version of Raspberry Pi OS is based on Debian Bookworm. The previous version was based on https://www.raspberrypi.com/news/raspberry-pi-os-debian-bullseye/[Debian Bullseye].
 
 ==== Searching for Software
 

--- a/documentation/asciidoc/computers/raspberry-pi/boot-nvme.adoc
+++ b/documentation/asciidoc/computers/raspberry-pi/boot-nvme.adoc
@@ -25,8 +25,6 @@ You might need to use `rpiboot` to update the CM4 bootloader. Instructions for b
 
 Remember to add the NVMe boot mode `6` to BOOT_ORDER in `recovery/boot.conf`.
 
-==== Firmware and kernel
-
 If you are using CM4 lite, remove the SD card and the board will boot from the NVMe disk. For versions of CM4 with an eMMC, make sure you have set NVMe first in the boot order.
 
 ==== NVMe BOOT_ORDER

--- a/documentation/asciidoc/computers/raspberry-pi/boot-nvme.adoc
+++ b/documentation/asciidoc/computers/raspberry-pi/boot-nvme.adoc
@@ -27,8 +27,6 @@ Remember to add the NVMe boot mode `6` to BOOT_ORDER in `recovery/boot.conf`.
 
 ==== Firmware and kernel
 
-You must have the latest versions of the VideoCore firmware and Raspberry Pi OS Linux kernel to boot directly from an NVMe SSD disk. The Raspberry Pi Bullseye and Buster Legacy releases have everything needed.
-
 If you are using CM4 lite, remove the SD card and the board will boot from the NVMe disk. For versions of CM4 with an eMMC, make sure you have set NVMe first in the boot order.
 
 ==== NVMe BOOT_ORDER

--- a/documentation/asciidoc/computers/remote-access/network-boot-ipv6.adoc
+++ b/documentation/asciidoc/computers/remote-access/network-boot-ipv6.adoc
@@ -13,7 +13,7 @@ IMPORTANT: IPv6 netboot is an *experimental alpha feature* and depending on feed
 
 === How it works
 
-To boot via IPv6 you need an updated version of the firmware (e.g. `start4.elf`) and the bootloader. Using the Bullseye release of Raspberry Pi OS and the latest stable bootloader should be sufficient.
+To boot via IPv6 you need an updated version of the firmware (e.g. `start4.elf`) and the bootloader. Using the latest release of Raspberry Pi OS and the latest stable bootloader should be sufficient.
 
 NOTE: The commonly used `dnsmasq` DHCP server doesn't currently support the network boot parameters required for IPv6 network boot, so for the time being you will have to use a different DHCP server such as https://www.isc.org/dhcp/[ISC DHCP].
 


### PR DESCRIPTION
re: issue #2954 

Batch of changes to reflect the moving of Bullseye to legacy. Definitely need a review for accuracy of some statements, especially those that mentioned Buster by name.

Also likely shouldn't merge until we get a blog post title for the changes to `updating.adoc`. Alternatively I can discard that change and make it in a separate PR later.