### PR TITLE
Updated kernel to 6.1.y

### DIFF
--- a/documentation/asciidoc/computers/camera/csi-2-usage.adoc
+++ b/documentation/asciidoc/computers/camera/csi-2-usage.adoc
@@ -87,7 +87,7 @@ The bcm2835-unicam has been written to try and accommodate all types of CSI-2 so
 
 The sensor driver for a camera sensor is responsible for all configuration of the device, usually via I2C or SPI. Rather than writing a driver from scratch, it is often easier to take an existing driver as a basis and modify it as appropriate.
 
-The https://github.com/raspberrypi/linux/blob/rpi-5.4.y/drivers/media/i2c/imx219.c[IMX219 driver] is a good starting point. This driver supports both 8bit and 10bit Bayer readout, so enumerating frame formats and frame sizes is slightly more involved.
+The https://github.com/raspberrypi/linux/blob/rpi-6.1.y/drivers/media/i2c/imx219.c[IMX219 driver] is a good starting point. This driver supports both 8bit and 10bit Bayer readout, so enumerating frame formats and frame sizes is slightly more involved.
 
 Sensors generally support https://www.kernel.org/doc/html/latest/userspace-api/media/v4l/control.html[V4L2 user controls]. Not all these controls need to be implemented in a driver. The IMX219 driver only implements a small subset, listed below, the implementation of which is handled by the `imx219_set_ctrl` function.
 
@@ -106,7 +106,7 @@ Further guidance can be found in libcamera's https://git.linuxtv.org/libcamera.g
 
 Device tree is used to select the sensor driver and configure parameters such as number of CSI-2 lanes, continuous clock lane operation, and link frequency (often only one is supported). 
 
-* The IMX219 https://github.com/raspberrypi/linux/blob/rpi-5.4.y/arch/arm/boot/dts/overlays/imx219-overlay.dts[device tree overlay] for the 5.4 kernel
+* The IMX219 https://github.com/raspberrypi/linux/blob/rpi-6.1.y/arch/arm/boot/dts/overlays/imx219-overlay.dts[device tree overlay] for the 6.1 kernel
 
 ==== Bridge chips
 
@@ -138,7 +138,7 @@ There are 2 bridge chips that are currently supported by the Raspberry Pi Linux 
 
 _Analog Devices ADV728x(A)-M Analogue video to CSI2 bridge_
 
-These chips convert composite, S-video (Y/C), or component (YPrPb) video into a single lane CSI-2 interface, and are supported by the https://github.com/raspberrypi/linux/blob/rpi-5.4.y/drivers/media/i2c/adv7180.c[ADV7180 kernel driver].
+These chips convert composite, S-video (Y/C), or component (YPrPb) video into a single lane CSI-2 interface, and are supported by the https://github.com/raspberrypi/linux/blob/rpi-6.1.y/drivers/media/i2c/adv7180.c[ADV7180 kernel driver].
 
 Product details for the various versions of this chip can be found on the Analog Devices website.
 
@@ -162,7 +162,7 @@ This is a HDMI to CSI-2 bridge chip, capable of converting video data at up to 1
 
 Information on this bridge chip can be found on the https://toshiba.semicon-storage.com/ap-en/semiconductor/product/interface-bridge-ics-for-mobile-peripheral-devices/hdmir-interface-bridge-ics/detail.TC358743XBG.html[Toshiba Website]
 
-The TC358743 interfaces HDMI in to CSI-2 and I2S outputs. It is supported by the https://github.com/raspberrypi/linux/blob/rpi-5.4.y/drivers/media/i2c/tc358743.c[TC358743 kernel module].
+The TC358743 interfaces HDMI in to CSI-2 and I2S outputs. It is supported by the https://github.com/raspberrypi/linux/blob/rpi-6.1.y/drivers/media/i2c/tc358743.c[TC358743 kernel module].
 
 The chip supports incoming HDMI signals as either RGB888, YUV444, or YUV422, at up to 1080p60. It can forward RGB888, or convert it to YUV444 or YUV422, and convert either way between YUV444 and YUV422. Only RGB888 and YUV422 support has been tested. When using 2 CSI-2 lanes, the maximum rates that can be supported are 1080p30 as RGB888, or 1080p50 as YUV422. When using 4 lanes on a Compute Module, 1080p60 can be received in either format.
 

--- a/documentation/asciidoc/computers/configuration/device-tree.adoc
+++ b/documentation/asciidoc/computers/configuration/device-tree.adoc
@@ -470,9 +470,9 @@ The introduction of the Raspberry Pi 4, built around the BCM2711 SoC, brought wi
 
 There is therefore a need for a method of tailoring an overlay to multiple platforms with differing hardware. Supporting them all in a single .dtbo file would require heavy use of hidden ("dormant") fragments and a switch to an on-demand symbol resolution mechanism so that a missing symbol that isn't needed doesn't cause a failure. A simpler solution is to add a facility to map an overlay name to one of several implementation files depending on the current platform.
 
-The overlay map, which is rolling out with the switch to Linux 5.4, is a file that gets loaded by the firmware at bootup. It is written in DTS source format - `overlay_map.dts`, compiled to `overlay_map.dtb` and stored in the overlays directory.
+The overlay map is a file that gets loaded by the firmware at bootup. It is written in DTS source format - `overlay_map.dts`, compiled to `overlay_map.dtb` and stored in the overlays directory.
 
-This is an edited version of the current map file (see the https://github.com/raspberrypi/linux/blob/rpi-5.4.y/arch/arm/boot/dts/overlays/overlay_map.dts[full version]):
+This is an edited version of the current map file (see the https://github.com/raspberrypi/linux/blob/rpi-6.1.y/arch/arm/boot/dts/overlays/overlay_map.dts[full version]):
 
 ----
 / {
@@ -587,7 +587,7 @@ Here are some examples of different types of properties, with parameters to modi
 };
 ----
 
-For further examples, there is a large collection of overlay source files https://github.com/raspberrypi/linux/tree/rpi-5.4.y/arch/arm/boot/dts/overlays[hosted in the Raspberry Pi Linux GitHub repository].
+For further examples, there is a large collection of overlay source files https://github.com/raspberrypi/linux/tree/rpi-6.1.y/arch/arm/boot/dts/overlays[hosted in the Raspberry Pi Linux GitHub repository].
 
 [[part2.3]]
 ==== Exporting labels
@@ -1098,7 +1098,7 @@ device_tree=my-pi.dtb
 [[part5.4]]
 ==== Disabling Device Tree usage
 
-Since the switch to the 4.4 kernel and the use of more upstream drivers, Device Tree usage is required in Raspberry Pi Linux kernels. However, for bare metal and other OSs, the method of disabling DT usage is to add:
+Device Tree usage is required in Raspberry Pi Linux kernels. However, for bare metal and other OSs, the method of disabling DT usage is to add:
 
 ----
 device_tree=

--- a/documentation/asciidoc/computers/configuration/kernel-command-line-config.adoc
+++ b/documentation/asciidoc/computers/configuration/kernel-command-line-config.adoc
@@ -34,7 +34,7 @@ The firmware automatically adds a preferred resolution and overscan settings via
 video=HDMI-A-1:1920x1080M@60,margin_left=0,margin_right=0,margin_top=0,margin_bottom=0
 ----
 
-This default entry can be modified by duplicating the entry above manually in /boot/cmdline.txt and making required changes to the margin parameters. In addition, it is possible to add rotation and reflect parameters as documented in the standard https://github.com/raspberrypi/linux/blob/rpi-5.4.y/Documentation/fb/modedb.rst[Linux framebuffer documentation]. By default the `margin_*` options are set from the `overscan` entries in config.txt, if present. The firmware can be prevented from making any KMS specific changes to the command line by adding `disable_fw_kms_setup=1` to `config.txt`
+This default entry can be modified by duplicating the entry above manually in /boot/cmdline.txt and making required changes to the margin parameters. In addition, it is possible to add rotation and reflect parameters as documented in the standard https://github.com/raspberrypi/linux/blob/rpi-6.1.y/Documentation/fb/modedb.rst[Linux framebuffer documentation]. By default the `margin_*` options are set from the `overscan` entries in config.txt, if present. The firmware can be prevented from making any KMS specific changes to the command line by adding `disable_fw_kms_setup=1` to `config.txt`
 
 An example entry may be as follows:
 

--- a/documentation/asciidoc/computers/configuration/uart.adoc
+++ b/documentation/asciidoc/computers/configuration/uart.adoc
@@ -198,7 +198,7 @@ NOTE: Selecting the wrong early console can prevent the Raspberry Pi from bootin
 
 === UARTs and Device Tree
 
-Various UART Device Tree overlay definitions can be found in the https://github.com/raspberrypi/linux[kernel GitHub tree]. The two most useful overlays are https://github.com/raspberrypi/linux/blob/rpi-5.4.y/arch/arm/boot/dts/overlays/disable-bt-overlay.dts[`disable-bt`] and https://github.com/raspberrypi/linux/blob/rpi-5.4.y/arch/arm/boot/dts/overlays/miniuart-bt-overlay.dts[`miniuart-bt`].
+Various UART Device Tree overlay definitions can be found in the https://github.com/raspberrypi/linux[kernel GitHub tree]. The two most useful overlays are https://github.com/raspberrypi/linux/blob/rpi-6.1.y/arch/arm/boot/dts/overlays/disable-bt-overlay.dts[`disable-bt`] and https://github.com/raspberrypi/linux/blob/rpi-6.1.y/arch/arm/boot/dts/overlays/miniuart-bt-overlay.dts[`miniuart-bt`].
 
 `disable-bt` disables the Bluetooth device and makes the first PL011 (UART0) the primary UART. You must also disable the system service that initialises the modem, so it does not connect to the UART, using `sudo systemctl disable hciuart`.
 

--- a/documentation/asciidoc/computers/linux_kernel/patching.adoc
+++ b/documentation/asciidoc/computers/linux_kernel/patching.adoc
@@ -10,12 +10,12 @@ It's important to check what version of the kernel you have when downloading and
 
 [source]
 ----
-VERSION = 3
-PATCHLEVEL = 10
-SUBLEVEL = 25
+VERSION = 6
+PATCHLEVEL = 1
+SUBLEVEL = 38
 ----
 
-In this instance, the sources are for a 3.10.25 kernel. You can see what version you're running on your system with the `uname -r` command.
+In this instance, the sources are for a 6.1.38 kernel. You can see what version you're running on your system with the `uname -r` command.
 
 === Applying Patches
 
@@ -23,9 +23,9 @@ How you apply patches depends on the format in which the patches are made availa
 
 [,bash]
 ----
- wget https://www.kernel.org/pub/linux/kernel/projects/rt/3.10/older/patch-3.10.25-rt23.patch.gz
- gunzip patch-3.10.25-rt23.patch.gz
- cat patch-3.10.25-rt23.patch | patch -p1
+ wget https://www.kernel.org/pub/linux/kernel/projects/rt/6.1/patch-6.1.38-rt13-rc1.patch.gz
+ gunzip patch-6.1.38-rt13-rc1.patch.gz
+ cat patch-6.1.38-rt13-rc1.patch | patch -p1
 ----
 
 In our example we simply download the file, uncompress it, and then pass it to the `patch` utility using the `cat` tool and a Unix pipe.

--- a/documentation/asciidoc/computers/raspberry-pi/revision-codes.adoc
+++ b/documentation/asciidoc/computers/raspberry-pi/revision-codes.adoc
@@ -15,7 +15,7 @@ Revision    : a02082
 Serial      : 00000000765fc593
 ----
 
-NOTE: As of the 4.9 kernel, all Raspberry Pi computers report `BCM2835`, even those with BCM2836, BCM2837 and BCM2711 processors. You should not use this string to detect the processor. Decode the revision code using the information below, or `cat /sys/firmware/devicetree/base/model`.
+NOTE: All Raspberry Pi computers report `BCM2835`, even those with BCM2836, BCM2837 and BCM2711 processors. You should not use this string to detect the processor. Decode the revision code using the information below, or `cat /sys/firmware/devicetree/base/model`.
 
 === Old-style revision codes
 

--- a/documentation/asciidoc/computers/raspberry-pi/spi-bus-on-raspberry-pi.adoc
+++ b/documentation/asciidoc/computers/raspberry-pi/spi-bus-on-raspberry-pi.adoc
@@ -430,7 +430,7 @@ This can be used to test SPI send and receive. Put a wire between MOSI and MISO.
 
 [,bash]
 ----
-wget https://raw.githubusercontent.com/raspberrypi/linux/rpi-3.10.y/Documentation/spi/spidev_test.c
+wget https://raw.githubusercontent.com/raspberrypi/linux/rpi-6.1.y/tools/spi/spidev_test.c
 gcc -o spidev_test spidev_test.c
 ./spidev_test -D /dev/spidev0.0
 spi mode: 0


### PR DESCRIPTION
Updated references to outdated Linux kernels, per issue #3075.

For references that contained language like, "as of" or "after" a certain kernel, I simply removed those version-specific callouts.