### PR TITLE
Custom template for tutorial sections

### DIFF
--- a/jekyll-assets/_templates/helpers.rb
+++ b/jekyll-assets/_templates/helpers.rb
@@ -1,3 +1,5 @@
+require 'net/http'
+
 module Slim::Helpers
   def book_link
     case (self.attr 'booktype')
@@ -17,6 +19,24 @@ module Slim::Helpers
     src = src.gsub(/^image::/, "")
     src = src.gsub(/\[.*?\]$/, "")
     return src
+  end
+
+  def tutorial_image
+    uri = URI(self.attr 'link')
+    source = Net::HTTP.get(uri)
+    # get the short description
+    desc = ""
+    desc_arr = /<meta[^>]+name="description"[^>]+content="([^>]+)"[^>]*>/.match(source)
+    if desc_arr
+      desc = desc_arr[1]
+    end
+    # get the image source
+    img_src = ""
+    img_arr = /<meta[^>]+property="og:image"[^>]+content="([^>]+)"[^>]*>/.match(source)
+    if img_arr
+      img_src = img_arr[1]
+    end
+    return '<a href="'+(self.attr 'link')+'" target="_blank" class="image"><div class="tutorialcard"><img src="'+img_src+'"/><p class="caption">'+desc+'</p></div></a>'
   end
 
   def section_title

--- a/jekyll-assets/_templates/section.html.slim
+++ b/jekyll-assets/_templates/section.html.slim
@@ -32,6 +32,13 @@
             =content
             div class="paragraph"
               p =book_link
+      - elsif role? 'tutoriallink'
+        div class="openblock float-group"
+          div class="content"
+            div class="imageblock related thumb right"
+              div class="content"
+                =tutorial_image  
+            =content
       - else
         =content
     - else
@@ -46,5 +53,12 @@
             =content
             div class="paragraph"
               p =book_link
+      - elsif role? 'tutoriallink'
+        div class="openblock float-group"
+          div class="content"
+            div class="imageblock related thumb right"
+              div class="content"
+                =tutorial_image  
+            =content
       - else
         =content

--- a/jekyll-assets/css/style.css
+++ b/jekyll-assets/css/style.css
@@ -647,6 +647,20 @@ div.videoblock iframe {
   margin-bottom: 10px;
 }
 
+/* TUTORIAL BLOCKS */
+
+#content .tutorialcard {
+  max-width: 400px;
+  border: 1px solid #dedede;
+  border-radius: 5px;
+}
+
+#content .tutorialcard p.caption {
+  padding-left: 10px;
+  padding-right: 10px;
+  font-size: 0.9em;
+}
+
 /* DOXYGEN ELEMENTS */
 
 div.memproto {


### PR DESCRIPTION
This PR scrapes the webpage for a given tutorial (e.g., https://www.raspberrypi.com/tutorials/build-your-own-weather-satellite-receiving-station/), and then creates a custom section in the documentation that sources in the tutorial description and header image.

Note that it is looking for these two `meta` elements on the linked page (attn: @mudge to let us know if this markup is prone to frequent changes):

```
<meta name="description" content="In this tutorial, we show you how to build a weather satellite receiving station using Raspberry Pi and a low-cost USB Software Defined Radio">
...
<meta property="og:image" content="https://www.raspberrypi.com/app/uploads/2023/08/Antenna-1024x576.jpg">
```

...though it should degrade gracefully, so if it can't find those it just won't show anything.

@aallan I laid it out card-style, so you should see something like the below, but let me know if you had something else in mind (the card is a clickable link):

<img width="892" alt="Screen Shot 2023-08-24 at 9 39 35 AM" src="https://github.com/raspberrypi/documentation/assets/812739/a45f8c64-2027-416b-9248-721404aadb55">

Required adoc markup is as follows:

```
[.tutoriallink, link=https://www.raspberrypi.com/tutorials/build-your-own-weather-satellite-receiving-station/]
==== Your Tutorial Heading

Your text content!
```

Someone else should definitely test this before we merge (by adding a tutorial section somewhere and then `make serve_html`), since I'm doing something a bit fancy and I'd love to be sure I'm not missing any key instructions or dependencies.