### PR TITLE
camera: Fix maximum exposure time value for Camera v1

### DIFF
--- a/documentation/asciidoc/accessories/camera/camera_hardware.adoc
+++ b/documentation/asciidoc/accessories/camera/camera_hardware.adoc
@@ -190,7 +190,7 @@ Then, please follow the relevant setup instructions for the xref:../computers/ca
 | Depends on lens
 
 | Maximum exposure times (seconds)
-| 6
+| 6 (legacy) / 0.97 (libcamera)
 | 11.76
 | 112
 | 112


### PR DESCRIPTION
This value is 6s only in the legacy firmware stack.