### PR TITLE
Bust cache for CSS and JS on every build

### DIFF
--- a/jekyll-assets/_includes/head.html
+++ b/jekyll-assets/_includes/head.html
@@ -16,8 +16,8 @@
 <link href="https://fonts.googleapis.com/css2?family=Roboto:ital,wght@0,100;0,300;0,400;0,700;1,100;1,300;1,400;1,700&display=swap" rel="stylesheet">
 <link rel="preconnect" href="https://IHWGNTJ1NP-dsn.algolia.net" crossorigin>
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@docsearch/css@3"/>
-<link rel="stylesheet" href="{{ site.baseurl }}/css/style.css?ver=1646652613">
-<link rel="stylesheet" href="{{ site.baseurl }}/css/tabs.css?ver=1639581228">
+<link rel="stylesheet" href="{{ site.baseurl }}/css/style.css?ver={{ site.time | date: '%s' }}">
+<link rel="stylesheet" href="{{ site.baseurl }}/css/tabs.css?ver={{ site.time | date: '%s' }}">
 <script async src="https://www.googletagmanager.com/gtag/js?id=UA-180927933-8"></script>
 <script>
   window.dataLayer = window.dataLayer || [];

--- a/jekyll-assets/_includes/scripts.html
+++ b/jekyll-assets/_includes/scripts.html
@@ -1,5 +1,5 @@
 <!-- Script for the TOC toggle -->
-<script src="{{ site.baseurl }}/scripts/nav.js" type="text/javascript"></script>
+<script src="{{ site.baseurl }}/scripts/nav.js?ver={{ site.time | date: '%s' }}" type="text/javascript"></script>
 
 <!-- TOCify scripts -->
 <script src="{{ site.baseurl }}/scripts/jquery-1.12.4.min.js"></script>
@@ -8,10 +8,10 @@
 
 <!-- Copy To Clipboard scripts -->
 <script src="{{ site.baseurl }}/scripts/clipboard.min.js"></script>
-<script src="{{ site.baseurl }}/scripts/copy-to-clipboard.js"></script>
+<script src="{{ site.baseurl }}/scripts/copy-to-clipboard.js?ver={{ site.time | date: '%s' }}"></script>
 
 <!-- Some custom handling for whitepapers -->
-<script src="{{ site.baseurl }}/scripts/whitepaper.js"></script>
+<script src="{{ site.baseurl }}/scripts/whitepaper.js?ver={{ site.time | date: '%s' }}"></script>
 
 <script>
   function hasher(text, element) {


### PR DESCRIPTION
GitHub: https://github.com/raspberrypi/documentation/issues/2991

To prevent stale versions of our stylesheets and JavaScript from being served after a deploy, ensure their URL is unique for each build by appending the time of the build (as seconds since the epoch) in a query string.

This means we will bust the cache even if our CSS and JS don't change (as the query string changes on every build rather than being a function of the contents of the relevant file) but this errs on the side of caution and keeps the implementation very simple compared to introducing an asset pipeline.

We only add the cache busting query string to files we change as opposed to vendored JavaScript (jQuery, etc.) as they shouldn't change without also updating their filename.
