### PR TITLE
Updated display configuration instructions for Bookworm changes

### DIFF
--- a/documentation/asciidoc/computers/legacy_config_txt/video.adoc
+++ b/documentation/asciidoc/computers/legacy_config_txt/video.adoc
@@ -1362,23 +1362,50 @@ hdmi_timings=<h_active_pixels> <h_sync_polarity> <h_front_porch> <h_sync_pulse> 
 <pixel_rep>       = leave at zero
 <frame_rate>      = screen refresh rate in Hz
 <interlaced>      = leave at zero
-<pixel_freq>      = clock frequency (width*height*framerate)
-<aspect_ratio>    = *
+<pixel_freq>      = clock frequency (h_active_pixels + h_front_porch + h_sync_pulse + h_back_porch)
+                                    * (v_active_lines + v_front_porch + v_sync_pulse + v_back_porch)
+                                    * framerate
+<aspect_ratio>    = [see footnote]
 ----
 
-`*` The aspect ratio can be set to one of eight values (choose the closest for your screen):
+The aspect ratio can be set to one of eight values. Choose a value representing the aspect ratio most similar to your screen from the following:
 
-[source]
-----
-HDMI_ASPECT_4_3 = 1
-HDMI_ASPECT_14_9 = 2
-HDMI_ASPECT_16_9 = 3
-HDMI_ASPECT_5_4 = 4
-HDMI_ASPECT_16_10 = 5
-HDMI_ASPECT_15_9 = 6
-HDMI_ASPECT_21_9 = 7
-HDMI_ASPECT_64_27 = 8
-----
+[cols="1,2,1"]
+|===
+|Aspect Ratio |Name |Value
+
+| 4:3
+| HDMI_ASPECT_4_3
+| 1
+
+| 14:9
+| HDMI_ASPECT_14_9
+| 2
+
+| 16:9
+| HDMI_ASPECT_16_9
+| 3
+
+| 5:4
+| HDMI_ASPECT_5_4
+| 4
+
+| 16:10
+| HDMI_ASPECT_16_10
+| 5
+
+| 15:9
+| HDMI_ASPECT_15_9
+| 6
+
+| 21:9
+| HDMI_ASPECT_21_9
+| 7
+
+| 64:27
+| HDMI_ASPECT_64_27
+| 8
+|===
 
 ==== `hdmi_force_mode`
 

--- a/documentation/asciidoc/computers/legacy_config_txt/video.adoc
+++ b/documentation/asciidoc/computers/legacy_config_txt/video.adoc
@@ -1591,22 +1591,50 @@ dpi_timings=<h_active_pixels> <h_sync_polarity> <h_front_porch> <h_sync_pulse> <
 <pixel_rep>       = leave at zero
 <frame_rate>      = screen refresh rate in Hz
 <interlaced>      = leave at zero
-<pixel_freq>      = clock frequency (width*height*framerate)
-<aspect_ratio>    = *
+<pixel_freq>      = clock frequency (h_active_pixels + h_front_porch + h_sync_pulse + h_back_porch)
+                                    * (v_active_lines + v_front_porch + v_sync_pulse + v_back_porch)
+                                    * framerate
+<aspect_ratio>    = [see footnote]
 ----
 
-`*` The aspect ratio can be set to one of eight values (choose the closest for your screen):
+The aspect ratio can be set to one of eight values. Choose a value representing the aspect ratio most similar to your screen from the following:
 
-----
-HDMI_ASPECT_4_3 = 1
-HDMI_ASPECT_14_9 = 2
-HDMI_ASPECT_16_9 = 3
-HDMI_ASPECT_5_4 = 4
-HDMI_ASPECT_16_10 = 5
-HDMI_ASPECT_15_9 = 6
-HDMI_ASPECT_21_9 = 7
-HDMI_ASPECT_64_27 = 8
-----
+[cols="1,2,1"]
+|===
+|Aspect Ratio |Name |Value
+
+| 4:3
+| HDMI_ASPECT_4_3
+| 1
+
+| 14:9
+| HDMI_ASPECT_14_9
+| 2
+
+| 16:9
+| HDMI_ASPECT_16_9
+| 3
+
+| 5:4
+| HDMI_ASPECT_5_4
+| 4
+
+| 16:10
+| HDMI_ASPECT_16_10
+| 5
+
+| 15:9
+| HDMI_ASPECT_15_9
+| 6
+
+| 21:9
+| HDMI_ASPECT_21_9
+| 7
+
+| 64:27
+| HDMI_ASPECT_64_27
+| 8
+|===
 
 === Generic Display Options
 

--- a/documentation/asciidoc/computers/raspberry-pi/display-parallel-interface.adoc
+++ b/documentation/asciidoc/computers/raspberry-pi/display-parallel-interface.adoc
@@ -1,10 +1,10 @@
-== Parallel Display Interface (DPI)
+== Parallel Display Interface
 
 [.whitepaper, title="Using a DPI Display on the Raspberry Pi", subtitle="", link=https://pip.raspberrypi.com/categories/685-whitepapers-app-notes/documents/RP-003471-WP/Using-a-DPI-display.pdf]
 ****
 Display Parallel Interface (DPI) displays can be connected to Raspberry Pi devices via the 40-pin general-purpose input/output (GPIO) connector as an alternative to using the dedicated Display Serial Interface (DSI) or High-Definition Multimedia Interface (HDMI) ports. Many third-party DPI displays have been made available to take advantage of this. The Buster (and earlier) Raspberry Pi operating system (OS) and the legacy display stack used Raspberry Pi-specific parameters in `config.txt` to configure DPI displays. With the move to Bullseye and its use of the Kernel Mode Setting (KMS) graphics driver by default, these `config.txt` entries are no longer relevant as all control of the display pipeline has shifted to the Linux kernel.
 
-This whitepaper assumes that the Raspberry Pi runs Raspberry Pi OS (Linux) and is fully up to date with the latest firmware and kernels.
+This whitepaper assumes that the Raspberry Pi is running the Raspberry Pi OS (Linux), and is fully up to date with the latest firmware and kernels.
 ****
 
 An up-to-24-bit parallel RGB interface is available on all Raspberry Pi boards with the 40 way header and the Compute Modules. This interface allows parallel RGB displays to be attached to the Raspberry Pi GPIO either in RGB24 (8 bits for red, green and blue) or RGB666 (6 bits per colour) or RGB565 (5 bits red, 6 green, and 5 blue).
@@ -335,7 +335,7 @@ h|*27* h|*26* h|*25* h|*24* h|*23* h|*22* h|*21* h|*20* h|*19* h|*18* h|*17* h|*
 
 === Disable Other GPIO Peripherals
 
-Note that all other peripheral overlays that use conflicting GPIO pins must be disabled. In `config.txt`, take care to comment out or invert any dtparams that enable I2C or SPI:
+All other peripheral overlays that use conflicting GPIO pins must be disabled. In `config.txt`, take care to comment out or invert any dtparams that enable I2C or SPI:
 
 ----
 dtparam=i2c_arm=off
@@ -349,7 +349,7 @@ The https://en.wikipedia.org/wiki/Direct_Rendering_Manager#Kernel_mode_setting[K
 ==== Auto Detect
 
 Auto detect allows your Raspberry Pi to connect with a display without a manually configured device tree overlay.
-Auto detection is enabled by default. You can enable display autodetect by adding the following line to `config.txt`:
+Auto detection is enabled by default. You can enable display auto detect by adding the following line to `config.txt`:
 
 ----
 `display_auto_detect=1`
@@ -362,7 +362,7 @@ When you connect the official Raspberry Pi display with auto detect enabled, KMS
 
 NOTE: In Raspberry Pi OS _Bookworm_ or later, the `dpi_output_format` and `dpi_timings` entries in `config.txt` previously used to set up DPI have been superseded by the `vc4-kms-dpi-generic` overlay.
 
-To use any display other than the official Raspberry Pi display, you must specify a `dtoverlay` entry in `config.txt`. The panel manufacturer should configure timings for your display in Linux kernel code and provide an overlay to enable those settings. See the https://github.com/raspberrypi/linux/blob/rpi-5.10.y/arch/arm/boot/dts/overlays/vc4-kms-kippah-7inch-overlay.dts[Adafruit Kippah display entry] for an example. The following example demonstrates how to set a `dtoverlay` entry for the Kippah display in your xref:config_txt.adoc#what-is-config-txt[`/boot/firmware/config.txt`] file:
+To use any display other than the official Raspberry Pi display, you must specify a `dtoverlay` entry in `config.txt`. The panel manufacturer should configure timings for your display in Linux kernel code and provide an overlay to enable those settings. See the https://github.com/raspberrypi/linux/blob/rpi-6.1.y/arch/arm/boot/dts/overlays/vc4-kms-kippah-7inch-overlay.dts[Adafruit Kippah display entry] for an example. The following example demonstrates how to set a `dtoverlay` entry for the Kippah display in your xref:config_txt.adoc#what-is-config-txt[`/boot/firmware/config.txt`] file:
 
 ----
 dtoverlay=vc4-kms-kippah-7inch-overlay
@@ -381,7 +381,7 @@ dtparam=clock-frequency=32000000,rgb666-padhi
 
 NOTE: Device tree line length must not exceed 80 characters. When a setting requires a line longer than 80 characters, split the assignment of that parameter across multiple lines.
 
-Paramater display tree definitions support the following options:
+Parameter display tree definitions support the following options:
 
 [cols="1,2"]
 |===
@@ -427,10 +427,10 @@ Paramater display tree definitions support the following options:
 | Negative edge pixel clock
 
 | `width-mm`
-| Defines the screen width in millimeters
+| Defines the screen width in millimetres
 
 | `height-mm`
-| Defines the screen height in millimeters
+| Defines the screen height in millimetres
 
 | `rgb565`
 | Change to RGB565 output on GPIOs 0-19

--- a/documentation/asciidoc/computers/raspberry-pi/display-parallel-interface.adoc
+++ b/documentation/asciidoc/computers/raspberry-pi/display-parallel-interface.adoc
@@ -2,14 +2,14 @@
 
 [.whitepaper, title="Using a DPI Display on the Raspberry Pi", subtitle="", link=https://pip.raspberrypi.com/categories/685-whitepapers-app-notes/documents/RP-003471-WP/Using-a-DPI-display.pdf]
 ****
-Display Parallel Interface (DPI) displays can be connected to Raspberry Pi devices via the 40-pin general-purpose input/output (GPIO) connector as an alternative to using the dedicated Display Serial Interface (DSI) or High-Definition Multimedia Interface (HDMI) ports. Many third-party DPI displays have been made available to take advantage of this. The Buster (and earlier) Raspberry Pi operating system (OS) and the legacy display stack used Raspberry Pi-specific parameters in config.txt to configure DPI displays. With the move to Bullseye and its use of the Kernel Mode Setting (KMS) graphics driver by default, these config.txt entries are no longer relevant as all control of the display pipeline has shifted to the Linux kernel.
+Display Parallel Interface (DPI) displays can be connected to Raspberry Pi devices via the 40-pin general-purpose input/output (GPIO) connector as an alternative to using the dedicated Display Serial Interface (DSI) or High-Definition Multimedia Interface (HDMI) ports. Many third-party DPI displays have been made available to take advantage of this. The Buster (and earlier) Raspberry Pi operating system (OS) and the legacy display stack used Raspberry Pi-specific parameters in `config.txt` to configure DPI displays. With the move to Bullseye and its use of the Kernel Mode Setting (KMS) graphics driver by default, these `config.txt` entries are no longer relevant as all control of the display pipeline has shifted to the Linux kernel.
 
-This whitepaper assumes that the Raspberry Pi is running the Raspberry Pi OS (Linux), and is fully up to date with the latest firmware and kernels.
+This whitepaper assumes that the Raspberry Pi runs Raspberry Pi OS (Linux) and is fully up to date with the latest firmware and kernels.
 ****
 
 An up-to-24-bit parallel RGB interface is available on all Raspberry Pi boards with the 40 way header and the Compute Modules. This interface allows parallel RGB displays to be attached to the Raspberry Pi GPIO either in RGB24 (8 bits for red, green and blue) or RGB666 (6 bits per colour) or RGB565 (5 bits red, 6 green, and 5 blue).
 
-This interface is controlled by the GPU firmware and can be programmed by a user via special config.txt parameters and by enabling the correct Linux Device Tree overlay.
+This interface is controlled by the GPU firmware and can be programmed by a user via special `config.txt` parameters and by enabling the correct Linux Device Tree overlay.
 
 === GPIO Pins
 
@@ -335,162 +335,115 @@ h|*27* h|*26* h|*25* h|*24* h|*23* h|*22* h|*21* h|*20* h|*19* h|*18* h|*17* h|*
 
 === Disable Other GPIO Peripherals
 
-Note that all other peripheral overlays that use conflicting GPIO pins must be disabled. In config.txt, take care to comment out or invert any dtparams that enable I2C or SPI:
+Note that all other peripheral overlays that use conflicting GPIO pins must be disabled. In `config.txt`, take care to comment out or invert any dtparams that enable I2C or SPI:
 
 ----
 dtparam=i2c_arm=off
 dtparam=spi=off
 ----
 
-=== Controlling Output Format
+=== Configure a Display
 
-The output format (clock, colour format, sync polarity, enable) can be controlled with a magic number (unsigned integer or hex value prefixed with 0x) passed to the `dpi_output_format` parameter in config.txt created from the following fields:
+The https://en.wikipedia.org/wiki/Direct_Rendering_Manager#Kernel_mode_setting[Kernel Mode Setting (KMS)] generic display interface enables output to arbitrary displays, as long as you have an appropriate driver.
 
-----
-output_format          = (dpi_output_format >>  0) & 0xf;
-rgb_order              = (dpi_output_format >>  4) & 0xf;
+==== Auto Detect
 
-output_enable_mode     = (dpi_output_format >>  8) & 0x1;
-invert_pixel_clock     = (dpi_output_format >>  9) & 0x1;
-
-hsync_disable          = (dpi_output_format >> 12) & 0x1;
-vsync_disable          = (dpi_output_format >> 13) & 0x1;
-output_enable_disable  = (dpi_output_format >> 14) & 0x1;
-
-hsync_polarity         = (dpi_output_format >> 16) & 0x1;
-vsync_polarity         = (dpi_output_format >> 17) & 0x1;
-output_enable_polarity = (dpi_output_format >> 18) & 0x1;
-
-hsync_phase            = (dpi_output_format >> 20) & 0x1;
-vsync_phase            = (dpi_output_format >> 21) & 0x1;
-output_enable_phase    = (dpi_output_format >> 22) & 0x1;
-
-output_format:
-   1: DPI_OUTPUT_FORMAT_9BIT_666
-   2: DPI_OUTPUT_FORMAT_16BIT_565_CFG1
-   3: DPI_OUTPUT_FORMAT_16BIT_565_CFG2
-   4: DPI_OUTPUT_FORMAT_16BIT_565_CFG3
-   5: DPI_OUTPUT_FORMAT_18BIT_666_CFG1
-   6: DPI_OUTPUT_FORMAT_18BIT_666_CFG2
-   7: DPI_OUTPUT_FORMAT_24BIT_888
-
-rgb_order:
-   1: DPI_RGB_ORDER_RGB
-   2: DPI_RGB_ORDER_BGR
-   3: DPI_RGB_ORDER_GRB
-   4: DPI_RGB_ORDER_BRG
-
-output_enable_mode:
-   0: DPI_OUTPUT_ENABLE_MODE_DATA_VALID
-   1: DPI_OUTPUT_ENABLE_MODE_COMBINED_SYNCS
-
-invert_pixel_clock:
-   0: RGB Data changes on rising edge and is stable at falling edge
-   1: RGB Data changes on falling edge and is stable at rising edge.
-
-hsync/vsync/output_enable_polarity:
-   0: default for HDMI mode
-   1: inverted
-
-hsync/vsync/oe phases:
-   0: DPI_PHASE_POSEDGE
-   1: DPI_PHASE_NEGEDGE
-----
-
-NB the single bit fields all act as an "invert default behaviour".
-
-=== Controlling Timings and Resolutions
-
-In firmware dated August 2018 or later, the `hdmi_timings` config.txt entry that was previously used to set up the DPI timings has be superseded by a new `dpi_timings` parameter. If the `dpi_timings` parameter is not present, the system will fall back to using the `hdmi_timings` parameter to ensure backwards compatibility. If neither are present and a custom mode is requested, then a default set of parameters for VGAp60 is used.
-
-The `dpi_group` and `dpi_mode` config.txt parameters are used to set either predetermined modes (DMT or CEA modes as used by HDMI) or a user can generate https://forums.raspberrypi.com/viewtopic.php?f=29&t=24679[custom modes].
-
-If you set up a custom DPI mode, then in config.txt use:
+Auto detect allows your Raspberry Pi to connect with a display without a manually configured device tree overlay.
+Auto detection is enabled by default. You can enable display autodetect by adding the following line to `config.txt`:
 
 ----
-dpi_group=2
-dpi_mode=87
+`display_auto_detect=1`
 ----
 
-This will tell the driver to use the custom `dpi_timings` (older firmware uses `hdmi_timings`) timings for the DPI panel.
+Replace the `1` with a `0` to disable auto detect.
+When you connect the official Raspberry Pi display with auto detect enabled, KMS determines the display model automatically and configures the appropriate display settings.
 
-The `dpi_timings` parameters are specified as a space-delimited set of parameters:
+==== Manually Configure a Display
 
-----
-dpi_timings=<h_active_pixels> <h_sync_polarity> <h_front_porch> <h_sync_pulse> <h_back_porch> <v_active_lines> <v_sync_polarity> <v_front_porch> <v_sync_pulse> <v_back_porch> <v_sync_offset_a> <v_sync_offset_b> <pixel_rep> <frame_rate> <interlaced> <pixel_freq> <aspect_ratio>
+NOTE: In Raspberry Pi OS _Bookworm_ or later, the `dpi_output_format` and `dpi_timings` entries in `config.txt` previously used to set up DPI have been superseded by the `vc4-kms-dpi-generic` overlay.
 
-<h_active_pixels> = horizontal pixels (width)
-<h_sync_polarity> = invert hsync polarity
-<h_front_porch>   = horizontal forward padding from DE active edge
-<h_sync_pulse>    = hsync pulse width in pixel clocks
-<h_back_porch>    = vertical back padding from DE active edge
-<v_active_lines>  = vertical pixels height (lines)
-<v_sync_polarity> = invert vsync polarity
-<v_front_porch>   = vertical forward padding from DE active edge
-<v_sync_pulse>    = vsync pulse width in pixel clocks
-<v_back_porch>    = vertical back padding from DE active edge
-<v_sync_offset_a> = leave at zero
-<v_sync_offset_b> = leave at zero
-<pixel_rep>       = leave at zero
-<frame_rate>      = screen refresh rate in Hz
-<interlaced>      = leave at zero
-<pixel_freq>      = clock frequency (width*height*framerate)
-<aspect_ratio>    = *
-
-* The aspect ratio can be set to one of eight values (choose closest for your screen):
-
-HDMI_ASPECT_4_3 = 1
-HDMI_ASPECT_14_9 = 2
-HDMI_ASPECT_16_9 = 3
-HDMI_ASPECT_5_4 = 4
-HDMI_ASPECT_16_10 = 5
-HDMI_ASPECT_15_9 = 6
-HDMI_ASPECT_21_9 = 7
-HDMI_ASPECT_64_27 = 8
-----
-
-=== Overlays
-
-A Linux Device Tree overlay is used to switch the GPIO pins into the correct mode (alt function 2). As previously mentioned, the GPU is responsible for driving the DPI display. Hence there is no Linux driver; the overlay simply sets the GPIO alt functions correctly.
-
-A 'full fat' DPI overlay (dpi24.dtb) is provided which sets all 28 GPIOs to ALT2 mode, providing the full 24 bits of colour bus as well as the h and v-sync, enable and pixel clock. Note this uses *all* of the bank 0 GPIO pins.
-
-A second overlay (vga666.dtb) is provided for driving VGA monitor signals in 666 mode which don't need the clock and DE pins (GPIO 0 and 1) and only require GPIOs 4-21 for colour (using mode 5).
-
-These overlays are fairly trivial and a user can edit them to create a custom overlay to enable just the pins required for their specific use case. For example, if one was using a DPI display using vsync, hsync, pclk, and de but in RGB565 mode (mode 2), then the dpi24.dtb overlay could be edited so that GPIOs 20-27 were not switched to DPI mode and hence could be used for other purposes.
-
-=== Example `config.txt` Settings
-
-==== Gert VGA666 adaptor
-
-This setup is for the https://github.com/fenlogic/vga666[Gert VGA adaptor].
-
-Note that the instructions provided in the documentation in the above GitHub link are somewhat out of date, so please use the settings below.
+To use any display other than the official Raspberry Pi display, you must specify a `dtoverlay` entry in `config.txt`. The panel manufacturer should configure timings for your display in Linux kernel code and provide an overlay to enable those settings. See the https://github.com/raspberrypi/linux/blob/rpi-5.10.y/arch/arm/boot/dts/overlays/vc4-kms-kippah-7inch-overlay.dts[Adafruit Kippah display entry] for an example. The following example demonstrates how to set a `dtoverlay` entry for the Kippah display in your xref:config_txt.adoc#what-is-config-txt[`/boot/firmware/config.txt`] file:
 
 ----
-dtoverlay=vga666
-enable_dpi_lcd=1
-display_default_lcd=1
-dpi_group=2
-dpi_mode=82
+dtoverlay=vc4-kms-kippah-7inch-overlay
 ----
 
-==== 800x480 LCD panel
+Display timings are usually defined in the kernel, but you can also define them in the provided `panel-dpi` driver. If your panel lacks a defined overlay in kernel code, you can use the `panel-dpi` driver to define display timings as parameters. This enables you to manually configure a device tree entry for any display.
 
-NOTE: This was tested with Adafruit's  https://www.adafruit.com/products/2453[DPI add-on board] and an 800x480 LCD panel.
+The following example demonstrates how you can define timings using device tree parameters:
 
 ----
-dtoverlay=dpi24
-overscan_left=0
-overscan_right=0
-overscan_top=0
-overscan_bottom=0
-framebuffer_width=800
-framebuffer_height=480
-enable_dpi_lcd=1
-display_default_lcd=1
-dpi_group=2
-dpi_mode=87
-dpi_output_format=0x6f005
-dpi_timings=800 0 40 48 88 480 0 13 3 32 0 0 0 60 0 32000000 6
+dtoverlay=vc4-kms-v3d
+dtoverlay=vc4-kms-dpi-generic,hactive=480,hfp=26,hsync=16,hbp=10
+dtparam=vactive=640,vfp=25,vsync=10,vbp=16
+dtparam=clock-frequency=32000000,rgb666-padhi
 ----
+
+NOTE: Device tree line length must not exceed 80 characters. When a setting requires a line longer than 80 characters, split the assignment of that parameter across multiple lines.
+
+Paramater display tree definitions support the following options:
+
+[cols="1,2"]
+|===
+| Option | Description
+
+| `clock-frequency`
+| Display clock frequency (Hz)
+
+| `hactive`
+| Horizontal active pixels
+
+| `hfp`
+| Horizontal front porch
+
+| `hsync`
+| Horizontal sync pulse width
+
+| `hbp`
+| Horizontal back porch
+
+| `vactive`
+| Vertical active lines
+
+| `vfp`
+| Vertical front porch
+
+| `vsync`
+| Vertical sync pulse width
+
+| `vbp`
+| Vertical back porch
+
+| `hsync-invert`
+| Horizontal sync active low
+
+| `vsync-invert`
+| Vertical sync active low
+
+| `de-invert`
+| Data Enable active low
+
+| `pixclk-invert`
+| Negative edge pixel clock
+
+| `width-mm`
+| Defines the screen width in millimeters
+
+| `height-mm`
+| Defines the screen height in millimeters
+
+| `rgb565`
+| Change to RGB565 output on GPIOs 0-19
+
+| `rgb666-padhi`
+| Change to RGB666 output on GPIOs 0-9, 12-17, and 20-25
+
+| `rgb888`
+| Change to RGB888 output on GPIOs 0-27
+
+| `bus-format`
+| Override the bus format for a MEDIA_BUS_FMT_* value, also overridden by rgbXXX overrides
+
+| `backlight-gpio`
+| Defines a GPIO to be used for backlight control (default value: none)
+|===


### PR DESCRIPTION
Updates the display configuration instructions to use the new `vc4-kms-dpi-generic` overlay instead of the deprecated `dpi_timings` configuration.

Requested `pixel-freq` clarification has been updated in the legacy documentation. But that documentation still refers to `hdmi_timings`, a configuration that's even more outdated than `dpi_timings`. Should we replace this doc with the current `dpi_timings` doc?

Closes https://github.com/raspberrypi/documentation/issues/2989