### PR TITLE
Updated to reflect journalctl

### DIFF
--- a/documentation/asciidoc/computers/configuration/securing-the-raspberry-pi.adoc
+++ b/documentation/asciidoc/computers/configuration/securing-the-raspberry-pi.adoc
@@ -279,11 +279,11 @@ Add the following section to the `jail.local` file. On some versions of fail2ban
 enabled  = true
 port     = ssh
 filter   = sshd
-logpath  = /var/log/auth.log
+backend  = systemd
 maxretry = 6
 ----
 
-As you can see, this section is named ssh, is enabled, examines the ssh port, filters using the `sshd` parameters, parses the `/var/log/auth.log` for malicious activity, and allows six retries before the detection threshold is reached. Checking the default section, we can see that the default banning action is:
+As you can see, this section is named ssh, is enabled, examines the ssh port, filters using the `sshd` parameters, parses the system log for malicious activity, and allows six retries before the detection threshold is reached. Checking the default section, we can see that the default banning action is:
 
 [,bash]
 ----
@@ -303,7 +303,7 @@ If you want to permanently ban an IP address after three failed attempts, you ca
 enabled  = true
 port     = ssh
 filter   = sshd
-logpath  = /var/log/auth.log
+backend  = systemd
 maxretry = 3
 bantime = -1
 ----

--- a/documentation/asciidoc/computers/remote-access/network-boot-raspberry-pi.adoc
+++ b/documentation/asciidoc/computers/remote-access/network-boot-raspberry-pi.adoc
@@ -249,7 +249,7 @@ Now monitor the `dnsmasq` log:
 
 [,bash]
 ----
-journalctl -ef
+journalctl -f
 ----
 
 You should see something like this:

--- a/documentation/asciidoc/computers/remote-access/network-boot-raspberry-pi.adoc
+++ b/documentation/asciidoc/computers/remote-access/network-boot-raspberry-pi.adoc
@@ -249,7 +249,7 @@ Now monitor the `dnsmasq` log:
 
 [,bash]
 ----
-tail -F /var/log/daemon.log
+journalctl -ef
 ----
 
 You should see something like this:

--- a/documentation/asciidoc/computers/remote-access/secure-shell-passwordless.adoc
+++ b/documentation/asciidoc/computers/remote-access/secure-shell-passwordless.adoc
@@ -95,7 +95,7 @@ If you can't establish a connection after following the steps above there might 
 
 [,bash]
 ----
-journalctl -ef
+journalctl -f
 # might return:
 Nov 23 12:31:26 raspberrypi sshd[9146]: Authentication refused: bad ownership or modes for directory /home/pi
 ----

--- a/documentation/asciidoc/computers/remote-access/secure-shell-passwordless.adoc
+++ b/documentation/asciidoc/computers/remote-access/secure-shell-passwordless.adoc
@@ -95,7 +95,7 @@ If you can't establish a connection after following the steps above there might 
 
 [,bash]
 ----
-tail -f /var/log/secure
+journalctl -ef
 # might return:
 Nov 23 12:31:26 raspberrypi sshd[9146]: Authentication refused: bad ownership or modes for directory /home/pi
 ----


### PR DESCRIPTION
Modified docs to reflect new system logging. Closes issue #3003 

Changes to `securing-the-raspberry-pi.adoc` pulled from: https://forum.proxmox.com/threads/pve-8-0-%E2%80%93-fail2ban-log-locations-missing.129338/

Changes to the other two files pulled from: https://www.debian.org/releases/bookworm/amd64/release-notes/ch-information.en.html#changes-to-system-logging

These may need to be tested. I'm not familiar enough to do so comfortably, however.