### PR TITLE
Scroll to a specific element if # is in the window url

### DIFF
--- a/jekyll-assets/_includes/scripts.html
+++ b/jekyll-assets/_includes/scripts.html
@@ -45,6 +45,7 @@
   function scrollToElement(selector) {
     try {
       // if found, scroll to that id hash
+      console.log("Scrolling to ", selector);
       var target = document.querySelector(selector);
       if (target) {
         var bbox = target.getBoundingClientRect();

--- a/jekyll-assets/_includes/scripts.html
+++ b/jekyll-assets/_includes/scripts.html
@@ -17,8 +17,61 @@
   function hasher(text, element) {
     return text.toLowerCase().replace(/ /g, "-").replace(/\./g, "-").replace(/[^-\w]/g, "").replace(/-+/g, "-");
   }
+
+  function waitForElementToDisplay(selector, checkFrequencyInMs, timeoutInMs) {
+    try {
+      // wait for all the content to load first...
+      var startTimeInMs = Date.now();
+      (function loopSearch() {
+        //  && document.querySelector(selector).getBoundingClientRect().top > 0
+        if (document.querySelector(selector) != null && document.querySelector(selector).getBoundingClientRect().top > 0) {
+          scrollToElement(selector);
+          return;
+        }
+        else {
+          setTimeout(function () {
+            if (timeoutInMs && Date.now() - startTimeInMs > timeoutInMs)
+              return;
+            loopSearch();
+          }, checkFrequencyInMs);
+        }
+      })();
+    } catch (e) {
+      console.log("there was an error in scrollToElement:");
+      console.log(e);
+    }
+  }
+
+  function scrollToElement(selector) {
+    try {
+      // if found, scroll to that id hash
+      var target = document.querySelector(selector);
+      if (target) {
+        var bbox = target.getBoundingClientRect();
+        var myid = target.getAttribute("id");
+        window.scrollTo({
+          top: bbox.top,
+          left: 0,
+          behavior: "smooth",
+        });
+      } else {
+        console.log("Target not found :(");
+      }
+    } catch (e) {
+      console.log("there was an error in scrollToElement:");
+      console.log(e);
+    }
+  }
+
   $(function() {
     $("#toc").tocify({ showAndHide: false, hashGenerator: hasher, extendPage: false, ignoreSelector: ".discrete" });
+    // special handling to scroll to tocify elements on the page
+    if (window.location.hasOwnProperty("hash") && window.location.hash.indexOf("#") > -1) {
+      var myhash = window.location.hash;
+      myhash = myhash.replace("#", "");
+      var selector = "div[data-unique="+myhash+"] + *";
+      waitForElementToDisplay(selector, 1000, 9000);
+    }
   });
 </script>
 


### PR DESCRIPTION
This script will scroll to a specific element as indicated in the window url, e.g. https://www.raspberrypi.com/documentation/pico-sdk/high_level.html#functions30. The reason this wasn't working before was due to the toc/nav library we use (tocify), which creates its own unique id markers for every header in the page and then links to those (e.g. "functions30") instead of the ids that we generate for each heading ("rpip1234..."). Since these ids don't exist until after tocify runs, it creates some order-of-operations issues when loading these kinds of pages.

This script should only run when the page is first loaded, meaning that it won't interfere with the existing nav functionality. If the specified element isn't found within 9 seconds, the script will give up and leave you at the top of the page. Note that this script is intended to work when a page is loaded from scratch, and you may get unexpected results in other scenarios. For example, if you load https://www.raspberrypi.com/documentation/pico-sdk/high_level.html#functions30, then scroll down on the page, and then click refresh, you'll just get scrolled to the top of the page.

I tried to find an option in tocify to let us just link to our generated ids, but I couldn't find one (would have been much cleaner).

Fixes #2829 