### PR TITLE
Update network configuration instructions for Bookworm

### DIFF
--- a/documentation/asciidoc/computers/configuration/configuring-networking.adoc
+++ b/documentation/asciidoc/computers/configuration/configuring-networking.adoc
@@ -2,13 +2,13 @@
 
 Raspberry Pi OS provides a Graphical User Interface (GUI) for setting up wireless connections. Users of Raspberry Pi OS Lite and headless machines can set up wireless networking from the command line with https://developer-old.gnome.org/NetworkManager/stable/nmcli.html[`nmcli`].
 
-NOTE: These instructions work for Raspberry Pi OS _Bookworm_ and later. For earlier versions, check an older version of the documentation.
+NOTE: Network Manager is the default networking configuration tool under Raspberry Pi OS _Bookworm_ or later. While Network Manager can be installed on earlier versions of the operating system using `apt` and configured as the default using `raspi-config`, earlier versions used `dhcpd` and other tools for network configuration by default.
 
 === Using the Desktop
 
 Access the Network Manager via the network icon at the right-hand end of the menu bar. If you are using a Raspberry Pi with built-in wireless connectivity, or if a wireless dongle is plugged in, click this icon to bring up a list of available wireless networks. If you see the message 'No APs found - scanning...', wait a few seconds, and the Network Manager should find your network.
 
-NOTE: Raspberry Pi devices that support the 5GHz band (Pi3B+, Pi4, CM4, Pi400), disable wireless networking until you assign a wireless LAN country. To set a wireless LAN country, open the `Raspberry Pi Configuration` application from the Preferences Menu, select *Localisation* and select your country.
+NOTE: Raspberry Pi devices that support dual-band wireless (Raspberry Pi 3B+, Raspberry Pi 4, Compute Module 4, and Raspberry Pi 400) automatically disable networking until a you assign a wireless LAN country. To set a wireless LAN country, open the Raspberry Pi Configuration application from the Preferences Menu, select *Localisation* and select your country from the menu.
 
 image::images/wifi2.png[wifi2]
 
@@ -21,7 +21,7 @@ Enter the key and click *OK*, then wait a couple of seconds. The network icon wi
 [[wireless-networking-command-line]]
 === Using the Command Line
 
-This guide will help you configure a wireless connection on your Raspberry Pi entirely from a terminal without using a GUI. No additional software is required; Raspberry Pi OS comes preconfigured with everything you need.
+This guide will help you configure a wireless connection on your Raspberry Pi entirely from a terminal without using graphical tools. No additional software is required; Raspberry Pi OS comes preconfigured with everything you need.
 
 NOTE: This guide should work for WEP, WPA, WPA2, or WPA3 networks, but may not work for enterprise networks.
 

--- a/documentation/asciidoc/computers/configuration/configuring-networking.adoc
+++ b/documentation/asciidoc/computers/configuration/configuring-networking.adoc
@@ -1,6 +1,8 @@
 == Configuring Networking
 
-Raspberry Pi OS provides a GUI (graphical user interface) for setting up wireless connections. Users of Raspberry Pi OS Lite and headless machines can set up wireless networking from the command line with https://developer-old.gnome.org/NetworkManager/stable/nmcli.html[`nmcli`].
+Raspberry Pi OS provides a Graphical User Interface (GUI) for setting up wireless connections. Users of Raspberry Pi OS Lite and headless machines can set up wireless networking from the command line with https://developer-old.gnome.org/NetworkManager/stable/nmcli.html[`nmcli`].
+
+NOTE: These instructions work for Raspberry Pi OS _Bookworm_ and later. For earlier versions, check an older version of the documentation.
 
 === Using the Desktop
 
@@ -29,18 +31,12 @@ On a fresh install, you must specify the country where you use your device.
 This allows your device to choose the correct frequency bands for 5GHz networking.
 Once you have specified a locale, you can use your Raspberry Pi's built-in wireless networking module.
 
-To do this, set your locale with the command line `raspi-config` tool.
-
-1. Run the following command:
-+
---
+To do this, set your locale with the command line `raspi-config` tool. Run the following command:
 ----
 sudo raspi-config
 ----
---
-2. Select the *Localisation Options* menu item using the arrow keys. Press `Enter`.
-3. Select the *WLAN Country* option.
-4. Pick your country from the dropdown using the arrow keys. Press `Enter` to select a country.
+Select the *Localisation Options* menu item using the arrow keys. Choose the *WLAN Country* option.
+Pick your country from the dropdown using the arrow keys. Press `Enter` to select your country.
 
 You should now have access to wireless networking. Run the following command to check if your wifi radio is enabled:
 
@@ -83,7 +79,7 @@ Run the following command to configure a network connection:
 sudo nmcli --ask dev wifi connect <example_ssid>
 ----
 
-NOTE: Don't forget to replace `<example_ssid>` with the name of the network you're trying to configure!
+Don't forget to replace `<example_ssid>` with the name of the network you're trying to configure.
 
 Enter your network password when prompted.
 
@@ -113,6 +109,7 @@ IN-USE  BSSID              SSID            MODE   CHAN  RATE        SIGNAL  BARS
 
 Check for an asterisk (`*`) in the "IN-USE" column; it should appear in the same row as the SSID of the network you intended to connect to.
 
+NOTE: You can manually edit your connection configurations in the `/etc/NetworkManager/system-connections/` directory.
 
 ==== Connect to an Unsecured Network
 
@@ -158,7 +155,20 @@ The following example command sets the priority of a network named "Pi Towers" t
 nmcli connection modify "Pi Towers" connection.autoconnect-priority 10
 ----
 
-Your device will always try to connect to the in-range network with the highest priority. You can also assign a network a negative priority; your device will only attempt to connect to a negative priority network if no other known network is in range.
+Your device will always try to connect to the in-range network with the highest non-negative priority value. You can also assign a network a negative priority; your device will only attempt to connect to a negative priority network if no other known network is in range. For example, consider three networks:
+
+----
+AUTOCONNECT-PRIORITY  NAME
+-1                    snake
+0                     rabbit
+1                     cat
+1000                  dog
+----
+
+- If all of these networks were in range, your device would first attempt to connect to the "dog" network.
+- If connection to the "dog" network fails, your device would attempt to connect to the "cat" network.
+- If connection to the "cat" network fails, your device would attempt to connect to the "rabbit" network.
+- If connection to the "rabbit" network fails, and your device detects no other known networks, your device will attempt to connect to the "snake" network.
 
 === Configure DHCP
 

--- a/documentation/asciidoc/computers/configuration/configuring-networking.adoc
+++ b/documentation/asciidoc/computers/configuration/configuring-networking.adoc
@@ -72,7 +72,6 @@ Look in the "SSID" column for the name of the network you would like to connect 
 
 ==== Connect to a Network
 
-We'll use `nmcli` to connect to a WiFi network.
 Run the following command to configure a network connection:
 
 ----

--- a/documentation/asciidoc/computers/configuration/configuring-networking.adoc
+++ b/documentation/asciidoc/computers/configuration/configuring-networking.adoc
@@ -6,9 +6,9 @@ NOTE: These instructions work for Raspberry Pi OS _Bookworm_ and later. For earl
 
 === Using the Desktop
 
-Quickly access the Network Manager via the network icon at the right-hand end of the menu bar. If you are using a Raspberry Pi with built-in wireless connectivity, or if a wireless dongle is plugged in, click this icon to bring up a list of available wireless networks. If you see the message 'No APs found - scanning...', wait a few seconds, and the Network Manager should find your network.
+Access the Network Manager via the network icon at the right-hand end of the menu bar. If you are using a Raspberry Pi with built-in wireless connectivity, or if a wireless dongle is plugged in, click this icon to bring up a list of available wireless networks. If you see the message 'No APs found - scanning...', wait a few seconds, and the Network Manager should find your network.
 
-NOTE: Raspberry Pi devices that support the 5GHz band (Pi3B+, Pi4, CM4, Pi400), disable wireless networking until you assign a locale. To set a locale, open the `Raspberry Pi Configuration` application from the Preferences Menu, select *Localisation* and select your country.
+NOTE: Raspberry Pi devices that support the 5GHz band (Pi3B+, Pi4, CM4, Pi400), disable wireless networking until you assign a wireless LAN country. To set a wireless LAN country, open the `Raspberry Pi Configuration` application from the Preferences Menu, select *Localisation* and select your country.
 
 image::images/wifi2.png[wifi2]
 
@@ -29,9 +29,9 @@ NOTE: This guide should work for WEP, WPA, WPA2, or WPA3 networks, but may not w
 
 On a fresh install, you must specify the country where you use your device.
 This allows your device to choose the correct frequency bands for 5GHz networking.
-Once you have specified a locale, you can use your Raspberry Pi's built-in wireless networking module.
+Once you have specified a wireless LAN country, you can use your Raspberry Pi's built-in wireless networking module.
 
-To do this, set your locale with the command line `raspi-config` tool. Run the following command:
+To do this, set your wireless LAN country with the command line `raspi-config` tool. Run the following command:
 ----
 sudo raspi-config
 ----

--- a/documentation/asciidoc/computers/configuration/configuring-networking.adoc
+++ b/documentation/asciidoc/computers/configuration/configuring-networking.adoc
@@ -1,183 +1,169 @@
 == Configuring Networking
 
-A GUI is provided for setting up wireless connections in Raspberry Pi OS with desktop. However if you are using Raspberry Pi OS Lite, you can set up wireless networking from the command line.
+Raspberry Pi OS provides a GUI (graphical user interface) for setting up wireless connections. Users of Raspberry Pi OS Lite and headless machines can set up wireless networking from the command line with https://developer-old.gnome.org/NetworkManager/stable/nmcli.html[`nmcli`].
 
 === Using the Desktop
 
-Wireless connections can be made via the network icon at the right-hand end of the menu bar. If you are using a Raspberry Pi with built-in wireless connectivity, or if a wireless dongle is plugged in, left-clicking this icon will bring up a list of available wireless networks, as shown below. If no networks are found, it will show the message 'No APs found - scanning...'. Wait a few seconds without closing the menu, and it should find your network.
+Quickly access the Network Manager via the network icon at the right-hand end of the menu bar. If you are using a Raspberry Pi with built-in wireless connectivity, or if a wireless dongle is plugged in, click this icon to bring up a list of available wireless networks. If you see the message 'No APs found - scanning...', wait a few seconds, and the Network Manager should find your network.
 
-Note that on Raspberry Pi devices that support the 5GHz band (Pi3B+, Pi4, CM4, Pi400), wireless networking is disabled for regulatory reasons, until the country code has been set. To set the country code, open the `Raspberry Pi Configuration` application from the Preferences Menu, select *Localisation* and set the appropriate code.
+NOTE: Raspberry Pi devices that support the 5GHz band (Pi3B+, Pi4, CM4, Pi400), disable wireless networking until you assign a locale. To set a locale, open the `Raspberry Pi Configuration` application from the Preferences Menu, select *Localisation* and select your country.
 
 image::images/wifi2.png[wifi2]
 
-The icons on the right show whether a network is secured or not, and give an indication of its signal strength. Click the network that you want to connect to. If it is secured, a dialogue box will prompt you to enter the network key:
+The icons on the right show whether a network is secured or not and give an indication of signal strength. Click the network that you want to connect to. If the network is secured, a dialogue box will prompt you to enter the network key:
 
 image::images/key.png[key]
 
-Enter the key and click *OK*, then wait a couple of seconds. The network icon will flash briefly to show that a connection is being made. When it is ready, the icon will stop flashing and show the signal strength.
+Enter the key and click *OK*, then wait a couple of seconds. The network icon will flash briefly to show that a connection is being made. When connected, the icon will stop flashing and show the signal strength.
 
 [[wireless-networking-command-line]]
 === Using the Command Line
 
-This method is suitable if you don't have access to the graphical user interface normally used to set up a wireless LAN on the Raspberry Pi. It is particularly suitable for use with a serial console cable if you don't have access to a screen or wired Ethernet network. Note also that no additional software is required; everything you need is already included on the Raspberry Pi.
+This guide will help you configure a wireless connection on your Raspberry Pi entirely from a terminal without using a GUI. No additional software is required; Raspberry Pi OS comes preconfigured with everything you need.
 
-==== Using raspi-config
+NOTE: This guide should work for WEP, WPA, WPA2, or WPA3 networks, but may not work for enterprise networks.
 
-The quickest way to enable wireless networking is to use the command line `raspi-config` tool.
+==== Enable Wireless Networking
 
-`sudo raspi-config`
+On a fresh install, you must specify the country where you use your device.
+This allows your device to choose the correct frequency bands for 5GHz networking.
+Once you have specified a locale, you can use your Raspberry Pi's built-in wireless networking module.
 
-Select the *Localisation Options* item from the menu, then the *Change wireless country* option. On a fresh install, for regulatory purposes, you will need to specify the country in which the device is being used. Then set the SSID of the network, and the passphrase for the network. If you do not know the SSID of the network you want to connect to, see the next section on how to list available networks prior to running `raspi-config`.
+To do this, set your locale with the command line `raspi-config` tool.
 
-Note that `raspi-config` does not provide a complete set of options for setting up wireless networking; you may need to refer to the extra sections below for more details if `raspi-config` fails to connect the Raspberry Pi to your requested network.
+1. Run the following command:
++
+--
+----
+sudo raspi-config
+----
+--
+2. Select the *Localisation Options* menu item using the arrow keys. Press `Enter`.
+3. Select the *WLAN Country* option.
+4. Pick your country from the dropdown using the arrow keys. Press `Enter` to select a country.
 
-==== Getting Wireless LAN Network Details
-
-To scan for wireless networks, use the command `sudo iwlist wlan0 scan`. This will list all available wireless networks, along with other useful information. Look out for:
-
-. 'ESSID:"testing"' is the name of the wireless network.
-. 'IE: IEEE 802.11i/WPA2 Version 1' is the authentication used. In this case it's WPA2, the newer and more secure wireless standard which replaces WPA. This guide should work for WPA or WPA2, but may not work for WPA2 enterprise. You'll also need the password for the wireless network. For most home routers, this is found on a sticker on the back of the router. The ESSID (ssid) for the examples below is `testing` and the password (psk) is `testingPassword`.
-
-==== Adding the Network Details to your Raspberry Pi
-
-Open the `wpa-supplicant` configuration file in nano:
-
-`sudo nano /etc/wpa_supplicant/wpa_supplicant.conf`
-
-Go to the bottom of the file and add the following:
+You should now have access to wireless networking. Run the following command to check if your wifi radio is enabled:
 
 ----
-network={
-    ssid="testing"
-    psk="testingPassword"
-}
+nmcli radio wifi
 ----
 
-The password can be configured either as the ASCII representation, in quotes as per the example above, or as a pre-encrypted 32 byte hexadecimal number. You can use the `wpa_passphrase` utility to generate an encrypted PSK. This takes the SSID and the password, and generates the encrypted PSK. With the example from above, you can generate the PSK with `wpa_passphrase "testing"`. Then you will be asked for the password of the wireless network (in this case `testingPassword`). The output is as follows:
+If this command returns the text "enabled", you're ready to configure a connection. If this command returns "disabled", try enabling WiFi with the following command:
 
 ----
-  network={
-	  ssid="testing"
-	  #psk="testingPassword"
-	  psk=131e1e221f6e06e3911a2d11ff2fac9182665c004de85300f9cac208a6a80531
-  }
+nmcli radio wifi on
 ----
 
-Note that the plain text version of the code is present, but commented out. You should delete this line from the final `wpa_supplicant` file for extra security.
+==== Find Networks
 
-The `wpa_passphrase` tool requires a password with between 8 and 63 characters. To use a more complex password, you can extract the content of a text file and use it as input for `wpa_passphrase`. Store the password in a text file and input it to `wpa_passphrase` by calling `wpa_passphrase "testing" < file_where_password_is_stored`. For extra security, you should delete the `file_where_password_is_stored` afterwards, so there is no plain text copy of the original password on the system.
-
-To use the `wpa_passphrase`--encrypted PSK, you can either copy and paste the encrypted PSK into the `wpa_supplicant.conf` file, or redirect the tool's output to the configuration file in one of two ways:
-
-* Either change to `root` by executing `sudo su`, then call `wpa_passphrase "testing" >> /etc/wpa_supplicant/wpa_supplicant.conf` and enter the testing password when asked
-* Or use `wpa_passphrase "testing" | sudo tee -a /etc/wpa_supplicant/wpa_supplicant.conf > /dev/null` and enter the testing password when asked; the redirection to `/dev/null` prevents `tee` from *also* outputting to the screen (standard output).
-
-If you want to use one of these two options, *make sure you use `>>`, or use `-a` with `tee`* -- either will *append* text to an existing file. Using a single chevron `>`, or omitting `-a` when using `tee`, will erase all contents and *then* append the output to the specified file.
-
-Now save the file by pressing `Ctrl+X`, then `Y`, then finally press `Enter`.
-
-Reconfigure the interface with `wpa_cli -i wlan0 reconfigure`.
-
-You can verify whether it has successfully connected using `ifconfig wlan0`. If the `inet addr` field has an address beside it, the Raspberry Pi has connected to the network. If not, check that your password and ESSID are correct.
-
-On the Raspberry Pi 3B+ and Raspberry Pi 4B, you will also need to set the country code, so that the 5GHz networking can choose the correct frequency bands. You can do this using the `raspi-config` application: select the 'Localisation Options' menu, then 'Change Wi-Fi Country'. Alternatively, you can edit the `wpa_supplicant.conf` file and add the following. (Note: you need to replace 'GB' with the 2 letter ISO code of your country. See https://en.wikipedia.org/wiki/ISO_3166-1[Wikipedia] for a list of 2 letter ISO 3166-1 country codes.)
+To scan for wireless networks, run the following command:
 
 ----
-country=GB
+nmcli dev wifi list
 ----
 
-Note that with the latest Raspberry Pi OS release, you must ensure that the `wpa_supplicant.conf` file contains the following information at the top:
+You should see output similar to the following:
 
 ----
-ctrl_interface=DIR=/var/run/wpa_supplicant GROUP=netdev
-update_config=1
-country=<Insert 2 letter ISO 3166-1 country code here>
+IN-USE  BSSID              SSID            MODE   CHAN  RATE        SIGNAL  BARS  SECURITY
+        90:72:40:1B:42:05  myNetwork       Infra  132   405 Mbit/s  89      ****  WPA2
+        90:72:42:1B:78:04  myNetwork5G     Infra  11    195 Mbit/s  79      ***   WPA2
+        9C:AB:F8:88:EB:0D  Pi Towers       Infra  1     260 Mbit/s  75      ***   WPA2 802.1X
+        B4:2A:0E:64:BD:BE  Example         Infra  6     195 Mbit/s  37      **    WPA1 WPA2
 ----
 
-==== Using Unsecured Networks
+Look in the "SSID" column for the name of the network you would like to connect to. Use the SSID and a password to connect to the network.
 
-If the network you are connecting to does not use a password, the `wpa_supplicant` entry for the network will need to include the correct `key_mgmt` entry.
-e.g.
+==== Connect to a Network
 
-----
-network={
-    ssid="testing"
-    key_mgmt=NONE
-}
-----
-
-WARNING: You should be careful when using unsecured wireless networks.
-
-==== Hidden Networks
-
-If you are using a hidden network, an extra option in the `wpa_supplicant file`, `scan_ssid`, may help connection.
+We'll use `nmcli` to connect to a WiFi network.
+Run the following command to configure a network connection:
 
 ----
-network={
-    ssid="yourHiddenSSID"
-    scan_ssid=1
-    psk="Your_wireless_network_password"
-}
+sudo nmcli --ask dev wifi connect <example_ssid>
 ----
 
-You can verify whether it has successfully connected using `ifconfig wlan0`. If the `inet addr` field has an address beside it, the Raspberry Pi has connected to the network. If not, check your password and ESSID are correct.
+NOTE: Don't forget to replace `<example_ssid>` with the name of the network you're trying to configure!
 
-==== Adding Multiple Wireless Network Configurations
+Enter your network password when prompted.
 
-On recent versions of Raspberry Pi OS, it is possible to set up multiple configurations for wireless networking. For example, you could set up one for home and one for school.
-
-For example
+Your Raspberry Pi should automatically connect to the network once you enter your password. If you see the following output:
 
 ----
-network={
-    ssid="SchoolNetworkSSID"
-    psk="passwordSchool"
-    id_str="school"
-}
-
-network={
-    ssid="HomeNetworkSSID"
-    psk="passwordHome"
-    id_str="home"
-}
+Error: Connection activation failed: Secrets were required, but not provided.
 ----
 
-If you have two networks in range, you can add the priority option to choose between them. The network in range, with the highest priority, will be the one that is connected.
+This means that you entered an incorrect password. If you see this error, run the above command again, being careful to enter your password correctly.
+
+To check if you're connected to a network, run the following command:
 
 ----
-network={
-    ssid="HomeOneSSID"
-    psk="passwordOne"
-    priority=1
-    id_str="homeOne"
-}
-
-network={
-    ssid="HomeTwoSSID"
-    psk="passwordTwo"
-    priority=2
-    id_str="homeTwo"
-}
+nmcli dev wifi list
 ----
 
-
-=== The DHCP Daemon
-
-The Raspberry Pi uses `dhcpcd` to configure TCP/IP across all of its network interfaces. The `dhcpcd` daemon is intended to be an all-in-one ZeroConf client for UNIX-like systems. This includes assigning each interface an IP address, setting netmasks, and configuring DNS resolution via the Name Service Switch (NSS) facility.
-
-By default, Raspberry Pi OS attempts to automatically configure all network interfaces by DHCP, falling back to automatic private addresses in the range 169.254.0.0/16 if DHCP fails. This is consistent with the behaviour of other Linux variants and of Microsoft Windows.
-
-=== Static IP Addresses
-
-WARNING: If allocation of IP addresses is normally handled by a DHCP server on your network, allocating your Raspberry Pi a static IP address may cause an address conflict which may lead to networking problems.
-
-If you want to allocate a static IP address to your Raspberry Pi, the best way to do so is to reserve an address for it on your router. That way your Raspberry Pi will continue to have its address allocated via DHCP but will receive the same address each time. A "fixed" address can be allocated by your DHCP server associating it with the MAC address of your Raspberry Pi. Management of IP addresses will remain with the DHCP server and this will avoid address conflicts and potential network problems.
-
-However, if you wish to disable automatic configuration for an interface, and instead configure it statically, you can do so in `/etc/dhcpcd.conf`. For example:
+You should see output similar to the following:
 
 ----
-interface eth0
-static ip_address=192.168.0.4/24	
-static routers=192.168.0.254
-static domain_name_servers=192.168.0.254 8.8.8.8
+IN-USE  BSSID              SSID            MODE   CHAN  RATE        SIGNAL  BARS  SECURITY
+*       90:72:40:1B:42:05  myNetwork       Infra  132   405 Mbit/s  89      ****  WPA2
+        90:72:42:1B:78:04  myNetwork5G     Infra  11    195 Mbit/s  79      ***   WPA2
+        9C:AB:F8:88:EB:0D  Pi Towers       Infra  1     260 Mbit/s  75      ***   WPA2 802.1X
+        B4:2A:0E:64:BD:BE  Example         Infra  6     195 Mbit/s  37      **    WPA1 WPA2
 ----
+
+Check for an asterisk (`*`) in the "IN-USE" column; it should appear in the same row as the SSID of the network you intended to connect to.
+
+
+==== Connect to an Unsecured Network
+
+If the network you are connecting to does not use a password, run the following command:
+
+----
+sudo nmcli dev wifi connect <example_ssid>
+----
+
+WARNING: Be careful when using unsecured wireless networks. 
+
+==== Connect to a Hidden Network
+
+If you are using a hidden network, specify the "hidden" option with a value of "yes" when you run `nmcli`:
+
+----
+sudo nmcli --ask dev wifi connect <example_ssid> hidden yes
+----
+
+==== Set Priority Among Multiple Networks
+
+If your device detects more than one known networks at the same time, it could connect any of the detected known networks. Use the priority option to force your device to prefer certain networks. Your device will connect to the network that is in range with the highest priority. Run the following command to view the priority of known networks:
+
+----
+nmcli --fields autoconnect-priority,name connection
+----
+
+You should see output similar to the following:
+
+----
+AUTOCONNECT-PRIORITY  NAME
+0                     myNetwork
+0                     lo
+0                     Pi Towers
+0                     Example
+-999                  Wired connection 1
+----
+
+Use the `nmcli connection modify` command to set the priority of a network.
+The following example command sets the priority of a network named "Pi Towers" to `10`:
+
+----
+nmcli connection modify "Pi Towers" connection.autoconnect-priority 10
+----
+
+Your device will always try to connect to the in-range network with the highest priority. You can also assign a network a negative priority; your device will only attempt to connect to a negative priority network if no other known network is in range.
+
+=== Configure DHCP
+
+By default, Raspberry Pi OS attempts to automatically configure all network interfaces by DHCP, falling back to automatic private addresses in the range 169.254.0.0/16 if DHCP fails.
+
+=== Assign a Static IP Address
+
+To allocate a static IP address to your Raspberry Pi, reserve an address for it on your router. That way your Raspberry Pi will continue to have its address allocated via DHCP but will receive the same address each time. A "fixed" address can be allocated by associating the MAC address of your Raspberry Pi with a static IP address in your DHCP server.


### PR DESCRIPTION
Closes https://github.com/raspberrypi/documentation/issues/2956

- Updated commands across the network configuration instructions to use `nmcli` instead of older network configuration tools that no longer exist in Bookworm.
- Removed instructions to input an encrypted password via a file; because `nmcli` stores network configuration in a file readable only by admin accounts, this no longer seems necessary. Open to adding encrypted password instructions back in, once I determine if it's even possible with `nmcli`.
- Removed instructions to set a static IP address locally. I'm sure it worked for someone at some point, but given my knowledge of DHCP, I am skeptical that we should endorse voodoo like this officially.
- General ~bug fixes and updates~ word removals, sentence streamlining, etc.