### PR TITLE
Bust cache for boxes.css on every build

### DIFF
--- a/jekyll-assets/_layouts/boxes.html
+++ b/jekyll-assets/_layouts/boxes.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     {% include head.html %} 
-    <link rel="stylesheet" href="{{ site.baseurl }}/css/boxes.css">
+    <link rel="stylesheet" href="{{ site.baseurl }}/css/boxes.css?ver={{ site.time | date: '%s' }}">
   </head>
   <body>
     {% include header.html %}      


### PR DESCRIPTION
Following on from the work in https://github.com/raspberrypi/documentation/pull/3097, ensure we bust the cache for boxes.css too which was missed in the first pass as it isn't included on every page.
