### PR TITLE
Remove style guide faux pas 'machine' term

### DIFF
--- a/documentation/asciidoc/computers/configuration/headless.adoc
+++ b/documentation/asciidoc/computers/configuration/headless.adoc
@@ -1,9 +1,9 @@
 [[setting-up-a-headless-raspberry-pi]]
 == Set up a headless Raspberry Pi
 
-A **headless** Raspberry Pi runs without a monitor, keyboard, or mouse. To run a Raspberry Pi headless, you need a way to access it from a remote machine. To access your Raspberry Pi remotely, you'll need to connect your Raspberry Pi to a network, and a way to access the Raspberry Pi over that network.
+A **headless** Raspberry Pi runs without a monitor, keyboard, or mouse. To run a Raspberry Pi headless, you need a way to access it from another computer. To access your Raspberry Pi remotely, you'll need to connect your Raspberry Pi to a network, and a way to access the Raspberry Pi over that network.
 
-To connect your Raspberry Pi to a network, you can either plug your machine into a wired connection via Ethernet or configure wireless networking.
+To connect your Raspberry Pi to a network, you can either plug your computer into a wired connection via Ethernet or configure wireless networking.
 
 To access your Raspberry Pi over that network, use SSH. Once you've connected over SSH, you can use `raspi-config` to xref:remote-access.adoc#vnc[enable VNC] if you'd prefer a graphical desktop environment.
 
@@ -35,7 +35,7 @@ At the root of your SD card, create a file named `userconf.txt`.
 
 This file should contain a single line of text, consisting of `<username>:<password>`: your desired username, followed immediately by a colon, followed immediately by an *encrypted* representation of the password you want to use.
 
-To generate the encrypted password, use https://www.openssl.org[OpenSSL] on another machine. Open a terminal and enter the following:
+To generate the encrypted password, use https://www.openssl.org[OpenSSL] on another computer. Open a terminal and enter the following:
 
 ----
 openssl passwd -6

--- a/documentation/asciidoc/computers/configuration/headless.adoc
+++ b/documentation/asciidoc/computers/configuration/headless.adoc
@@ -3,7 +3,7 @@
 
 A **headless** Raspberry Pi runs without a monitor, keyboard, or mouse. To run a Raspberry Pi headless, you need a way to access it from another computer. To access your Raspberry Pi remotely, you'll need to connect your Raspberry Pi to a network, and a way to access the Raspberry Pi over that network.
 
-To connect your Raspberry Pi to a network, you can either plug your computer into a wired connection via Ethernet or configure wireless networking.
+To connect your Raspberry Pi to a network, you can either plug your device into a wired connection via Ethernet or configure wireless networking.
 
 To access your Raspberry Pi over that network, use SSH. Once you've connected over SSH, you can use `raspi-config` to xref:remote-access.adoc#vnc[enable VNC] if you'd prefer a graphical desktop environment.
 


### PR DESCRIPTION
Replaced "machine" with "computer" -- the [style guide advises against this](https://github.com/raspberrypi/style-guide/blob/master/style-guide.md).

In one instance, "machine" referred to the Pi in a theoretical scenario. I replaced that instance with "device" because I've seen that pattern elsewhere in the docs and it's a) less confusing that reusing the generic term computer and b) less fatiguing than repeating "Raspberry Pi" in full each time we refer to that Pi.