### PR TITLE
Small typo

### DIFF
--- a/documentation/asciidoc/computers/configuration/screensaver.adoc
+++ b/documentation/asciidoc/computers/configuration/screensaver.adoc
@@ -37,7 +37,7 @@ The `dpms_timeout` variable controls the number of seconds of inactivity require
 
 === Console
 
-The `dpms_timeout` screen blanking configuration used by Raspberry Pi Configuration only affects desktop sessions. In *console mode*, when your Raspberry Pi is connected to a monitor and keyboard with only a terminal for input, use the `consoleblank` setting in the boot command line.
+The `dpms_timeout` screen blanking configuration used by Raspberry Pi Configuration only affects desktop sessions. In *console mode*, when your Raspberry Pi is connected to a monitor and keyboard with only a terminal for input, use the `consoleblank` setting in the kernel command line.
 
 ==== Set console mode screen blanking
 


### PR DESCRIPTION
For consistency with how it's referred to elsewhere.