### PR TITLE
bootloader-config: Bootloader configuration updates

### DIFF
--- a/documentation/asciidoc/computers/compute-module/cm-emmc-flashing.adoc
+++ b/documentation/asciidoc/computers/compute-module/cm-emmc-flashing.adoc
@@ -93,7 +93,7 @@ Make sure J4 (USB SLAVE BOOT ENABLE) / J2 (nRPI_BOOT) is set to the disabled pos
 The default bootloader configuration on CM4 is designed to support bringup and development on a https://www.raspberrypi.com/products/compute-module-4-io-board/[Compute Module 4 IO board] and the software version flashed at manufacture may be older than the latest release. For final products please consider:-
 
 * Selecting and verifying a specific bootloader release. The version in the `usbboot` repo is always a recent stable release.
-* Configuring the boot device (e.g. network boot). See `BOOT_ORDER` section in the xref:raspberry-pi.adoc#raspberry-pi-4-bootloader-configuration[bootloader configuration] guide.
+* Configuring the boot device (e.g. network boot). See `BOOT_ORDER` section in the xref:raspberry-pi.adoc#raspberry-pi-bootloader-configuration[bootloader configuration] guide.
 * Enabling hardware write protection on the bootloader EEPROM to ensure that the bootloader can't be modified on remote/inaccessible products.
 
 N.B. The Compute Module 4 ROM never runs `recovery.bin` from SD/EMMC and the `rpi-eeprom-update` service is not enabled by default. This is necessary because the EMMC is not removable and an invalid `recovery.bin` file would prevent the system from booting. This can be overridden and used with `self-update` mode where the bootloader can be updated from USB MSD or Network boot. However, `self-update` mode is not an atomic update and therefore not safe in the event of a power failure whilst the EEPROM was being updated.

--- a/documentation/asciidoc/computers/configuration/boot_folder.adoc
+++ b/documentation/asciidoc/computers/configuration/boot_folder.adoc
@@ -12,7 +12,7 @@ NOTE: Prior to _Bookworm_, Raspberry Pi OS stored the boot partition at `/boot/`
 
 ==== bootcode.bin
 
-This is the bootloader, which is loaded by the SoC on boot; it does some very basic setup, and then loads one of the `start*.elf` files. `bootcode.bin` is not used on the Raspberry Pi 4, because it has been replaced by boot code in the xref:raspberry-pi.adoc#raspberry-pi-4-boot-eeprom[onboard EEPROM].
+This is the bootloader, which is loaded by the SoC on boot; it does some very basic setup, and then loads one of the `start*.elf` files. `bootcode.bin` is not used on the Raspberry Pi 4, because it has been replaced by boot code in the xref:raspberry-pi.adoc#raspberry-pi-boot-eeprom[onboard EEPROM].
 
 ==== start.elf, start_x.elf, start_db.elf, start_cd.elf, start4.elf, start4x.elf, start4db.elf, start4cd.elf
 

--- a/documentation/asciidoc/computers/configuration/raspi-config.adoc
+++ b/documentation/asciidoc/computers/configuration/raspi-config.adoc
@@ -222,7 +222,7 @@ Configure the network's proxy settings.
 
 ===== Boot Order
 
-On the Raspberry Pi 4, you can specify whether to boot from USB or network if the SD card isn't inserted. See xref:raspberry-pi.adoc#raspberry-pi-4-bootloader-configuration[this page] for more information.
+On the Raspberry Pi 4, you can specify whether to boot from USB or network if the SD card isn't inserted. See xref:raspberry-pi.adoc#raspberry-pi-bootloader-configuration[this page] for more information.
 
 ===== Bootloader Version
 
@@ -669,7 +669,7 @@ sudo raspi-config nonint do_proxy <SCHEMES> <ADDRESS>
 
 ===== Boot Order
 
-On the Raspberry Pi 4, you can specify whether to boot from USB or network if the SD card isn't inserted. See xref:raspberry-pi.adoc#raspberry-pi-4-bootloader-configuration[this page] for more information.
+On the Raspberry Pi 4, you can specify whether to boot from USB or network if the SD card isn't inserted. See xref:raspberry-pi.adoc#raspberry-pi-bootloader-configuration[this page] for more information.
 
 ----
 sudo raspi-config nonint do_boot_order <B1/B2/B3>

--- a/documentation/asciidoc/computers/raspberry-pi/bcm2711-bootloader.adoc
+++ b/documentation/asciidoc/computers/raspberry-pi/bcm2711-bootloader.adoc
@@ -1,4 +1,4 @@
-== Raspberry Pi 4 Bootloader Configuration
+== Raspberry Pi Bootloader Configuration
 
 === Editing the Configuration
 
@@ -10,7 +10,7 @@ To view the current EEPROM configuration: +
 To edit it and apply the updates to latest EEPROM release: +
 `sudo -E rpi-eeprom-config --edit`
 
-Please see the xref:raspberry-pi.adoc#raspberry-pi-4-boot-eeprom[boot EEPROM] page for more information about the EEPROM update process.
+Please see the xref:raspberry-pi.adoc#raspberry-pi-boot-eeprom[boot EEPROM] page for more information about the EEPROM update process.
 
 === Configuration Properties
 
@@ -23,10 +23,21 @@ If `1` then enable UART debug output on GPIO 14 and 15. Configure the receiving 
 
 Default: `0`
 
+[[UART_BAUD]]
+==== UART_BAUD
+Raspberry Pi 5 only.
+
+Changes the baud rate for the bootloader UART. +
+Supported values are `9600`, `19200`, `38400`, `57600`, `115200`, `230400`, `460800`, `921600`
+
+Default: `115200`
+
 [[WAKE_ON_GPIO]]
 ==== WAKE_ON_GPIO
 
 If `1` then `sudo halt` will run in a lower power mode until either GPIO3 or GLOBAL_EN are shorted to ground.
+
+This setting is not relevant on Raspberry Pi 5 because the xref:raspberry-pi-5.adoc#adding-your-own-power-button[dedicated power button] may always be used to wakeup from `HALT` or `STANDBY`.
 
 Default: `1`
 
@@ -36,6 +47,9 @@ Default: `1`
 If `1` and `WAKE_ON_GPIO=0` then `sudo halt` will switch off all PMIC outputs. This is lowest possible power state for halt but may cause problems with some HATs because 5V will still be on. `GLOBAL_EN` must be shorted to ground to boot.
 
 Raspberry Pi 400 has a dedicated power button which operates even if the processor is switched off. This behaviour is enabled by default, however, `WAKE_ON_GPIO=2` may be set to use an external GPIO power button instead of the dedicated power button.
+
+On Raspberry Pi 5 this places the PMIC in `STANDBY` mode where all outputs are switched off. There is no need to set `WAKE_ON_GPIO` and pressing the xref:raspberry-pi-5.adoc#adding-your-own-power-button[dedicated power button] will boot the device.
+
 
 Default: `0`
 
@@ -75,11 +89,11 @@ The BOOT_ORDER property defines the sequence for the different boot modes. It is
 
 | 0x5
 | BCM-USB-MSD
-| USB 2.0 boot from USB Type C socket (CM4: USB type A socket on CM4IO board).
+| USB 2.0 boot from USB Type C socket (CM4: USB type A socket on CM4IO board). Not available on Raspberry Pi 5.
 
 | 0x6
 | NVME
-| CM4 only: boot from an NVMe SSD connected to the PCIe interface. See xref:raspberry-pi.adoc#nvme-ssd-boot[NVMe boot] for more details.
+| CM4 and Pi5 only: boot from an NVMe SSD connected to the PCIe interface. See xref:raspberry-pi.adoc#nvme-ssd-boot[NVMe boot] for more details.
 
 | 0x7
 | HTTP
@@ -425,6 +439,15 @@ PARTITION=2
 
 Default: 0
 
+[[PSU_MAX_CURRENT]]
+==== PSU_MAX_CURRENT
+Raspberry Pi 5 only.
+
+If set, this property instructions the firmware to skip USB power-deliber negoation and assume that it is connected to a bench power supply with the given current rating.
+Typically, this would either be set to `3000` or `5000` i.e. low or high-current capable power supply.
+
+Default: ""
+
 [[USB_MSD_EXCLUDE_VID_PID]]
 ==== USB_MSD_EXCLUDE_VID_PID
 
@@ -530,6 +553,8 @@ WARNING: If an invalid configuration which causes boot to fail is specified then
 
 === Configuration Properties in `config.txt`
 
+Raspberry Pi 5 requires a `config.txt` file to be present to indicate that the partition is bootable. 
+
 [[boot_ramdisk]]
 ==== boot_ramdisk
 If this property is set to `1` then the bootloader will attempt load a ramdisk file called `boot.img` containing the boot xref:configuration.adoc#boot-folder-contents[boot file-system]. Subsequent files (e.g. `start4.elf`) are read from the ramdisk instead of the original boot file-system.
@@ -552,6 +577,8 @@ Default: `0`
 Experimental property for custom firmware (bare metal).
 
 Bit 0 (0x1) indicates that the .elf file is custom firmware. This disables any compatibility checks (e.g. is USB MSD boot supported) and resets PCIe before starting the executable.
+
+Not relevant on Raspberry Pi 5 because there is no `start.elf` file.
 
 Default: `0x0`
 
@@ -578,7 +605,7 @@ Configures the EEPROM `Write Status Register`. This can be set to either mark th
 
 This option must be used in conjunction with the EEPROM `/WP` pin which controls updates to the EEPROM `Write Status Register`.  Pulling `/WP` low (CM4 `EEPROM_nWP` or on a Raspberry Pi 4 `TP5`) does NOT write-protect the EEPROM unless the `Write Status Register` has also been configured.
 
-See the https://www.winbond.com/resource-files/w25x40cl_f%2020140325.pdf[Winbond W25x40cl datasheet] for further details.
+See the https://www.winbond.com/resource-files/w25x40cl_f%2020140325.pdf[Winbond W25x40cl] or https://www.winbond.com/hq/product/code-storage-flash-memory/serial-nor-flash/?__locale=en&partNo=W25Q16JV[Winbond W25Q16JV] datasheets for further details.
 
 `eeprom_write_protect` settings in `config.txt` for `recovery.bin`.
 
@@ -597,7 +624,16 @@ See the https://www.winbond.com/resource-files/w25x40cl_f%2020140325.pdf[Winbond
 
 NOTE: `flashrom` does not support clearing of the write-protect regions and will fail to update the EEPROM if write-protect regions are defined.
 
+On Raspberry Pi5 `/WP` is pulled low by default and consequently write-protect is enabled as soon as the `Write Status Register` is configued. To clear write-protect pull `/WP` high by connecting `TP14` and `TP1`.
+
 Default: `-1`
+
+[[os_check]]
+==== os_check
+On Raspberry Pi 5 the firmware automatically checks for a compatible device-tree file before attempting to boot from the current partition. Otherwise, older non-compatible kernels would be loaded and then hang.
+To disable this check (e.g. for bare metal development) set `os_check=0` in config.txt
+
+Default: `1`
 
 [[bootloader_update]]
 ==== bootloader_update

--- a/documentation/asciidoc/computers/raspberry-pi/boot-diagnostics-rpi4.adoc
+++ b/documentation/asciidoc/computers/raspberry-pi/boot-diagnostics-rpi4.adoc
@@ -49,6 +49,6 @@ The diagnostic information is as follows:
 | Indicates whether hotplug was detected (`HPD=1`) and if so whether the EDID was read successfully (`EDID=ok`) for each HDMI output.
 |===
 
-This display can be disabled using the `DISABLE_HDMI` option, see xref:raspberry-pi.adoc#raspberry-pi-4-bootloader-configuration[Bootloader Configuration].
+This display can be disabled using the `DISABLE_HDMI` option, see xref:raspberry-pi.adoc#raspberry-pi-bootloader-configuration[Bootloader Configuration].
 
 NOTE: This is purely for diagnosing boot failures; it is not an interactive bootloader. If you require an interactive bootloader, consider using a tool such as U-Boot.

--- a/documentation/asciidoc/computers/raspberry-pi/boot-eeprom-rpi4.adoc
+++ b/documentation/asciidoc/computers/raspberry-pi/boot-eeprom-rpi4.adoc
@@ -1,6 +1,6 @@
-== Raspberry Pi 4 Boot EEPROM
+== Raspberry Pi Boot EEPROM
 
-Raspberry Pi 4, 400, Compute Module 4, and Compute Module 4S computers use an EEPROM to boot the system. All other models of Raspberry Pi computer use the `bootcode.bin` file located in the boot filesystem.
+Raspberry Pi 5, Raspberry Pi 4, 400, Compute Module 4, and Compute Module 4S computers use an EEPROM to boot the system. All other models of Raspberry Pi computer use the `bootcode.bin` file located in the boot filesystem.
 
 NOTE: The scripts and pre-compiled binaries used to create the `rpi-eeprom` package which is used to update the Raspberry Pi 4 bootloader and VLI USB controller EEPROMs is available https://github.com/raspberrypi/rpi-eeprom/[on Github].
 
@@ -13,7 +13,7 @@ If an error occurs during boot then an xref:configuration.adoc#led-warning-flash
 
 There are multiple ways to update the bootloader of your Raspberry Pi.
 
-==== Raspberry Pi 4 and Raspberry Pi 400
+==== Raspberry Pi 5, Raspberry Pi 4 and Raspberry Pi 400
 
 Raspberry Pi OS automatically updates the bootloader for critical bug fixes. The recommended methods for manually updating the bootloader or changing the boot modes are https://www.raspberrypi.com/software/[Raspberry Pi Imager] and xref:configuration.adoc#raspi-config[raspi-config]
 
@@ -212,8 +212,7 @@ rpi-eeprom-update -h
 The firmware release status corresponds to a particular subdirectory of bootloader firmware images (`+/lib/firmware/raspberrypi/bootloader/...+`), and can be changed to select a different release stream.
 
 * `default` - Updated for new hardware support, critical bug fixes and periodic update for new features that have been tested via the `latest` release.
-* `latest` - Updated when new features have been successfully beta tested.
-* `beta` - New or experimental features are tested here first.
+* `latest` - Updated when new features are available.
 
 Since the release status string is just a subdirectory name, then it is possible to create your own release streams e.g. a pinned release or custom network boot configuration.
 
@@ -258,7 +257,7 @@ See also xref:raspberry-pi.adoc#raspberry-pi-4-boot-flow[Raspberry Pi 4 boot-flo
 | The sha256 checksum of bootloader image (pieeprom.upd/pieeprom.bin)
 
 | vl805.bin
-| The VLI805 USB firmware EEPROM image - ignored on 1.4 and later board revisions which do not have a dedicated VLI EEPROM
+| The VLI805 USB firmware EEPROM image - Raspberry Pi 4B revision 1.3 and earlier only.
 
 | vl805.sig| The sha256 checksum of vl805.bin
 |===
@@ -266,7 +265,7 @@ See also xref:raspberry-pi.adoc#raspberry-pi-4-boot-flow[Raspberry Pi 4 boot-flo
 * If the bootloader update image is called `pieeprom.upd` then `recovery.bin` is renamed to `recovery.000` once the update has completed, then the system is rebooted. Since `recovery.bin` is no longer present the ROM loads the newly updated bootloader from EEPROM and the OS is booted as normal.
 * If the bootloader update image is called `pieeprom.bin` then `recovery.bin` will stop after the update has completed. On success the HDMI output will be green and the green activity LED is flashed rapidly. If the update fails, the HDMI output will be red and an xref:configuration.adoc#led-warning-flash-codes[error code] will be displayed via the activity LED.
 * The `.sig` files contain the hexadecimal sha256 checksum of the corresponding image file; additional fields may be added in the future.
-* The BCM2711 ROM does not support loading `recovery.bin` from USB mass storage or TFTP. Instead, newer versions of the bootloader support a self-update mechanism where the bootloader is able to reflash the EEPROM itself. See `ENABLE_SELF_UPDATE` on the xref:raspberry-pi.adoc#raspberry-pi-4-bootloader-configuration[bootloader configuration] page.
+* The BCM2711 ROM does not support loading `recovery.bin` from USB mass storage or TFTP. Instead, newer versions of the bootloader support a self-update mechanism where the bootloader is able to reflash the EEPROM itself. See `ENABLE_SELF_UPDATE` on the xref:raspberry-pi.adoc#raspberry-pi-bootloader-configuration[bootloader configuration] page.
 * The temporary EEPROM update files are automatically deleted by the `rpi-eeprom-update` service at startup.
 
 For more information about the `rpi-eeprom-update` configuration file see `rpi-eeprom-update -h`.

--- a/documentation/asciidoc/computers/raspberry-pi/boot-msd.adoc
+++ b/documentation/asciidoc/computers/raspberry-pi/boot-msd.adoc
@@ -13,7 +13,7 @@ See:-
 
 * Instructions for changing the boot mode via the xref:raspberry-pi.adoc#imager[Raspberry Pi Imager].
 * Instructions for changing the boot mode via the xref:raspberry-pi.adoc#raspi-config[raspi-config].
-* The xref:raspberry-pi.adoc#raspberry-pi-4-bootloader-configuration[bootloader configuration] page for other boot configuration options.
+* The xref:raspberry-pi.adoc#raspberry-pi-bootloader-configuration[bootloader configuration] page for other boot configuration options.
 
 [[cm4]]
 === Compute Module 4

--- a/documentation/asciidoc/computers/raspberry-pi/boot-net.adoc
+++ b/documentation/asciidoc/computers/raspberry-pi/boot-net.adoc
@@ -1,6 +1,6 @@
 == Network Booting
 
-This section describes how network booting works on the Raspberry Pi 3B, 3B+ and 2B v1.2. On the Raspberry Pi 4 network booting is implemented in the second stage bootloader in the EEPROM. Please see the xref:raspberry-pi.adoc#raspberry-pi-4-bootloader-configuration[Raspberry Pi 4 Bootloader Configuration] page for more information.
+This section describes how network booting works on the Raspberry Pi 3B, 3B+ and 2B v1.2. On the Raspberry Pi 4 network booting is implemented in the second stage bootloader in the EEPROM. Please see the xref:raspberry-pi.adoc#raspberry-pi-bootloader-configuration[Raspberry Pi 4 Bootloader Configuration] page for more information.
 We also have a xref:remote-access.adoc#network-boot-your-raspberry-pi[tutorial about setting up a network boot system]. Network booting works only for the wired adapter built into the above models of Raspberry Pi. Booting over wireless LAN is not supported, nor is booting from any other wired network device.
 
 To network boot, the boot ROM does the following:

--- a/documentation/asciidoc/computers/raspberry-pi/boot-nvme.adoc
+++ b/documentation/asciidoc/computers/raspberry-pi/boot-nvme.adoc
@@ -29,7 +29,7 @@ If you are using CM4 lite, remove the SD card and the board will boot from the N
 
 ==== NVMe BOOT_ORDER
 
-This boot behaviour is controlled via the `BOOT_ORDER` setting in the EEPROM configuration: we have added a new boot mode `6` for NVMe. See xref:raspberry-pi.adoc#raspberry-pi-4-bootloader-configuration[Raspberry Pi 4 Bootloader Configuration].
+This boot behaviour is controlled via the `BOOT_ORDER` setting in the EEPROM configuration: we have added a new boot mode `6` for NVMe. See xref:raspberry-pi.adoc#raspberry-pi-bootloader-configuration[Raspberry Pi Bootloader Configuration].
 
 Below is an example of UART output when the bootloader detects the NVMe drive:
 

--- a/documentation/asciidoc/computers/raspberry-pi/bootflow-2711.adoc
+++ b/documentation/asciidoc/computers/raspberry-pi/bootflow-2711.adoc
@@ -1,6 +1,6 @@
 == Raspberry Pi 4 Boot Flow
 
-The main difference between this and previous products is that the second stage bootloader is loaded from an SPI flash xref:raspberry-pi.adoc#raspberry-pi-4-boot-eeprom[EEPROM] instead of the `bootcode.bin` file on previous products.
+The main difference between this and previous products is that the second stage bootloader is loaded from an SPI flash xref:raspberry-pi.adoc#raspberry-pi-boot-eeprom[EEPROM] instead of the `bootcode.bin` file on previous products.
 
 === First Stage Bootloader
 
@@ -29,7 +29,7 @@ NOTE: `recovery.bin` is a minimal second stage program used to reflash the bootl
 
 This section describes the high-level flow of the second stage bootloader.
 
-Please see the xref:raspberry-pi.adoc#raspberry-pi-4-bootloader-configuration[bootloader configuration] page for more information about each boot mode and the xref:configuration.adoc#the-boot-folder[boot folder] page for a description of the GPU firmware files loaded by this stage.
+Please see the xref:raspberry-pi.adoc#raspberry-pi-bootloader-configuration[bootloader configuration] page for more information about each boot mode and the xref:configuration.adoc#the-boot-folder[boot folder] page for a description of the GPU firmware files loaded by this stage.
 
 * Initialise clocks and SDRAM
 * Read the EEPROM configuration file
@@ -70,9 +70,13 @@ Please see the xref:raspberry-pi.adoc#raspberry-pi-4-bootloader-configuration[bo
  ** else if boot-mode == `RPIBOOT` then
   *** Attempt to load firmware using USB device mode from the USB OTG port - see https://github.com/raspberrypi/usbboot[usbboot]. There is no timeout for `RPIBOOT` mode.
 
+==== Differences on Raspberry Pi5
+* The power button is used to wakeup from PMIC `STANDBY` or HALT instead of `GPIO 3`
+* Instead of loading `start.elf` the firmware loads the Linux kernel. Effectively, the bootloader has an embedded version of `start.elf`
+
 === Bootloader Updates
 
-The bootloader may also be updated before the firmware is started if a `pieeprom.upd` file is found. Please see the xref:raspberry-pi.adoc#raspberry-pi-4-boot-eeprom[bootloader EEPROM] page for more information about bootloader updates.
+The bootloader may also be updated before the firmware is started if a `pieeprom.upd` file is found. Please see the xref:raspberry-pi.adoc#raspberry-pi-boot-eeprom[bootloader EEPROM] page for more information about bootloader updates.
 
 === Fail-safe OS updates (TRYBOOT)
 

--- a/documentation/asciidoc/computers/raspberry-pi/bootmodes.adoc
+++ b/documentation/asciidoc/computers/raspberry-pi/bootmodes.adoc
@@ -6,7 +6,7 @@ The Raspberry Pi has a number of different stages of booting. This document expl
 
 USB host and Ethernet boot can be performed by BCM2837-based Raspberry Pis - that is, Raspberry Pi 2B version 1.2, Raspberry Pi 3B, and Raspberry Pi 3B+ (Raspberry Pi 3A+ cannot net boot since it does not have a built-in Ethernet interface). In addition, all Raspberry Pi models *except Raspberry Pi 4B* can use a new `bootcode.bin`-only method to enable USB host boot.
 
-NOTE: The Raspberry Pi 4B does not use the bootcode.bin file - instead the bootloader is located in an on-board EEPROM chip. See xref:raspberry-pi.adoc#raspberry-pi-4-boot-flow[Raspberry Pi 4 Bootflow] and  xref:raspberry-pi.adoc#raspberry-pi-4-boot-eeprom[SPI Boot EEPROM].
+NOTE: The Raspberry Pi 4B does not use the bootcode.bin file - instead the bootloader is located in an on-board EEPROM chip. See xref:raspberry-pi.adoc#raspberry-pi-4-boot-flow[Raspberry Pi 4 Bootflow] and  xref:raspberry-pi.adoc#raspberry-pi-boot-eeprom[SPI Boot EEPROM].
 
 Format an SD card as FAT32 and copy on the latest https://github.com/raspberrypi/firmware/raw/master/boot/firmware/bootcode.bin[`bootcode.bin`]. The SD card must be present in the Raspberry Pi for it to boot. Once bootcode.bin is loaded from the SD card, the Raspberry Pi continues booting using USB host mode.
 
@@ -18,7 +18,7 @@ If you have a problem with a mass storage device still not working, even with th
 
 NOTE: For boards pre-Raspberry Pi 4 Model B.
 
-For information on enabling the UART on the Raspberry Pi 4 bootloader, please see xref:raspberry-pi.adoc#raspberry-pi-4-bootloader-configuration[this page].
+For information on enabling the UART on the Raspberry Pi 4 bootloader, please see xref:raspberry-pi.adoc#raspberry-pi-bootloader-configuration[this page].
 
 It is possible to enable an early stage UART to debug booting issues (useful with the above bootcode.bin only boot mode).  To do this, make sure you've got a recent version of the firmware (including bootcode.bin).  To check if UART is supported in your current firmware:
 

--- a/documentation/asciidoc/computers/raspberry-pi/otp-bits.adoc
+++ b/documentation/asciidoc/computers/raspberry-pi/otp-bits.adoc
@@ -25,7 +25,7 @@ This list contains the publicly available information on the registers. If a reg
 * Bit 28: enables USB device booting
 * Bit 29: enables USB host booting (ethernet and mass storage)
 
-NOTE: On BCM2711 the bootmode is defined by the xref:raspberry-pi.adoc#raspberry-pi-4-bootloader-configuration[bootloader EEPROM configuration] instead of OTP.
+NOTE: On BCM2711 the bootmode is defined by the xref:raspberry-pi.adoc#raspberry-pi-bootloader-configuration[bootloader EEPROM configuration] instead of OTP.
 
 18 -- copy of bootmode register +
 28 -- serial number +

--- a/documentation/asciidoc/computers/remote-access/network-boot-raspberry-pi.adoc
+++ b/documentation/asciidoc/computers/remote-access/network-boot-raspberry-pi.adoc
@@ -56,7 +56,7 @@ Within `raspi-config`, choose `Advanced Options`, then `Boot Order`, then `Netwo
 vcgencmd bootloader_config
 ----
 
-For further details of configuring the Raspberry Pi 4 bootloader, see xref:raspberry-pi.adoc#raspberry-pi-4-bootloader-configuration[Raspberry Pi 4 Bootloader Configuration].
+For further details of configuring the Raspberry Pi 4 bootloader, see xref:raspberry-pi.adoc#raspberry-pi-bootloader-configuration[Raspberry Pi Bootloader Configuration].
 
 === Ethernet MAC address
 


### PR DESCRIPTION
First pass at updating the common EEPROM config and bootloader related configuration parameters.

* Add documentation for os_check, PSU_MAX_CURRENT
* Rename some titles to be less hardware specific i.e. not just Pi4
* Drop references to beta bootloader releases - these were dropped from APT