### PR TITLE
Fix typo in power-supply.adoc

### DIFF
--- a/documentation/asciidoc/computers/raspberry-pi-5/power-supply.adoc
+++ b/documentation/asciidoc/computers/raspberry-pi-5/power-supply.adoc
@@ -63,7 +63,7 @@ The bootloader will prompt you to "press power button to continue", which effect
 
 === Power supplies and Raspberry Pi OS
 
-The bootloader passes information about the powe supply via device-tree `/proc/device-tree/chosen/power`. Users will typically not read this directly.
+The bootloader passes information about the power supply via device-tree `/proc/device-tree/chosen/power`. Users will typically not read this directly.
 
 max_current:: The max current in mA
 uspd_power_data_objects:: A dump of the PDOs - debug for advanced users


### PR DESCRIPTION
Change "powe supply" to "power supply" in the "Power supplies and Raspberry Pi OS" section.