### PR TITLE
Pi5 clocks gpu memory

### DIFF
--- a/documentation/asciidoc/computers/config_txt/boot.adoc
+++ b/documentation/asciidoc/computers/config_txt/boot.adoc
@@ -9,6 +9,8 @@ These options specify the firmware files transferred to the VideoCore GPU prior 
 
 NOTE: Cut-down firmware (`start*cd.elf` and `fixup*cd.dat`) cannot be selected this way - the system will fail to boot.  The only way to enable the cut-down firmware is to specify `gpu_mem=16`. The cut-down firmware removes support for codecs and 3D as well as limiting the initial early-boot framebuffer to 1080p @  16bpp - although KMS can replace this with up-to 32bpp 4K framebuffer(s) at a later stage as with any firmware.
 
+NOTE: The Raspberry Pi 5 firmware is self-contained in the bootloader EEPROM.
+
 === `cmdline`
 
 `cmdline` is the alternative filename on the boot partition from which to read the kernel command line string; the default value is `cmdline.txt`.
@@ -16,6 +18,8 @@ NOTE: Cut-down firmware (`start*cd.elf` and `fixup*cd.dat`) cannot be selected t
 === `kernel`
 
 `kernel` is the alternative filename on the boot partition to use when loading the kernel. The default value on the Raspberry Pi 1, Zero and Zero W, and Raspberry Pi Compute Module 1 is `kernel.img`. The default value on the Raspberry Pi 2, 3, 3+ and Zero 2 W, and Raspberry Pi Compute Modules 3 and 3+ is `kernel7.img`. The default value on the Raspberry Pi 4 and 400, and Raspberry Pi Compute Module 4 is `kernel8.img`, or `kernel7l.img` if `arm_64bit` is set to 0.
+
+The Raspberry Pi 5 firmware defaults to loading `kernel_2712.img` because this image contains optmizations specific to Raspberry Pi 5 (e.g. 16K page-size). If this file is not present then the common 64-bit kernel (`kernel8.img`) will be loaded instead.
 
 === `arm_64bit`
 
@@ -28,6 +32,8 @@ Defaults to 1 on Pi 4s (Pi 4B, Pi 400, CM4 and CM4S), and 0 on all other platfor
 NOTE: 64-bit kernels may be uncompressed image files or a gzip archive of an image (which can still be called kernel8.img; the bootloader will recognize the archive from the signature bytes at the beginning).
 
 NOTE: The 64-bit kernel will only work on the Raspberry Pi 3, 3+, 4, 400, Zero 2 W and 2B rev 1.2, and Raspberry Pi Compute Modules 3, 3+ and 4.
+
+NOTE: Raspberry Pi 5 only supports 64-bit kernel so this parameter has been removed.
 
 === `ramfsfile`
 

--- a/documentation/asciidoc/computers/config_txt/conditional.adoc
+++ b/documentation/asciidoc/computers/config_txt/conditional.adoc
@@ -131,6 +131,8 @@ Note that these settings apply only at boot, so the monitor must be connected at
 
 On the Raspberry Pi 4, if both HDMI ports are in use, then the EDID filter will be checked against both of them, and configuration from all matching conditional filters will be applied.
 
+NOTE: This setting is not available on Raspberry Pi 5.
+
 === The Serial Number Filter
 
 Sometimes settings should only be applied to a single specific Raspberry Pi, even if you swap the SD card to a different one. Examples include licence keys and overclocking settings (although the licence keys already support SD card swapping in a different way). You can also use this to select different display settings, even if the EDID identification above is not possible, provided that you don't swap monitors between your Raspberry Pis. For example, if your monitor doesn't supply a usable EDID name, or if you are using composite output (for which EDID cannot be read).

--- a/documentation/asciidoc/computers/config_txt/overclocking.adoc
+++ b/documentation/asciidoc/computers/config_txt/overclocking.adoc
@@ -2,7 +2,7 @@
 
 The kernel has a https://www.kernel.org/doc/html/latest/admin-guide/pm/cpufreq.html[CPUFreq] driver with the "powersave" governor enabled by default, switched to "ondemand" during boot, when xref:configuration.adoc#raspi-config[raspi-config] is installed. With "ondemand" governor, CPU frequency will vary with processor load. You can adjust the minimum values with the `*_min` config options or disable dynamic clocking by applying a static scaling governor ("powersave" or "performance") or with `force_turbo=1`.
 
-Overclocking and overvoltage will be disabled at runtime when the SoC reaches `temp_limit` (see below), which defaults to 85°C, in order to cool down the SoC. You should not hit this limit with Raspberry Pi 1 and Raspberry Pi 2, but you are more likely to with Raspberry Pi 3 and Raspberry Pi 4. Overclocking and overvoltage are also disabled when an undervoltage situation is detected.
+Overclocking and overvoltage will be disabled at runtime when the SoC reaches `temp_limit` (see below), which defaults to 85°C, in order to cool down the SoC. You should not hit this limit with Raspberry Pi 1 and Raspberry Pi 2, but you are more likely to with Raspberry Pi 3 and newer Overclocking and overvoltage are also disabled when an undervoltage situation is detected.
 
 NOTE: For more information xref:raspberry-pi.adoc#frequency-management-and-thermal-control[see the section on frequency management and thermal control].
 
@@ -32,13 +32,13 @@ WARNING: Setting any overclocking parameters to values other than those used by 
 | Frequency of the image sensor pipeline block in MHz; individual override of the `gpu_freq` setting
 
 | v3d_freq
-| Frequency of the 3D block in MHz; individual override of the `gpu_freq` setting
+| Frequency of the 3D block in MHz; individual override of the `gpu_freq` setting. On Raspberry Pi 5 V3D is independent of `core_freq`, `isp_freq`  and `hevc_freq`
 
 | hevc_freq
 | Frequency of the High Efficiency Video Codec block in MHz; individual override of the `gpu_freq` setting. Raspberry Pi 4 only.
 
 | sdram_freq
-| Frequency of the SDRAM in MHz. SDRAM overclocking on Raspberry Pi 4B is not currently supported
+| Frequency of the SDRAM in MHz. SDRAM overclocking on Raspberry Pi 4 or newer is not supported.
 
 | over_voltage
 | CPU/GPU core upper voltage limit. The value should be in the range [-16,8] which equates to the range [0.95V,1.55V] ([0.8,1.4V] on Raspberry Pi 1) with 0.025V steps. In other words, specifying -16 will give 0.95V (0.8V on Raspberry Pi 1) as the maximum CPU/GPU core voltage, and specifying 8 will allow up to 1.55V (1.4V on Raspberry Pi 1). For defaults see table below. Values above 6 are only allowed when `force_turbo=1` is specified: this sets the warranty bit if `over_voltage_*` > `0` is also set.
@@ -47,14 +47,14 @@ WARNING: Setting any overclocking parameters to values other than those used by 
 | Sets `over_voltage_sdram_c`, `over_voltage_sdram_i`, and `over_voltage_sdram_p` together.
 
 | over_voltage_sdram_c
-| SDRAM controller voltage adjustment. [-16,8] equates to [0.8V,1.4V] with 0.025V steps.
+| SDRAM controller voltage adjustment. [-16,8] equates to [0.8V,1.4V] with 0.025V steps. Not supported on Raspberry Pi 4 or newer.
 
 | over_voltage_sdram_i
-| SDRAM I/O voltage adjustment. [-16,8] equates to [0.8V,1.4V] with 0.025V steps.
+| SDRAM I/O voltage adjustment. [-16,8] equates to [0.8V,1.4V] with 0.025V steps. Not supported on Raspberry Pi 4 or newer.
 
 | over_voltage_sdram_p
-| SDRAM phy voltage adjustment. [-16,8] equates to [0.8V,1.4V] with 0.025V steps.
-
+| SDRAM phy voltage adjustment. [-16,8] equates to [0.8V,1.4V] with 0.025V steps. Not supported on Raspberry Pi 4 or newer.
+ 
 | force_turbo
 | Forces turbo mode frequencies even when the ARM cores are not busy. Enabling this may set the warranty bit if `over_voltage_*` is also set.
 
@@ -86,7 +86,10 @@ WARNING: Setting any overclocking parameters to values other than those used by 
 | Minimum value of `sdram_freq` used for dynamic frequency clocking.
 
 | over_voltage_min
-| Minimum value of `over_voltage` used for dynamic frequency clocking. The value should be in the range [-16,8] which equates to the range [0.8V,1.4V] with 0.025V steps. In other words, specifying -16 will give 0.8V as the CPU/GPU core idle voltage, and specifying 8 will give a minimum of 1.4V.
+| Minimum value of `over_voltage` used for dynamic frequency clocking. The value should be in the range [-16,8] which equates to the range [0.8V,1.4V] with 0.025V steps. In other words, specifying -16 will give 0.8V as the CPU/GPU core idle voltage, and specifying 8 will give a minimum of 1.4V. This setting is deprecated on Raspberry Pi 4 and Raspberry Pi 5.
+
+| over_voltage_delta
+| On Raspberry Pi 4 and Raspberry Pi 5 the over_voltage_delta parameter adds the given offset in microvolts to the number calculated by the DVFS algorithm.
 
 | temp_limit
 | Overheat protection. This sets the clocks and voltages to default when the SoC reaches this value in degree Celsius. Values over 85 are clamped to 85.
@@ -97,9 +100,9 @@ WARNING: Setting any overclocking parameters to values other than those used by 
 
 This table gives the default values for the options on various Raspberry Pi models, all frequencies are stated in MHz.
 
-[cols=",^,^,^,^,^,^,^,^,^"]
+[cols=",^,^,^,^,^,^,^,^,^,^"]
 |===
-| Option | Pi 0/W | Pi1 | Pi2 | Pi3 | Pi3A+/Pi3B+ | CM4 & Pi4B <= R1.3 | Pi4B R1.4 | Pi 400 | Pi Zero 2 W
+| Option | Pi 0/W | Pi1 | Pi2 | Pi3 | Pi3A+/Pi3B+ | CM4 & Pi4B <= R1.3 | Pi4B R1.4 | Pi 400 | Pi Zero 2 W | Pi 5
 
 | arm_freq
 | 1000
@@ -111,6 +114,7 @@ This table gives the default values for the options on various Raspberry Pi mode
 | 1500 or 1800 if arm_boost=1
 | 1800
 | 1000
+| 2400
 
 | core_freq
 | 400
@@ -122,6 +126,7 @@ This table gives the default values for the options on various Raspberry Pi mode
 | 500
 | 500
 | 400
+| 910
 
 | h264_freq
 | 300
@@ -133,6 +138,7 @@ This table gives the default values for the options on various Raspberry Pi mode
 | 500
 | 500
 | 300
+| N/A
 
 | isp_freq
 | 300
@@ -144,6 +150,7 @@ This table gives the default values for the options on various Raspberry Pi mode
 | 500
 | 500
 | 300
+| 910
 
 | v3d_freq
 | 300
@@ -155,6 +162,7 @@ This table gives the default values for the options on various Raspberry Pi mode
 | 500
 | 500
 | 300
+| 910
 
 | hevc_freq
 | N/A
@@ -166,6 +174,7 @@ This table gives the default values for the options on various Raspberry Pi mode
 | 500
 | 500
 | N/A
+| 910
 
 | sdram_freq
 | 450
@@ -177,6 +186,7 @@ This table gives the default values for the options on various Raspberry Pi mode
 | 3200
 | 3200
 | 450
+| 4267
 
 | arm_freq_min
 | 700
@@ -188,6 +198,7 @@ This table gives the default values for the options on various Raspberry Pi mode
 | 600
 | 600
 | 600
+| 1500
 
 | core_freq_min
 | 250
@@ -199,6 +210,7 @@ This table gives the default values for the options on various Raspberry Pi mode
 | 200
 | 200
 | 250
+| 500
 
 | gpu_freq_min
 | 250
@@ -210,6 +222,7 @@ This table gives the default values for the options on various Raspberry Pi mode
 | 250
 | 250
 | 250
+| 500
 
 | h264_freq_min
 | 250
@@ -221,6 +234,7 @@ This table gives the default values for the options on various Raspberry Pi mode
 | 250
 | 250
 | 250
+| N/A
 
 | isp_freq_min
 | 250
@@ -232,6 +246,7 @@ This table gives the default values for the options on various Raspberry Pi mode
 | 250
 | 250
 | 250
+| 500
 
 | v3d_freq_min
 | 250
@@ -243,6 +258,7 @@ This table gives the default values for the options on various Raspberry Pi mode
 | 250
 | 250
 | 250
+| 500
 
 | sdram_freq_min
 | 400
@@ -254,6 +270,7 @@ This table gives the default values for the options on various Raspberry Pi mode
 | 3200
 | 3200
 | 400
+| 4267
 |===
 
 This table gives defaults for options that are the same across all models.
@@ -304,10 +321,12 @@ The minimum core frequency when the system is idle must be fast enough to suppor
 | 550
 |===
 
+NOTE: Raspberry Pi 5 supports dual-4Kp60 displays with the idle-clock settings so `hdmi_enable_4kp60` is redundant.
+
 * Overclocking requires the latest firmware release.
 * The latest firmware automatically scales up the voltage if the system is overclocked. Manually setting `over_voltage` disables automatic voltage scaling for overclocking.
 * It is recommended when overclocking to use the individual frequency settings (`isp_freq`, `v3d_freq` etc) rather than `gpu_freq` because the maximum stable frequency will be different for ISP, V3D, HEVC etc.
-* The SDRAM frequency is not configurable on Raspberry Pi 4.
+* The SDRAM frequency is not configurable on Raspberry Pi 4 or newer.
 
 ==== `force_turbo`
 
@@ -317,6 +336,7 @@ By default (`force_turbo=0`) the "On Demand" CPU frequency driver will raise clo
 
 === Clocks Relationship
 
+==== Raspberry Pi 4
 The GPU core, CPU, SDRAM and GPU each have their own PLLs and https://forums.raspberrypi.com/viewtopic.php?f=29&t=6201&start=275#p168042[can have unrelated frequencies]. The h264, v3d and ISP blocks share a PLL.
 
 To view the Raspberry Pi's current frequency in KHz, type: `cat /sys/devices/system/cpu/cpu0/cpufreq/scaling_cur_freq`. Divide the result by 1000 to find the value in MHz. Note that this frequency is the kernel _requested_ frequency, and it is possible that any throttling (for example at high temperatures) may mean the CPU is actually running more slowly than reported. An instantaneous measurement of the actual ARM CPU frequency can be retrieved using the vcgencmd `vcgencmd measure_clock arm`. This is displayed in Hertz.
@@ -342,6 +362,8 @@ It is essential to keep the supply voltage above 4.8V for reliable performance. 
 To monitor the Raspberry Pi's PSU voltage, you will need to use a multimeter to measure between the VCC and GND pins on the GPIO. More information is available in xref:raspberry-pi.adoc#power-supply[power].
 
 If the voltage drops below 4.63V (+-5%), the ARM cores and the GPU will be throttled back, and a message indicating the low voltage state will be added to the kernel log.
+
+The Raspberry Pi 5 `PMIC` has built in ADCs that allows the supply voltage to be measured. To do this run `vcgencmd pmic_read_adc EXT5V_V`
 
 === Overclocking Problems
 

--- a/documentation/asciidoc/computers/config_txt/video.adoc
+++ b/documentation/asciidoc/computers/config_txt/video.adoc
@@ -79,4 +79,6 @@ Enable/disable the touchscreen.
 
 By default, the firmware parses the EDID of any HDMI attached display, picks an appropriate video mode, then passes the resolution and frame rate of the mode, along with overscan parameters, to the Linux kernel via settings on the kernel command line. In rare circumstances, this can have the effect of choosing a mode that is not in the EDID, and may be incompatible with the device. You can use `disable_fw_kms_setup=1` to disable the passing of these parameters and avoid this problem. The Linux video mode system (KMS) will then parse the EDID itself and pick an appropriate mode.
 
+NOTE: On Raspberry Pi 5 this parameter defaults to `1`
+
 

--- a/documentation/asciidoc/computers/legacy_config_txt/memory.adoc
+++ b/documentation/asciidoc/computers/legacy_config_txt/memory.adoc
@@ -1,6 +1,8 @@
 == Legacy Memory Options
 (see also xref:config_txt.adoc#memory-options[config.txt Memory Options])
 
+NOTE: Raspberry Pi 5 does not allocate GPU memory on behalf of the OS so the following settings have no effect.
+
 === `gpu_mem`
 
 Specifies how much memory, in megabytes, to reserve for the exclusive use of the GPU: the remaining memory is allocated to the ARM CPU for use by the OS. For Raspberry Pis with less than 1GB of memory, the default is `64`; for Raspberry Pis with 1GB or more of memory the default is `76`.

--- a/documentation/asciidoc/computers/raspberry-pi/boot-eeprom-rpi4.adoc
+++ b/documentation/asciidoc/computers/raspberry-pi/boot-eeprom-rpi4.adoc
@@ -235,7 +235,7 @@ rpi-eeprom-config --config boot.conf --out new.bin pieeprom.bin
 
 At power on, the BCM2711 ROM looks for a file called `recovery.bin` in the root directory of the boot partition on the SD card. If a valid `recovery.bin` is found then the ROM executes this instead of the contents of the EEPROM. This mechanism ensures that the bootloader EEPROM can always be reset to a valid image with factory default settings.
 
-See also xref:raspberry-pi.adoc#raspberry-pi-4-boot-flow[Raspberry Pi 4 boot-flow]
+See also xref:raspberry-pi.adoc#raspberry-pi-4-and-raspberry-pi-5-boot-flow[Raspberry Pi boot-flow]
 
 ==== EEPROM update files
 

--- a/documentation/asciidoc/computers/raspberry-pi/bootflow-2711.adoc
+++ b/documentation/asciidoc/computers/raspberry-pi/bootflow-2711.adoc
@@ -1,4 +1,4 @@
-== Raspberry Pi 4 Boot Flow
+== Raspberry Pi 4 and Raspberry Pi 5 Boot Flow
 
 The main difference between this and previous products is that the second stage bootloader is loaded from an SPI flash xref:raspberry-pi.adoc#raspberry-pi-boot-eeprom[EEPROM] instead of the `bootcode.bin` file on previous products.
 

--- a/documentation/asciidoc/computers/raspberry-pi/bootflow-legacy.adoc
+++ b/documentation/asciidoc/computers/raspberry-pi/bootflow-legacy.adoc
@@ -1,6 +1,6 @@
 == Boot sequence
 
-IMPORTANT: The following boot sequence applies to the BCM2837 and BCM2837B0 based models of Raspberry Pi only. On models prior to this, the Raspberry Pi will try SD card boot, followed by xref:raspberry-pi.adoc#usb-device-boot-mode[USB device mode boot]. For the Raspberry Pi 4 boot sequence please see the xref:raspberry-pi.adoc#raspberry-pi-4-boot-flow[Raspberry Pi 4 boot flow] section.
+IMPORTANT: The following boot sequence applies to the BCM2837 and BCM2837B0 based models of Raspberry Pi only. On models prior to this, the Raspberry Pi will try SD card boot, followed by xref:raspberry-pi.adoc#usb-device-boot-mode[USB device mode boot]. For the Raspberry Pi 4 and Raspberry Pi 5 boot sequence please see the xref:raspberry-pi.adoc#raspberry-pi-4-and-raspberry-pi-5-boot-flow[Raspberry Pi boot flow] section.
 
 USB boot defaults on the Raspberry Pi 3 will depend on which version is being used. See this xref:raspberry-pi.adoc#usb-mass-storage-boot[page] for information on enabling USB boot modes when not enabled by default.
 

--- a/documentation/asciidoc/computers/raspberry-pi/bootmodes.adoc
+++ b/documentation/asciidoc/computers/raspberry-pi/bootmodes.adoc
@@ -6,7 +6,7 @@ The Raspberry Pi has a number of different stages of booting. This document expl
 
 USB host and Ethernet boot can be performed by BCM2837-based Raspberry Pis - that is, Raspberry Pi 2B version 1.2, Raspberry Pi 3B, and Raspberry Pi 3B+ (Raspberry Pi 3A+ cannot net boot since it does not have a built-in Ethernet interface). In addition, all Raspberry Pi models *except Raspberry Pi 4B* can use a new `bootcode.bin`-only method to enable USB host boot.
 
-NOTE: The Raspberry Pi 4B does not use the bootcode.bin file - instead the bootloader is located in an on-board EEPROM chip. See xref:raspberry-pi.adoc#raspberry-pi-4-boot-flow[Raspberry Pi 4 Bootflow] and  xref:raspberry-pi.adoc#raspberry-pi-boot-eeprom[SPI Boot EEPROM].
+NOTE: Raspberry Pi 4 and Raspberry Pi 5 do not use the bootcode.bin file - instead the bootloader is located in an on-board EEPROM chip. See xref:raspberry-pi.adoc#raspberry-pi-4-and-raspberry-pi-5-boot-flow[Raspberry Pi bootflow] and  xref:raspberry-pi.adoc#raspberry-pi-boot-eeprom[SPI Boot EEPROM].
 
 Format an SD card as FAT32 and copy on the latest https://github.com/raspberrypi/firmware/raw/master/boot/firmware/bootcode.bin[`bootcode.bin`]. The SD card must be present in the Raspberry Pi for it to boot. Once bootcode.bin is loaded from the SD card, the Raspberry Pi continues booting using USB host mode.
 

--- a/documentation/asciidoc/computers/raspberry-pi/frequency-management.adoc
+++ b/documentation/asciidoc/computers/raspberry-pi/frequency-management.adoc
@@ -31,6 +31,8 @@ Due to possible system stability problems involved with running an undervoltage,
 | scale voltage up on demand for over clocking (default). If `over_voltage` is specified in `config.txt` then dynamic voltage scaling is disabled causing the system to revert to `dvfs=2`.
 |===
 
+NOTE: This setting has been removed on Raspberry Pi 5 and is effectively always mode 3.
+
 In addition, a more stepped CPU governor is also used to produce finer-grained control of ARM core frequencies, which means the DVFS is more effective. The steps are now 1500MHz, 1000MHz, 750MHz, and 600MHz. These steps can also help when the SoC is being throttled, and mean that throttling all the way back to 600MHz is much less likely, giving an overall increase in fully loaded performance.
 
 The default CPU governor is `ondemand`, the governor can be manually changed with the `cpufreq-set` command (from the `cpufrequtils` package) to reduce idle power consumption:


### PR DESCRIPTION
Describe the high-level clock configuration on Pi 5 and tidy up a few other settings that are no longer relevant.