### PR TITLE
Adding max-width for floated images

### DIFF
--- a/jekyll-assets/css/style.css
+++ b/jekyll-assets/css/style.css
@@ -544,6 +544,11 @@ div.imageblock div.title {
   margin-top: 0px;
 }
 
+#content .imageblock.left img,
+#content  .imageblock.right img {
+  max-width: 250px;
+}
+
 div.admonitionblock table {
   display: flex;
   width: 100%;


### PR DESCRIPTION
Fixes the booklink issue where large images appear not to float