### PR TITLE
Moved rpi_power_supply + Fixed typo

### DIFF
--- a/documentation/asciidoc/computers/configuration/device-tree.adoc
+++ b/documentation/asciidoc/computers/configuration/device-tree.adoc
@@ -849,7 +849,7 @@ For bench power supplies (e.g. connected to the GPIO header) define `PSU_MAX_CUR
 
 `rpi_power_supply` - 2 32-bit integers
 
-The USB VID and PID of the official Raspberry Pi 5A power supply (if connected).
+The USB VID and Product VDO of the official Raspberry Pi 5A power supply (if connected).
 
 `usb_max_current_enable` - 32-bit integer
 

--- a/documentation/asciidoc/computers/configuration/device-tree.adoc
+++ b/documentation/asciidoc/computers/configuration/device-tree.adoc
@@ -834,10 +834,6 @@ The partition number used during boot. If a `boot.img` ramdisk is loaded then th
 
 The value of the `PM_RSTS` register during boot.
 
-`rpi_power_supply` - 2 32-bit integers
-
-The USB VID and PID of the official Raspberry Pi 5A power supply (if connected).
-
 `tryboot` - 32-bit integer
 
 Set to `1` if the `tryboot` flag was set at boot.
@@ -848,8 +844,12 @@ Raspberry Pi 5 only.
 
 `max_current` - 32-bit integer
 
-The maximum current in mA that the power supply can supply. The firmware reports the value indicated by the USB-C, USB-PD or POE interfaces.
+The maximum current in mA that the power supply can supply. The firmware reports the value indicated by the USB-C, USB-PD or PoE interfaces.
 For bench power supplies (e.g. connected to the GPIO header) define `PSU_MAX_CURRENT` in the bootloader configuration to indicate the power supply current capability.
+
+`rpi_power_supply` - 2 32-bit integers
+
+The USB VID and PID of the official Raspberry Pi 5A power supply (if connected).
 
 `usb_max_current_enable` - 32-bit integer
 


### PR DESCRIPTION
rpi_power_supply is under power/ not bootloader/

```
$ ls /proc/device-tree/chosen/power/rpi_power_supply 
/proc/device-tree/chosen/power/rpi_power_supply
```

I've got a question about rpi_power_supply. The documentation says it is 2 32-bit integers but rpi_power_supply has extra padding? Is this a documentation issue or a firmware issue?

```
$ od -x --endian=big rpi_power_supply
0000000 0000 2e8a 000f 0000

```