### PR TITLE
Rework TOC generation for doxygen docs

### DIFF
--- a/scripts/create_build_adoc_doxygen.py
+++ b/scripts/create_build_adoc_doxygen.py
@@ -44,11 +44,12 @@ if __name__ == "__main__":
         for tab in data['tabs']:
             if 'from_json' in tab and 'directory' in tab and tab['directory'] == output_subdir:
                 filebase = os.path.splitext(adoc_filename)[0]
-                if filebase in picosdk_data:
-                    index_title = picosdk_data[filebase]['name']
-                else:
-                    index_title = filebase
-                break
+                index_title = filebase
+                picosdk_filename = re.sub("_", "__", filebase)+".html"
+                for item in picosdk_data:
+                    if re.sub("^group__", "", item["html"]) == picosdk_filename:
+                        index_title = item['name']
+                        break
     if index_title is None:
         raise Exception("Couldn't find title for {} in {}".format(os.path.join(output_subdir, adoc_filename), index_json))
 
@@ -59,7 +60,7 @@ if __name__ == "__main__":
     seen_header = False
     with open(src_adoc) as in_fh:
         for line in in_fh.readlines():
-            if line.startswith('== '):
+            if re.match('^=+ ', line) is not None:
                 if not seen_header:
                     seen_header = True
             else:
@@ -75,6 +76,7 @@ if __name__ == "__main__":
 :doctitle: {}
 :page-sub_title: {}
 :sectanchors:
+:figure-caption!:
 
 {}
 """.format(output_subdir, includes_dir, '{} - {}'.format(site_config['title'], index_title), index_title, new_contents))

--- a/scripts/create_output_index_json.py
+++ b/scripts/create_output_index_json.py
@@ -27,9 +27,9 @@ def build_tab_from_json(tab, adoc_dir, img_dir):
         num_available_images = len(available_images)
         for item in tab_data:
             newsubitem = {}
-            newsubitem['title'] = tab_data[item]['name']
-            newsubitem['description'] = tab_data[item]['description']
-            newsubitem['subpath'] = item + ".adoc"
+            newsubitem['title'] = item['name']
+            newsubitem['description'] = item['description']
+            newsubitem['subpath'] = item['group_id'] + ".adoc"
             if tab_key == 'pico-sdk' and newsubitem['title'] == "Introduction":
                 newsubitem['imagepath'] = os.path.join('/images', 'full-sized/SDK-Intro.png')
             else:

--- a/scripts/transform_doxygen_html.py
+++ b/scripts/transform_doxygen_html.py
@@ -431,8 +431,8 @@ def fix_heading_levels(root):
     print("ERROR: ", e, exc_tb.tb_lineno)
   return root
 
-def get_document_title(root):
-  title_text = ""
+def get_document_title(root, html_file):
+  title_text = re.sub(".html", "", html_file)
   try:
     title = root.find(".//div[@class='headertitle']/div[@class='title']")
     if title is not None:
@@ -765,7 +765,7 @@ def parse_indiviual_file(html_path, html_file, complete_json_mappings, updated_l
     # cleanup
     root = strip_attribute("data-processed", root)
     # get the document title
-    title_text = get_document_title(root)
+    title_text = get_document_title(root, html_file)
     # get only the relevant content
     contents = root.find(".//div[@class='contents']")
     # prep and write the adoc
@@ -808,10 +808,6 @@ def handler(html_path, output_path, header_path, output_json):
       this_output_path = os.path.join(output_path, html_file)
       # parse the file
       adoc, h_json = parse_indiviual_file(html_path, html_file, complete_json_mappings, updated_links, h_json)
-      # fix heading levels for non-included pages
-      # MOVED BELOW
-      # if html_file not in toc_list:
-      #   adoc = decrease_heading_levels(adoc)
       # write the final adoc file
       adoc_path = re.sub(".html$", ".adoc", this_output_path)
       write_output(adoc_path, adoc)
@@ -834,7 +830,9 @@ def handler(html_path, output_path, header_path, output_json):
       with open(this_path) as h:
         content = h.read()
       src_html_file = re.sub(".adoc", ".html", adoc_file)
+      # fix heading levels for non-included pages
       if src_html_file not in toc_list:
+        print(src_html_file)
         adoc = decrease_heading_levels(adoc)
       for link in updated_links:
         content = re.sub(link, updated_links[link], content)

--- a/scripts/transform_doxygen_html.py
+++ b/scripts/transform_doxygen_html.py
@@ -641,7 +641,6 @@ def find_toc_item(subitems, path, parent_tree):
         parent_tree.append(ix)
         if "html" in item and item["html"] == path:
           val = item
-          print("FOUND!")
         elif "subitems" in item:
           val, parent_tree = find_toc_item(item["subitems"], path, parent_tree)
         if val is None:

--- a/scripts/transform_doxygen_html.py
+++ b/scripts/transform_doxygen_html.py
@@ -307,29 +307,23 @@ def make_filename_id(filename):
     print("ERROR: ", e, exc_tb.tb_lineno)
   return my_id
 
-def find_item_in_toc(toc_data, filename):
+def find_item_in_toc(h_json, filename):
   try:
     found = False
     matching_file = None
-    for item in toc_data:
-      if item == filename:
-        matching_file = item
+    for item in h_json:
+      if "html" in item and item["html"] == filename:
+        matching_file = item["html"]
         found = True
         break
-      else:
-        for k, v in toc_data[item].items():
-          found = find_item_in_dict(k,v,filename)
-          if found == True:
-            matching_file = item
-            break
-        if found == True:
-          break
+      elif "subitems" in item:
+        matching_file, found = find_item_in_toc(item["subitems"], filename)
   except Exception as e:
     exc_type, exc_obj, exc_tb = sys.exc_info()
     print("ERROR: ", e, exc_tb.tb_lineno)
-  return matching_file
+  return matching_file, found
 
-def fix_external_links(root, toc_data):
+def fix_external_links(root, h_json):
   try:
     matches = root.xpath(".//a[@href]")
     for match in matches:
@@ -341,8 +335,9 @@ def fix_external_links(root, toc_data):
           filename = href.split("#")[0]
           target_id = href.split("#")[1]
         # walk the toc data to find the main html file
-        parent_file = find_item_in_toc(toc_data, filename)
+        parent_file, found = find_item_in_toc(h_json, filename)
         if parent_file is not None:
+          print(parent_file)
           parent_file_dest = re.sub("^group__", "", parent_file)
           new_href = parent_file_dest
           if filename != parent_file:
@@ -525,43 +520,56 @@ def make_dict_path(arr, level):
     print("ERROR: ", e, exc_tb.tb_lineno)
   return dict_path_str
 
-def parse_toc(root):
+def traverse_subitems(subitems, toc_list):
+  for item in subitems:
+    if "html" in item:
+      toc_list.append(item["html"])
+    if "subitems" in item:
+      toc_list = traverse_subitems(item["subitems"], toc_list)
+  return toc_list
+
+def parse_toc(h_json, toc_list):
   try:
-    toc_data = {}
-    toc_list = {}
-    parents = []
-    items = root.findall(".//a[@class='el']")
-    for item in items:
-      href = item.get("href")
-      target = item.get("target")
-      if target != "_self":
-        continue
-      parent = item.xpath("./ancestor::tr")[-1]
-      parent_id = parent.get("id")
-      level = len(parent_id.split("_"))-2
-      parent_level = level-1
-      if parent_level == 0:
-        # just add it to the main tree
-        toc_data[href] = {}
-      else:
-        # add it as a child at the correct nesting level
-        cmd = make_dict_path(parents, parent_level-1)
-        cmd = cmd + "[href] = {}"
-        exec(cmd)
-      toc_list[href] = level
-      if len(parents) > level-1:
-        parents[level-1] = href
-      else:
-        parents.append(href)
+    # toc_data = {}
+    # toc_list = {}
+    # parents = []
+    # items = root.findall(".//a[@class='el']")
+    # for item in items:
+    #   href = item.get("href")
+    #   target = item.get("target")
+    #   if target != "_self":
+    #     continue
+    #   parent = item.xpath("./ancestor::tr")[-1]
+    #   parent_id = parent.get("id")
+    #   level = len(parent_id.split("_"))-2
+    #   parent_level = level-1
+    #   if parent_level == 0:
+    #     # just add it to the main tree
+    #     toc_data[href] = {}
+    #   else:
+    #     # add it as a child at the correct nesting level
+    #     cmd = make_dict_path(parents, parent_level-1)
+    #     cmd = cmd + "[href] = {}"
+    #     exec(cmd)
+    #   toc_list[href] = level
+    #   if len(parents) > level-1:
+    #     parents[level-1] = href
+    #   else:
+    #     parents.append(href)
+    for item in h_json:
+      if "filename" in item:
+        toc_list.append(item["filename"])
+      elif "subitems" in item:
+        toc_list = traverse_subitems(item["subitems"], toc_list)
   except Exception as e:
     exc_type, exc_obj, exc_tb = sys.exc_info()
     print("ERROR: ", e, exc_tb.tb_lineno)
-  return toc_data, toc_list
+  return h_json, toc_list
 
 def parse_header(header_path):
-  h_json = {
-    'index_doxygen': { 'name': 'Introduction', 'description': 'An introduction to the Pico SDK', 'subitems': [] }
-  }
+  h_json = [
+    { 'group_id': 'index_doxygen', 'name': 'Introduction', 'description': 'An introduction to the Pico SDK', 'html': 'index_doxygen.html', 'subitems': [] }
+  ]
   try:
     with open(header_path) as h:
       content = h.read()
@@ -581,7 +589,8 @@ def parse_header(header_path):
           group_desc = re.sub("\n", "", group_desc, re.M)
           group_desc = re.sub("\*", "", group_desc, re.M)
           group_desc = re.sub("^\s", "", group_desc, re.M)
-          h_json[group_id] = { 'name': group_name, 'description': group_desc, 'filename': group_filename, 'subitems': [] }
+          group_json = { 'group_id': group_id, 'name': group_name, 'description': group_desc, 'html': group_filename, 'subitems': [] }
+          h_json.append(group_json)
         else:
           cleaned = item
           cleaned = re.sub("\n*", "", cleaned, re.M)
@@ -590,7 +599,7 @@ def parse_header(header_path):
           val = cleaned.split(" ")[0]
           filename = re.sub("_", "__", val)
           filename = "group__" + filename
-          h_json[group_id]['subitems'].append({ 'name': val, 'file': filename + ".adoc" })
+          group_json['subitems'].append({ 'name': val, 'file': filename + ".adoc", 'html': filename + ".html" })
   except Exception as e:
     exc_type, exc_obj, exc_tb = sys.exc_info()
     print("ERROR: ", e, exc_tb.tb_lineno)
@@ -612,11 +621,11 @@ def compile_json_mappings(json_dir, json_files):
     print("ERROR: ", e, exc_tb.tb_lineno)
   return compiled
 
-def compile_includes(my_adoc, output_path, v):
+def compile_includes(my_adoc, output_path, subitems):
   try:
-    for sk, sv in v.items():
+    for item in subitems:
       # append includes directly to the parent file
-      adoc_filename = re.sub("html$", "adoc", sk)
+      adoc_filename = item["file"]
       full_adoc_path = os.path.join(output_path, adoc_filename)
       # read the adoc
       included_content = ""
@@ -624,25 +633,25 @@ def compile_includes(my_adoc, output_path, v):
         included_content = f.read()
       my_adoc += "\n\n"
       my_adoc += included_content
-      if len(sv) > 0:
-        my_adoc = compile_includes(my_adoc, output_path, sv)
+      if "subitems" in item and len(item["subitems"]) > 0:
+        my_adoc = compile_includes(my_adoc, output_path, item["subitems"])
       os.remove(full_adoc_path)
   except Exception as e:
     exc_type, exc_obj, exc_tb = sys.exc_info()
     print("ERROR: ", e, exc_tb.tb_lineno)
   return my_adoc
 
-def walk_json(k, v, group_adoc, output_path):
+def walk_json(item, group_adoc, output_path):
   try:
-    filename = re.sub("html$", "adoc", k)
+    filename = item["file"]
     group_adoc = group_adoc + "include::" + filename + "[]\n\n"
-    if len(v) > 0:
+    if "subitems" in item and len(item["subitems"]) > 0:
       # compile includes into a single file
       my_adoc = ""
       my_adoc_path = os.path.join(output_path, filename)
       with open(my_adoc_path) as f:
         my_adoc = f.read()
-      my_adoc = compile_includes(my_adoc, output_path, v)
+      my_adoc = compile_includes(my_adoc, output_path, item["subitems"])
       # write the new file
       write_output(my_adoc_path, my_adoc)
   except Exception as e:
@@ -650,12 +659,14 @@ def walk_json(k, v, group_adoc, output_path):
     print("ERROR: ", e, exc_tb.tb_lineno)
   return group_adoc
 
-def walk_nested_adoc(k, v, output_path, level):
+def walk_nested_adoc(item, output_path, level):
   try:
     # only adjust nested items
     if level > 1:
       # read the adoc file
-      adoc_path = re.sub(".html$", ".adoc", k)
+      print(item)
+      # not all items in the json have an adoc path
+      adoc_path = re.sub(".html$", ".adoc", item["html"])
       filepath = os.path.join(output_path, adoc_path)
       with open(filepath) as f:
         content = f.read()
@@ -666,15 +677,49 @@ def walk_nested_adoc(k, v, output_path, level):
       # print(content)
       write_output(filepath, content)
       # adjust the heading levels
-    for sk,sv in v.items():
-      newlevel = level + 1
-      newlevel = walk_nested_adoc(sk, sv, output_path, newlevel)
+    if "subitems" in item:
+      for subitem in item["subitems"]:
+        newlevel = level + 1
+        newlevel = walk_nested_adoc(subitem, output_path, newlevel)
   except Exception as e:
     exc_type, exc_obj, exc_tb = sys.exc_info()
     print("ERROR: ", e, exc_tb.tb_lineno)
   return level
 
-def parse_indiviual_file(html_path, html_file, complete_json_mappings, updated_links, toc_data):
+# <div class="headertitle"><div class="title">timestamp<div class="ingroups"><a class="el" href="group__high__level.html">High Level APIs</a> &raquo; <a class="el" href="group__pico__time.html">pico_time</a></div></div></div>
+def check_toc_level(h_json, html_file, root):
+  try:
+    # check for header info:
+    header = root.find(".//div[@class='headertitle']")
+    if header is not None:
+      name = header.find(".//div[@class='title']").text
+      parents = header.findall(".//div[@class='ingroups']/a")
+      print("---------CHECK HTML TOC---------")
+      print(html_file)
+      print(parents)
+      level = h_json
+      if "Struct Reference" not in name and parents is not None:
+        full_item_paths = [f.get("href") for f in parents]
+        full_item_paths.append(html_file)
+        for ix, item in enumerate(full_item_paths):
+          found = False
+          for toc_item in level:
+            if "html" in toc_item and toc_item["html"] == item:
+              found = True
+              if len(full_item_paths) > ix+1:
+                if "subitems" not in toc_item:
+                  toc_item["subitems"] = []
+                level = toc_item["subitems"]
+                level_type = "list"
+          # create each toc level as needed
+          if found == False and ix > 0:
+            level.append({'name': re.sub(".html", "", item), 'file': re.sub(".html", ".adoc", item), 'html': item})
+  except Exception as e:
+    exc_type, exc_obj, exc_tb = sys.exc_info()
+    print("ERROR: ", e, exc_tb.tb_lineno)
+  return h_json
+
+def parse_indiviual_file(html_path, html_file, complete_json_mappings, updated_links, h_json):
   try:
     # create the full path
     this_path = os.path.join(html_path, html_file)
@@ -692,6 +737,8 @@ def parse_indiviual_file(html_path, html_file, complete_json_mappings, updated_l
     
     # give everything an id
     root = add_ids(root, html_file)
+    # first check to see if this should be in the toc list
+    h_json = check_toc_level(h_json, html_file, root)
     # loop over each json file
     skip = ["table_memname.json"]
     for mapping in complete_json_mappings:
@@ -699,7 +746,7 @@ def parse_indiviual_file(html_path, html_file, complete_json_mappings, updated_l
         root = transform_element(item, root)
     # fix links
     root, updated_links = fix_internal_links(root, html_file, updated_links)
-    root = fix_external_links(root, toc_data)
+    root = fix_external_links(root, h_json)
     # cleanup
     root = merge_lists("ul", root)
     root = merge_lists("ol", root)
@@ -723,7 +770,7 @@ def parse_indiviual_file(html_path, html_file, complete_json_mappings, updated_l
   except Exception as e:
     exc_type, exc_obj, exc_tb = sys.exc_info()
     print("ERROR: ", e, exc_tb.tb_lineno)
-  return adoc
+  return adoc, h_json
 
 def handler(html_path, output_path, header_path, output_json):
   try:
@@ -745,31 +792,37 @@ def handler(html_path, output_path, header_path, output_json):
     html_files = [f for f in html_files if re.search(".html", f) is not None]
     # sort the files ascending
     html_files.sort()
-    # get the TOC data
-    toc_file = os.path.join(html_path, "modules.html")
-    if os.path.exists(toc_file):
-      with open(toc_file) as h:
-        toc_root = etree.HTML(h.read())
-      toc_data, toc_list = parse_toc(toc_root)
+    # collect the TOC data
+    # toc_file = os.path.join(html_path, "modules.html")
+    # if os.path.exists(toc_file):
+    #   with open(toc_file) as h:
+    #     toc_root = etree.HTML(h.read())
+    #   toc_data, toc_list = parse_toc(toc_root)
     # process every html file
     updated_links = {}
+
     for html_file in html_files:
       this_output_path = os.path.join(output_path, html_file)
       # parse the file
-      adoc = parse_indiviual_file(html_path, html_file, complete_json_mappings, updated_links, toc_data)
+      adoc, h_json = parse_indiviual_file(html_path, html_file, complete_json_mappings, updated_links, h_json)
       # fix heading levels for non-included pages
-      if html_file not in toc_list:
-        adoc = decrease_heading_levels(adoc)
+      # MOVED BELOW
+      # if html_file not in toc_list:
+      #   adoc = decrease_heading_levels(adoc)
       # write the final adoc file
       adoc_path = re.sub(".html$", ".adoc", this_output_path)
       write_output(adoc_path, adoc)
       print("Generated " + adoc_path)
 
+    print(h_json)
+    toc_list = []
+    toc_list = parse_toc(h_json, toc_list)
+
     # adjust nested adoc headings
-    for k,v in toc_data.items():
+    for item in h_json:
       level = 0
       # walk the tree and adjust as necessary
-      level = walk_nested_adoc(k, v, output_path, level)
+      level = walk_nested_adoc(item, output_path, level)
 
     # fix any links that were updated from other files
     adoc_files = os.listdir(output_path)
@@ -778,6 +831,9 @@ def handler(html_path, output_path, header_path, output_json):
       this_path = os.path.join(output_path, adoc_file)
       with open(this_path) as h:
         content = h.read()
+      src_html_file = re.sub(".adoc", ".html", adoc_file)
+      if src_html_file not in toc_list:
+        adoc = decrease_heading_levels(adoc)
       for link in updated_links:
         content = re.sub(link, updated_links[link], content)
       write_output(this_path, content)
@@ -785,13 +841,14 @@ def handler(html_path, output_path, header_path, output_json):
     # make the group adoc files
     # include::micropython/what-board.adoc[]
     for item in h_json:
-      group_adoc = "= " + h_json[item]['name'] + "\n\n"
-      group_adoc = group_adoc + h_json[item]['description'] + "\n\n"
-      if 'filename' in h_json[item]:
-        item_filename = h_json[item]['filename']
-        for k,v in toc_data[item_filename].items():
-          group_adoc = walk_json(k,v,group_adoc,output_path)
-      group_output_path = os.path.join(output_path, item + ".adoc")
+      group_adoc = "= " + item['name'] + "\n\n"
+      group_adoc = group_adoc + item['description'] + "\n\n"
+      if 'html' in item:
+        item_filename = item['html']
+        print(item_filename)
+        for toc_item in item["subitems"]:
+          group_adoc = walk_json(toc_item,group_adoc,output_path)
+      group_output_path = os.path.join(output_path, item["group_id"] + ".adoc")
       write_output(group_output_path, group_adoc)
     # write the json structure file as well
     write_output(output_json, json.dumps(h_json, indent="\t"))


### PR DESCRIPTION
Unfortunately the fix for #3288 wasn't as simple as swapping out a filename, plus if this experience has taught us anything, it's not to rely on arbitrary doxygen filenames. I reworked the TOC build process to read file include info from each content file instead. Required a few tweaks to some other buildscripts, but nothing major. Spot-QA'd left-nav TOC contents and content pages, and all looked good.