### PR TITLE
Update installing-tools.adoc to fix ./bootstrap issue

### DIFF
--- a/documentation/asciidoc/microcontrollers/debug-probe/installing-tools.adoc
+++ b/documentation/asciidoc/microcontrollers/debug-probe/installing-tools.adoc
@@ -21,7 +21,7 @@ You need to be running OpenOCD version 0.11.0 or 0.12.0 to have support for the 
 Start by installing needed dependencies, 
 
 ----
-$ sudo apt install automake autoconf build-essential texinfo libtool libftdi-dev libusb-1.0-0-dev
+$ sudo apt install automake autoconf build-essential texinfo libtool libftdi-dev libusb-1.0-0-dev pkg-config
 ----
 
 and then build OpenOCD.


### PR DESCRIPTION
* Add pkg-config in install list. 
To fix: configure.ac:32: error: Macro PKG_PROG_PKG_CONFIG is not available. It is usually defined in file pkg.m4 provided by package pkg-config.