### PR TITLE
Add Pi 5 model filter to config.txt documentation

### DIFF
--- a/documentation/asciidoc/computers/config_txt/conditional.adoc
+++ b/documentation/asciidoc/computers/config_txt/conditional.adoc
@@ -31,6 +31,9 @@ The conditional model filters are applied according to the following table.
 | `[pi4]`
 | Model 4B, Pi 400, Compute Module 4, Compute Module 4S
 
+| `[pi5]`
+| Raspberry Pi 5
+
 | `[pi400]`
 | Pi 400 (also sees `[pi4]` contents)
 


### PR DESCRIPTION
Missed at release time.