### PR TITLE
Update headless.adoc: Add details about allowed symbols for the username

### DIFF
--- a/documentation/asciidoc/computers/configuration/headless.adoc
+++ b/documentation/asciidoc/computers/configuration/headless.adoc
@@ -37,6 +37,8 @@ At the root of your SD card, create a file named `userconf.txt`.
 
 This file should contain a single line of text, consisting of `<username>:<password>`: your desired username, followed immediately by a colon, followed immediately by an *encrypted* representation of the password you want to use.
 
+NOTE: `<username>` must only contain lower-case letters, digits and hyphens, and must start with a letter. (More details `/etc/adduser.conf`: `NAME_REGEX="^[a-z][-a-z0-9_]*\$?$"`)
+
 To generate the encrypted password, use https://www.openssl.org[OpenSSL] on another computer. Open a terminal and enter the following:
 
 ----

--- a/documentation/asciidoc/computers/configuration/headless.adoc
+++ b/documentation/asciidoc/computers/configuration/headless.adoc
@@ -37,7 +37,7 @@ At the root of your SD card, create a file named `userconf.txt`.
 
 This file should contain a single line of text, consisting of `<username>:<password>`: your desired username, followed immediately by a colon, followed immediately by an *encrypted* representation of the password you want to use.
 
-NOTE: `<username>` must only contain lower-case letters, digits and hyphens, and must start with a letter. (More details `/etc/adduser.conf`: `NAME_REGEX="^[a-z][-a-z0-9_]*\$?$"`)
+NOTE: `<username>` must only contain lower-case letters, digits and hyphens, and must start with a letter. It should not be longer than 30 characters to avoid unexpected side effects. (See this https://systemd.io/USER_NAMES/[article] for more details.)
 
 To generate the encrypted password, use https://www.openssl.org[OpenSSL] on another computer. Open a terminal and enter the following:
 

--- a/documentation/asciidoc/computers/configuration/headless.adoc
+++ b/documentation/asciidoc/computers/configuration/headless.adoc
@@ -37,7 +37,7 @@ At the root of your SD card, create a file named `userconf.txt`.
 
 This file should contain a single line of text, consisting of `<username>:<password>`: your desired username, followed immediately by a colon, followed immediately by an *encrypted* representation of the password you want to use.
 
-NOTE: `<username>` must only contain lower-case letters, digits and hyphens, and must start with a letter. It must not be longer than 32 characters. (See this https://systemd.io/USER_NAMES/[article] for more details.)
+NOTE: `<username>` must only contain lower-case letters, digits and hyphens, and must start with a letter. It must not be longer than 32 characters. 
 
 To generate the encrypted password, use https://www.openssl.org[OpenSSL] on another computer. Open a terminal and enter the following:
 

--- a/documentation/asciidoc/computers/configuration/headless.adoc
+++ b/documentation/asciidoc/computers/configuration/headless.adoc
@@ -37,7 +37,7 @@ At the root of your SD card, create a file named `userconf.txt`.
 
 This file should contain a single line of text, consisting of `<username>:<password>`: your desired username, followed immediately by a colon, followed immediately by an *encrypted* representation of the password you want to use.
 
-NOTE: `<username>` must only contain lower-case letters, digits and hyphens, and must start with a letter. It should not be longer than 30 characters to avoid unexpected side effects. (See this https://systemd.io/USER_NAMES/[article] for more details.)
+NOTE: `<username>` must only contain lower-case letters, digits and hyphens, and must start with a letter. It must not be longer than 32 characters. (See this https://systemd.io/USER_NAMES/[article] for more details.)
 
 To generate the encrypted password, use https://www.openssl.org[OpenSSL] on another computer. Open a terminal and enter the following:
 


### PR DESCRIPTION
As the NAME_REGEX differs on different distributions I had to connect a screen to my 'headless' setup to find the following error message:

```
/boot/firmware/failed_userconf.txt detected:
Entered username is invalid:
Must only contrain lower-case letters, digits and hyphens, and must start with a letter.
```
The provided error message is clear and helps to fix this.
As finding the error message on a real headless setup is not that strait forward I hope this helps to avoid troubleshooting in the future.
 