### PR TITLE
Correct password length limit

### DIFF
--- a/documentation/asciidoc/computers/configuration/headless.adoc
+++ b/documentation/asciidoc/computers/configuration/headless.adoc
@@ -37,7 +37,7 @@ At the root of your SD card, create a file named `userconf.txt`.
 
 This file should contain a single line of text, consisting of `<username>:<password>`: your desired username, followed immediately by a colon, followed immediately by an *encrypted* representation of the password you want to use.
 
-NOTE: `<username>` must only contain lower-case letters, digits and hyphens, and must start with a letter. It must not be longer than 32 characters. 
+NOTE: `<username>` must only contain lower-case letters, digits and hyphens, and must start with a letter. It must not be longer than 31 characters. 
 
 To generate the encrypted password, use https://www.openssl.org[OpenSSL] on another computer. Open a terminal and enter the following:
 


### PR DESCRIPTION
Per https://github.com/raspberrypi/rpi-imager/pull/741/files, the soon-to-be-imposed limit on username length is 31 characters, not 32. (There is currently no limit imposed by Raspberry Pi OS).