### PR TITLE
Revise BCM2711-exclusive statements to also include BCM2712

### DIFF
--- a/documentation/asciidoc/computers/configuration/device-tree.adoc
+++ b/documentation/asciidoc/computers/configuration/device-tree.adoc
@@ -893,9 +893,9 @@ To capture this for a bug report run `hexdump -C /proc/device-tree/chosen/power/
 The format is defined by the https://usb.org/document-library/usb-power-delivery[USB Power Delivery] specification.
 
 
-==== BCM2711 & BCM2712 specific bootloader properties `/chosen/bootloader`
+==== BCM2711 and BCM2712 specific bootloader properties `/chosen/bootloader`
 
-The following properties are specific to the BCM2711 & BCM2712 SPI EEPROM bootloaders.
+The following properties are specific to the BCM2711 and BCM2712 SPI EEPROM bootloaders.
 
 `build_timestamp` - 32-bit integer
 
@@ -964,7 +964,7 @@ If secure-boot is enabled then this bit-field will be non-zero. The individual b
 
 The Git version string for the bootloader.
 
-==== BCM2711 & BCM2712 USB boot properties `/chosen/bootloader/usb`
+==== BCM2711 and BCM2712 USB boot properties `/chosen/bootloader/usb`
 
 The following properties are defined if the system was booted from USB. These may be used to uniquely identify the USB boot device.
 

--- a/documentation/asciidoc/computers/configuration/device-tree.adoc
+++ b/documentation/asciidoc/computers/configuration/device-tree.adoc
@@ -894,7 +894,8 @@ The format is defined by the https://usb.org/document-library/usb-power-delivery
 
 
 ==== BCM2711 & BCM2712 specific bootloader properties `/chosen/bootloader`
-The following properties are specific to BCM2711 SPI EEPROM bootloader.
+
+The following properties are specific to the BCM2711 & BCM2712 SPI EEPROM bootloaders.
 
 `build_timestamp` - 32-bit integer
 
@@ -964,6 +965,7 @@ If secure-boot is enabled then this bit-field will be non-zero. The individual b
 The Git version string for the bootloader.
 
 ==== BCM2711 & BCM2712 USB boot properties `/chosen/bootloader/usb`
+
 The following properties are defined if the system was booted from USB. These may be used to uniquely identify the USB boot device.
 
 `usb-version` - 32-bit integer

--- a/documentation/asciidoc/computers/legacy_config_txt/memory.adoc
+++ b/documentation/asciidoc/computers/legacy_config_txt/memory.adoc
@@ -50,5 +50,5 @@ The `gpu_mem_1024` command sets the GPU memory in megabytes for Raspberry Pis wi
 
 === `disable_l2cache`
 
-Setting this to `1` disables the CPU's access to the GPU's L2 cache and requires a corresponding L2 disabled kernel. Default value on BCM2835 is `0`. On BCM2836, BCM2837, and BCM2711, the ARMs have their own L2 cache and therefore the default is `1`. The standard Raspberry Pi `kernel.img` and `kernel7.img` builds reflect this difference in cache setting.
+Setting this to `1` disables the CPU's access to the GPU's L2 cache and requires a corresponding L2 disabled kernel. Default value on BCM2835 is `0`. On BCM2836, BCM2837, BCM2711, and BCM2712, the ARMs have their own L2 cache and therefore the default is `1`. The standard Raspberry Pi `kernel.img` and `kernel7.img` builds reflect this difference in cache setting.
 

--- a/documentation/asciidoc/computers/raspberry-pi/boot-eeprom-rpi4.adoc
+++ b/documentation/asciidoc/computers/raspberry-pi/boot-eeprom-rpi4.adoc
@@ -233,7 +233,7 @@ rpi-eeprom-config --config boot.conf --out new.bin pieeprom.bin
 
 ==== recovery.bin
 
-At power on, the BCM2711 ROM looks for a file called `recovery.bin` in the root directory of the boot partition on the SD card. If a valid `recovery.bin` is found then the ROM executes this instead of the contents of the EEPROM. This mechanism ensures that the bootloader EEPROM can always be reset to a valid image with factory default settings.
+At power on, the ROM found on BCM2711 and BCM2712 looks for a file called `recovery.bin` in the root directory of the boot partition on the SD card. If a valid `recovery.bin` is found then the ROM executes this instead of the contents of the EEPROM. This mechanism ensures that the bootloader EEPROM can always be reset to a valid image with factory default settings.
 
 See also xref:raspberry-pi.adoc#raspberry-pi-4-and-raspberry-pi-5-boot-flow[Raspberry Pi boot-flow]
 
@@ -265,7 +265,7 @@ See also xref:raspberry-pi.adoc#raspberry-pi-4-and-raspberry-pi-5-boot-flow[Rasp
 * If the bootloader update image is called `pieeprom.upd` then `recovery.bin` is renamed to `recovery.000` once the update has completed, then the system is rebooted. Since `recovery.bin` is no longer present the ROM loads the newly updated bootloader from EEPROM and the OS is booted as normal.
 * If the bootloader update image is called `pieeprom.bin` then `recovery.bin` will stop after the update has completed. On success the HDMI output will be green and the green activity LED is flashed rapidly. If the update fails, the HDMI output will be red and an xref:configuration.adoc#led-warning-flash-codes[error code] will be displayed via the activity LED.
 * The `.sig` files contain the hexadecimal sha256 checksum of the corresponding image file; additional fields may be added in the future.
-* The BCM2711 ROM does not support loading `recovery.bin` from USB mass storage or TFTP. Instead, newer versions of the bootloader support a self-update mechanism where the bootloader is able to reflash the EEPROM itself. See `ENABLE_SELF_UPDATE` on the xref:raspberry-pi.adoc#raspberry-pi-bootloader-configuration[bootloader configuration] page.
+* The ROM found on BCM2711 and BCM2712 does not support loading `recovery.bin` from USB mass storage or TFTP. Instead, newer versions of the bootloader support a self-update mechanism where the bootloader is able to reflash the EEPROM itself. See `ENABLE_SELF_UPDATE` on the xref:raspberry-pi.adoc#raspberry-pi-bootloader-configuration[bootloader configuration] page.
 * The temporary EEPROM update files are automatically deleted by the `rpi-eeprom-update` service at startup.
 
 For more information about the `rpi-eeprom-update` configuration file see `rpi-eeprom-update -h`.

--- a/documentation/asciidoc/computers/raspberry-pi/bootflow-2711.adoc
+++ b/documentation/asciidoc/computers/raspberry-pi/bootflow-2711.adoc
@@ -4,9 +4,9 @@ The main difference between this and previous products is that the second stage 
 
 === First Stage Bootloader
 
-The boot flow for the ROM (first stage) is as follows:-
+The boot flow for the ROM (first stage) is as follows:
 
-* BCM2711 SoC powers up
+* SoC powers up
 * Read OTP to determine if the `nRPIBOOT` GPIO is configured
 * If `nRPIBOOT` GPIO is high or OTP does NOT define `nRPIBOOT` GPIO
  ** Check OTP to see if `recovery.bin` can be loaded from SD/EMMC
@@ -17,11 +17,9 @@ The boot flow for the ROM (first stage) is as follows:-
   *** Success - run second stage bootloader
   *** Fail - continue
 * While True
- ** Attempt to load recovery.bin from xref:compute-module.adoc#flashing-the-compute-module-emmc[USB device boot]
+ ** Attempt to load `recovery.bin` from xref:compute-module.adoc#flashing-the-compute-module-emmc[USB device boot]
   *** Success - run `recovery.bin` and update the SPI EEPROM or switch to USB mass storage device mode
   *** Fail - retry USB device boot
-
-NOTE: Currently only CM4 reserves a GPIO for `nRPIBOOT`.
 
 NOTE: `recovery.bin` is a minimal second stage program used to reflash the bootloader SPI EEPROM image.
 

--- a/documentation/asciidoc/computers/raspberry-pi/revision-codes.adoc
+++ b/documentation/asciidoc/computers/raspberry-pi/revision-codes.adoc
@@ -15,7 +15,7 @@ Revision    : a02082
 Serial      : 00000000765fc593
 ----
 
-NOTE: All Raspberry Pi computers report `BCM2835`, even those with BCM2836, BCM2837 and BCM2711 processors. You should not use this string to detect the processor. Decode the revision code using the information below, or `cat /sys/firmware/devicetree/base/model`.
+NOTE: All Raspberry Pi computers report `BCM2835`, even those with BCM2836, BCM2837, BCM2711, and BCM2712 processors. You should not use this string to detect the processor. Decode the revision code using the information below, or `cat /sys/firmware/devicetree/base/model`.
 
 === Old-style revision codes
 

--- a/documentation/asciidoc/computers/raspberry-pi/spi-bus-on-raspberry-pi.adoc
+++ b/documentation/asciidoc/computers/raspberry-pi/spi-bus-on-raspberry-pi.adoc
@@ -12,9 +12,9 @@ Raspberry Pi Zero, 1, 2 and 3 have three SPI controllers:
 * SPI1, with three hardware chip selects, is available on all Raspberry Pi models except the original Raspberry Pi 1 Model A and Model B.
 * SPI2, also with three hardware chip selects, is only available on Compute Module 1, 3 and 3+.
 
-On the Raspberry Pi 4, 400 and Compute Module 4 there are four additional SPI buses: SPI3 to SPI6, each with 2 hardware chip selects. These extra SPI buses are available via alternate function assignments on certain GPIO pins - see the https://datasheets.raspberrypi.com/bcm2711/bcm2711-peripherals.pdf[BCM2711 ARM Peripherals] datasheet.
+On the Raspberry Pi 4, 400 and Compute Module 4 there are four additional SPI buses: SPI3 to SPI6, each with 2 hardware chip selects. These extra SPI buses are available via alternate function assignments on certain GPIO pins. For more information, see the https://datasheets.raspberrypi.com/bcm2711/bcm2711-peripherals.pdf[BCM2711 ARM Peripherals] datasheet.
 
-Chapter 10 in the https://datasheets.raspberrypi.com/bcm2835/bcm2835-peripherals.pdf[BCM2835 ARM Peripherals] datasheet describes the main controller.  Chapter 2.3 describes the auxiliary controller.
+Chapter 10 in the https://datasheets.raspberrypi.com/bcm2835/bcm2835-peripherals.pdf[BCM2835 ARM Peripherals] datasheet describes the main controller. Chapter 2.3 describes the auxiliary controller.
 
 ==== Pin/GPIO mappings
 


### PR DESCRIPTION
* closes https://github.com/raspberrypi/documentation/issues/3356
* minor copy fixes, eliminated a NOTE that will be difficult to maintain in the future