### PR TITLE
Add link to USB PID repo

### DIFF
--- a/documentation/asciidoc/microcontrollers/rp2040/rp2040_based_boards.adoc
+++ b/documentation/asciidoc/microcontrollers/rp2040/rp2040_based_boards.adoc
@@ -15,4 +15,16 @@ THE DESIGN IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH REGA
 
 === Other Boards
 
-Discussions around other third party RP2040-based boards can be found on the https://forums.raspberrypi.com/viewforum.php?f=147[Raspberry Pi forums].
+You can find discussions around third-party RP2040-based boards on the https://forums.raspberrypi.com/viewforum.php?f=147[Raspberry Pi forums].
+
+==== USB PIDs
+
+Many RP2040-based devices use Raspberry Pi's USB Vendor ID and Product ID combination. If you build a third-party board based on RP2040, you may require a unique USB Product ID (PID).
+
+You might need a unique USB PID if you need to provide a custom driver for Windows users.
+
+USB-IF have given Raspberry Pi permission to license USB product ID values for its Vendor ID (`0x2E8A`) for common silicon components used with RP2040.
+
+To reserve a USB PID associated with Raspberry Pi's vendor ID, follow the instructions found at the [Raspberry Pi USB PID git repository](https://github.com/raspberrypi/usb-pid).
+
+NOTE: If you use the standard RP2040 PID, you can use the `iManufacturer`, `iProduct`, and `iSerial` strings to uniquely identify your device.

--- a/documentation/asciidoc/microcontrollers/rp2040/rp2040_based_boards.adoc
+++ b/documentation/asciidoc/microcontrollers/rp2040/rp2040_based_boards.adoc
@@ -25,6 +25,6 @@ You might need a unique USB PID if you need to provide a custom driver for Windo
 
 USB-IF have given Raspberry Pi permission to license USB product ID values for its Vendor ID (`0x2E8A`) for common silicon components used with RP2040.
 
-To reserve a USB PID associated with Raspberry Pi's vendor ID, follow the instructions found at the https://github.com/raspberrypi/usb-pid[Raspberry Pi USB PID git repository].
+To reserve a USB PID associated with Raspberry Pi's vendor ID, follow the instructions in the https://github.com/raspberrypi/usb-pid[Raspberry Pi USB PID git repository].
 
 NOTE: If you use the standard RP2040 PID, you can use the `iManufacturer`, `iProduct`, and `iSerial` strings to uniquely identify your device.

--- a/documentation/asciidoc/microcontrollers/rp2040/rp2040_based_boards.adoc
+++ b/documentation/asciidoc/microcontrollers/rp2040/rp2040_based_boards.adoc
@@ -25,6 +25,6 @@ You might need a unique USB PID if you need to provide a custom driver for Windo
 
 USB-IF have given Raspberry Pi permission to license USB product ID values for its Vendor ID (`0x2E8A`) for common silicon components used with RP2040.
 
-To reserve a USB PID associated with Raspberry Pi's vendor ID, follow the instructions found at the [Raspberry Pi USB PID git repository](https://github.com/raspberrypi/usb-pid).
+To reserve a USB PID associated with Raspberry Pi's vendor ID, follow the instructions found at the https://github.com/raspberrypi/usb-pid[Raspberry Pi USB PID git repository].
 
 NOTE: If you use the standard RP2040 PID, you can use the `iManufacturer`, `iProduct`, and `iSerial` strings to uniquely identify your device.

--- a/documentation/asciidoc/microcontrollers/rp2040/technical_specification.adoc
+++ b/documentation/asciidoc/microcontrollers/rp2040/technical_specification.adoc
@@ -10,7 +10,7 @@ lowest possible barrier to entry for beginner and hobbyist users.
 
 RP2040 is a stateless device, with support for cached execute-in-place from external QSPI memory. This design
 decision allows you to choose the appropriate density of non-volatile storage for your application, and to benefit from
-the low pricing of commodity Flash parts.
+the low pricing of commodity flash parts.
 
 RP2040 is manufactured on a modern 40nm process node, delivering high performance, low dynamic power
 consumption, and low leakage, with a variety of low-power modes to support extended-duration operation on battery


### PR DESCRIPTION
* https://github.com/raspberrypi/documentation/issues/3270
* added as a subsection of the "Other Boards" section, beneath "RP2040-based Boards"