### PR TITLE
0 in 'reboot "0 tryboot"' means nothing

### DIFF
--- a/documentation/asciidoc/computers/config_txt/autoboot.adoc
+++ b/documentation/asciidoc/computers/config_txt/autoboot.adoc
@@ -43,7 +43,7 @@ boot_partition=3
 
 * System is powered on and boots to partition 2 by default
 * An `Update service` downloads the next version of the OS to partition 3
-* The update is tested by rebooting to `tryboot` mode `reboot "0 tryboot"` where `0` means the default partition
+* The update is tested by rebooting to `tryboot` mode `reboot "0 tryboot"`
 
 **Committing or cancelling the update**
 


### PR DESCRIPTION
According to the sources, there is only a check for " tryboot" substring. Everything else is ignored.

https://github.com/raspberrypi/linux/blob/3bb5880ab3dd31f75c07c3c33bf29c5d469b28f3/drivers/firmware/raspberrypi.c#L217