### PR TITLE
Improve wording, content, and organisation of network boot section

### DIFF
--- a/documentation/asciidoc/computers/raspberry-pi.adoc
+++ b/documentation/asciidoc/computers/raspberry-pi.adoc
@@ -16,7 +16,7 @@ include::raspberry-pi/bootflow-legacy.adoc[]
 
 include::raspberry-pi/bootflow-2711.adoc[]
 
-include::raspberry-pi/bcm2711-bootloader.adoc[]
+include::raspberry-pi/eeprom-bootloader.adoc[]
 
 include::raspberry-pi/boot-usb.adoc[]
 

--- a/documentation/asciidoc/computers/raspberry-pi/boot-net.adoc
+++ b/documentation/asciidoc/computers/raspberry-pi/boot-net.adoc
@@ -1,49 +1,57 @@
-== Network Booting
+== Network booting
 
-This section describes how network booting works on the Raspberry Pi 3B, 3B+ and 2B v1.2. On the Raspberry Pi 4 network booting is implemented in the second stage bootloader in the EEPROM. Please see the xref:raspberry-pi.adoc#raspberry-pi-bootloader-configuration[Raspberry Pi 4 Bootloader Configuration] page for more information.
-We also have a xref:remote-access.adoc#network-boot-your-raspberry-pi[tutorial about setting up a network boot system]. Network booting works only for the wired adapter built into the above models of Raspberry Pi. Booting over wireless LAN is not supported, nor is booting from any other wired network device.
+This section describes how network booting works on Raspberry Pi 3B, 3B+ and 2B v1.2.
+
+On Pi 4 and Pi 5, network booting is implemented in the second stage bootloader in the EEPROM. For more information, see xref:raspberry-pi.adoc#raspberry-pi-bootloader-configuration[Raspberry Pi 4 bootloader configuration].
+
+We also have a xref:remote-access.adoc#network-boot-your-raspberry-pi[tutorial about setting up a network boot system].
+
+Network booting works only for the wired adapter built into the above models of Raspberry Pi. Booting over wireless LAN is not supported, nor is booting from any other wired network device.
+
+=== Network boot flow
 
 To network boot, the boot ROM does the following:
 
 * Initialise on-board Ethernet device (Microchip LAN9500 or LAN7500)
-* Send DHCP request (with Vendor Class identifier DHCP option 60 set to 'PXEClient:Arch:00000:UNDI:002001')
+* Send DHCP request (with Vendor Class identifier DHCP option 60 set to `PXEClient:Arch:00000:UNDI:002001`)
 * Receive DHCP reply
 * (optional) Receive DHCP proxy reply
 * ARP to tftpboot server
 * ARP reply includes tftpboot server ethernet address
-* TFTP RRQ 'bootcode.bin'
+* TFTP RRQ `bootcode.bin`
  ** File not found: Server replies with TFTP error response with textual error message
  ** File exists: Server will reply with the first block (512 bytes) of data for the file with a block number in the header
   *** Raspberry Pi replies with TFTP ACK packet containing the block number, and repeats until the last block which is not 512 bytes
-* TFTP RRQ 'bootsig.bin'
+* TFTP RRQ `bootsig.bin`
  ** This will normally result in an error `file not found`. This is to be expected, and TFTP boot servers should be able to handle it.
 
-From this point the `bootcode.bin` code continues to load the system. The first file it will try to access is [`serial_number`]/start.elf. If this does not result in an error then any other files to be read will be prepended with the `serial_number`. This is useful because it enables you to create separate directories with separate start.elf / kernels for your Raspberry Pis.
+From this point the `bootcode.bin` code continues to load the system. The first file it will try to access is `<serial_number>/start.elf`. If this does not result in an error then any other files to be read will be prepended with the `serial_number`. This is useful because it enables you to create separate directories with separate `start.elf` / kernels for your Raspberry Pis.
+
 To get the serial number for the device you can either try this boot mode and see what file is accessed using tcpdump / wireshark, or you can run a standard Raspberry Pi OS SD card and `cat /proc/cpuinfo`.
 
-If you put all your files into the root of your tftp directory then all following files will be accessed from there.
+If you put all your files into the root of your TFTP directory then all following files will be accessed from there.
 
-=== Debugging Network Boot Mode
+=== Debugging network boot mode
 
-The first thing to check is that the OTP bit is correctly programmed. To do this, you need to add `program_usb_boot_mode=1` to config.txt and reboot (with a standard SD card that boots correctly into Raspberry Pi OS). Once you've done this, you should be able to do:
+The first thing to check is that the OTP bit is correctly programmed. To do this, you need to add `program_usb_boot_mode=1` to `config.txt` and reboot (with a standard SD card that boots correctly into Raspberry Pi OS). Once you've done this, you should be able to do:
 
-[,bash]
+[source,console]
 ----
- vcgencmd otp_dump | grep 17:
-----
-
-If row 17 contains `3020000a` then the OTP is correctly programmed. You should now be able to remove the SD card, plug in Ethernet,
-and then the Ethernet LEDs should light up around 5 seconds after the Raspberry Pi powers up.
-
-To capture the ethernet packets on the server, use tcpdump on the tftpboot server (or DHCP server if they are different). You will need to capture the packets there otherwise you will not be able to see packets that get sent directly because network switches are not hubs!
-
-----
-sudo tcpdump -i eth0 -w dump.pcap
+$ vcgencmd otp_dump | grep 17:
 ----
 
-This will write everything from eth0 to a file dump.pcap you can then post process it or upload it to cloudshark.com for communication
+If row 17 contains `3020000a` then the OTP is correctly programmed. You should now be able to remove the SD card, plug in Ethernet, and then the Ethernet LEDs should light up around 5 seconds after the Raspberry Pi powers up.
 
-==== DHCP Request / Reply
+To capture the Ethernet packets on the server, use tcpdump on the tftpboot server (or DHCP server if they are different). You will need to capture the packets there otherwise you will not be able to see packets that get sent directly because network switches are not hubs!
+
+[source,console]
+----
+$ sudo tcpdump -i eth0 -w dump.pcap
+----
+
+This will write everything from eth0 to a file named `dump.pcap`. You can then post-process or upload the packets to cloudshark for communication.
+
+==== DHCP request / reply
 
 As a minimum you should see a DHCP request and reply which looks like the following:
 
@@ -83,12 +91,11 @@ As a minimum you should see a DHCP request and reply which looks like the follow
 	    END Option 255, length 0
 ----
 
-The important part of the reply is the Vendor-Option Option 43. This needs to contain the string "Raspberry Pi Boot", although, due
-to a bug in the boot ROM, you may need to add three spaces to the end of the string.
+ `Vendor-Option Option 43` contains the important part of the reply. This must contain the string "Raspberry Pi Boot". Due to a bug in the boot ROM, you may need to add three spaces to the end of the string.
 
 ==== TFTP file read
 
-You will know whether the Vendor Option is correctly specified: if it is, you'll see a subsequent TFTP RRQ packet being sent. RRQs can be replied to by either the first block of data or an error saying file not found. In a couple of cases they even receive the first packet and then the transmission is aborted by the Raspberry Pi (this happens when checking whether a file exists). The example below is just three packets: the original read request, the first data block (which is always 516 bytes containing a header and 512 bytes of data, although the last block is always less than 512 bytes and may be zero length), and the third packet (the ACK which contains a frame number to match the frame number in the data block).
+When the Vendor Option is correctly specified, you'll see a subsequent TFTP RRQ packet being sent. RRQs can be replied to by either the first block of data or an error saying file not found. In a couple of cases they even receive the first packet and then the transmission is aborted by the Raspberry Pi (this happens when checking whether a file exists). The example below is just three packets: the original read request, the first data block (which is always 516 bytes containing a header and 512 bytes of data, although the last block is always less than 512 bytes and may be zero length), and the third packet (the ACK which contains a frame number to match the frame number in the data block).
 
 ----
 16:44:41.224964 IP (tos 0x0, ttl 128, id 0, offset 0, flags [none], proto UDP (17), length 49)
@@ -99,9 +106,9 @@ You will know whether the Vendor Option is correctly specified: if it is, you'll
     192.168.1.139.49152 > 192.168.1.1.55985: [no cksum] UDP, length 4
 ----
 
-=== Known Problems
+=== Known problems
 
-There are a number of known problems with the Ethernet boot mode. Since the implementation of the boot modes is in the chip itself, there are no workarounds other than to use an SD card with just the bootcode.bin file.
+There are a number of known problems with the Ethernet boot mode. Since the implementation of the boot modes is in the chip itself, there are no workarounds other than to use an SD card with just the `bootcode.bin` file.
 
 ==== DHCP requests time out after five tries
 
@@ -117,11 +124,11 @@ The DHCP check also checked if the hops value was `1`, which it wouldn't be with
 
 Fixed in Raspberry Pi 3 Model B+.
 
-==== Raspberry Pi Boot string
+==== Raspberry Pi boot string
 
 The "Raspberry Pi Boot   " string in the DHCP reply requires the extra three spaces due to an error calculating the string length.
 
-Fixed in Raspberry Pi 3 Model B+
+Fixed in Raspberry Pi 3 Model B+.
 
 ==== DHCP UUID constant
 

--- a/documentation/asciidoc/computers/raspberry-pi/eeprom-bootloader.adoc
+++ b/documentation/asciidoc/computers/raspberry-pi/eeprom-bootloader.adoc
@@ -4,36 +4,46 @@
 
 Before editing the bootloader configuration, xref:os.adoc#updating-and-upgrading-raspberry-pi-os[update your system] to get the latest version of the `rpi-eeprom` package.
 
-To view the current EEPROM configuration: +
-`rpi-eeprom-config`
+To view the current EEPROM configuration, run the following command:
 
-To edit it and apply the updates to latest EEPROM release: +
-`sudo -E rpi-eeprom-config --edit`
+[source,console]
+----
+rpi-eeprom-config
+----
 
-Please see the xref:raspberry-pi.adoc#raspberry-pi-boot-eeprom[boot EEPROM] page for more information about the EEPROM update process.
+To edit the current EEPROM configuration and apply the updates to latest EEPROM release, run the following command:
+
+[source,console]
+----
+sudo -E rpi-eeprom-config --edit
+----
+
+For more information about the EEPROM update process, see xref:raspberry-pi.adoc#raspberry-pi-boot-eeprom[boot EEPROM].
 
 === Configuration properties
 
 This section describes all the configuration items available in the bootloader. The syntax is the same as xref:config_txt.adoc[config.txt] but the properties are specific to the bootloader. xref:config_txt.adoc#conditional-filters[Conditional filters] are also supported except for EDID.
 
 [[BOOT_UART]]
-==== BOOT_UART
+==== `BOOT_UART`
 
 If `1` then enable UART debug output on GPIO 14 and 15. Configure the receiving debug terminal at 115200bps, 8 bits, no parity bits, 1 stop bit.
 
 Default: `0`
 
 [[UART_BAUD]]
-==== UART_BAUD
+==== `UART_BAUD`
+
 Raspberry Pi 5 only.
 
-Changes the baud rate for the bootloader UART. +
-Supported values are `9600`, `19200`, `38400`, `57600`, `115200`, `230400`, `460800`, `921600`
+Changes the baud rate for the bootloader UART.
+
+Supported values: `9600`, `19200`, `38400`, `57600`, `115200`, `230400`, `460800`, `921600`
 
 Default: `115200`
 
 [[WAKE_ON_GPIO]]
-==== WAKE_ON_GPIO
+==== `WAKE_ON_GPIO`
 
 If `1` then `sudo halt` will run in a lower power mode until either GPIO3 or GLOBAL_EN are shorted to ground.
 
@@ -42,7 +52,7 @@ This setting is not relevant on Raspberry Pi 5 because the xref:raspberry-pi-5.a
 Default: `1`
 
 [[POWER_OFF_ON_HALT]]
-==== POWER_OFF_ON_HALT
+==== `POWER_OFF_ON_HALT`
 
 If `1` and `WAKE_ON_GPIO=0` then `sudo halt` will switch off all PMIC outputs. This is lowest possible power state for halt but may cause problems with some HATs because 5V will still be on. `GLOBAL_EN` must be shorted to ground to boot.
 
@@ -50,17 +60,14 @@ Raspberry Pi 400 has a dedicated power button which operates even if the process
 
 On Raspberry Pi 5 this places the PMIC in `STANDBY` mode where all outputs are switched off. There is no need to set `WAKE_ON_GPIO` and pressing the xref:raspberry-pi-5.adoc#adding-your-own-power-button[dedicated power button] will boot the device.
 
-
 Default: `0`
 
 [[BOOT_ORDER]]
-==== BOOT_ORDER
+==== `BOOT_ORDER`
 
 The `BOOT_ORDER` setting allows flexible configuration for the priority of different boot modes. It is represented as a 32-bit unsigned integer where each nibble represents a boot-mode. The boot modes are attempted in lowest significant nibble to highest significant nibble order.
 
-
-[discrete]
-====== `BOOT_ORDER` fields
+===== `BOOT_ORDER` fields
 
 The BOOT_ORDER property defines the sequence for the different boot modes. It is read right to left, and up to eight digits may be defined.
 
@@ -110,8 +117,7 @@ The BOOT_ORDER property defines the sequence for the different boot modes. It is
 
 `RPIBOOT` is intended for use with Compute Module 4 to load a custom debug image (e.g. a Linux RAM-disk) instead of the normal boot. This should be the last boot option because it does not currently support timeouts or retries.
 
-[discrete]
-====== `BOOT_ORDER` examples
+===== `BOOT_ORDER` examples
 
 |===
 | BOOT_ORDER | Description
@@ -127,62 +133,68 @@ The BOOT_ORDER property defines the sequence for the different boot modes. It is
 |===
 
 [[MAX_RESTARTS]]
-==== MAX_RESTARTS
+==== `MAX_RESTARTS`
 
 If the RESTART (`0xf`) boot-mode is encountered more than MAX_RESTARTS times then a watchdog reset is triggered. This isn't recommended for general use but may be useful for test or remote systems where a full reset is needed to resolve issues with hardware or network interfaces.
 
 Default: `-1` (infinite)
 
 [[SD_BOOT_MAX_RETRIES]]
-==== SD_BOOT_MAX_RETRIES
+==== `SD_BOOT_MAX_RETRIES`
 
-The number of times that SD boot will be retried after failure before moving to the next boot-mode defined by `BOOT_ORDER`. +
+The number of times that SD boot will be retried after failure before moving to the next boot-mode defined by `BOOT_ORDER`.
+
 `-1` means infinite retries.
 
 Default: `0`
 
 [[NET_BOOT_MAX_RETRIES]]
-==== NET_BOOT_MAX_RETRIES
+==== `NET_BOOT_MAX_RETRIES`
 
-The number of times that network boot will be retried after failure before moving to the next boot-mode defined by `BOOT_ORDER`. +
+The number of times that network boot will be retried after failure before moving to the next boot-mode defined by `BOOT_ORDER`.
+
 `-1` means infinite retries.
 
 Default: `0`
 
 [[DHCP_TIMEOUT]]
-==== DHCP_TIMEOUT
+==== `DHCP_TIMEOUT`
 
 The timeout in milliseconds for the entire DHCP sequence before failing the current iteration.
 
-Minimum: `5000` +
+Minimum: `5000`
+
 Default: `45000`
 
 [[DHCP_REQ_TIMEOUT]]
-==== DHCP_REQ_TIMEOUT
+==== `DHCP_REQ_TIMEOUT`
 
 The timeout in milliseconds before retrying DHCP DISCOVER or DHCP REQ.
 
-Minimum: `500` +
+Minimum: `500`
+
 Default: `4000`
 
 [[TFTP_FILE_TIMEOUT]]
-==== TFTP_FILE_TIMEOUT
+==== `TFTP_FILE_TIMEOUT`
 
 The timeout in milliseconds for an individual file download via TFTP.
 
-Minimum: `5000` +
+Minimum: `5000`
+
 Default: `30000`
 
 [[TFTP_IP]]
-==== TFTP_IP
+==== `TFTP_IP`
 
-Optional dotted decimal ip address (e.g. `192.168.1.99`) for the TFTP server which overrides the server-ip from the DHCP request. +
+Optional dotted decimal ip address (e.g. `192.168.1.99`) for the TFTP server which overrides the server-ip from the DHCP request.
+
 This may be useful on home networks because tftpd-hpa can be used instead of dnsmasq where broadband router is the DHCP server.
 
-Default: ""
+Default: `""`
 
 [[TFTP_PREFIX]]
-==== TFTP_PREFIX
+==== `TFTP_PREFIX`
 
 In order to support unique TFTP boot directories for each Raspberry Pi the bootloader prefixes the filenames with a device specific directory. If neither start4.elf nor start.elf are found in the prefixed directory then the prefix is cleared.
 
@@ -204,22 +216,23 @@ On earlier models the serial number is used as the prefix, however, on Raspberry
 Default: 0
 
 [[TFTP_PREFIX_STR]]
-==== TFTP_PREFIX_STR
+==== `TFTP_PREFIX_STR`
 
 Specify the custom directory prefix string used when `TFTP_PREFIX` is set to 1. For example:- `TFTP_PREFIX_STR=tftp_test/`
 
-Default: "" +
+Default: `""`
+
 Max length: 32 characters
 
 [[PXE_OPTION43]]
-==== PXE_OPTION43
+==== `PXE_OPTION43`
 
 Overrides the PXE Option43 match string with a different string. It's normally better to apply customisations to the DHCP server than change the client behaviour, but this option is provided in case that's not possible.
 
 Default: `Raspberry Pi Boot`
 
 [[DHCP_OPTION97]]
-==== DHCP_OPTION97
+==== `DHCP_OPTION97`
 
 In earlier releases the client GUID (Option97) was just the serial number repeated four times. By default, the new GUID format is the concatenation of the four-character code (FourCC) for `RPi4` (0x34695052 - little endian), the board revision (e.g. 0x00c03111) (4-bytes), the least significant 4 bytes of the mac address and the 4-byte serial number.
 This is intended to be unique but also provides structured information to the DHCP server, allowing Raspberry Pi 4 computers to be identified without relying upon the Ethernet MAC OUID.
@@ -229,14 +242,15 @@ Specify DHCP_OPTION97=0 to revert the old behaviour or a non-zero hex-value to s
 Default: `0x34695052`
 
 [[MAC_ADDRESS]]
-==== MAC_ADDRESS
+==== `MAC_ADDRESS`
 
 Overrides the Raspberry Pi Ethernet MAC address with the given value. e.g. `dc:a6:32:01:36:c2`
 
-Default: ""
+Default: `""`
 
 [[MAC_ADDRESS_OTP]]
-==== MAC_ADDRESS_OTP
+==== `MAC_ADDRESS_OTP`
+
 Overrides the Raspberry Pi Ethernet MAC address with a value stored in the xref:raspberry-pi.adoc#write-and-read-customer-otp-values[Customer OTP] registers.
 
 For example, to use a MAC address stored in rows 0 and 1 of the `Customer OTP`.
@@ -256,49 +270,49 @@ The `Customer OTP` rows are OTP registers 36 to 43 in the `vcgencmd otp_dump` ou
 37:e45f0120
 ----
 
-Default: ""
+Default: `""`
 
 ==== Static IP address configuration
 
 If TFTP_IP and the following options are set then DHCP is skipped and the static IP configuration is applied. If the TFTP server is on the same subnet as the client then GATEWAY may be omitted.
 
 [[CLIENT_IP]]
-===== CLIENT_IP
+===== `CLIENT_IP`
 
 The IP address of the client e.g. `192.168.0.32`
 
-Default: ""
+Default: `""`
 
 [[SUBNET]]
-===== SUBNET
+===== `SUBNET`
 
 The subnet address mask e.g. `255.255.255.0`
 
-Default: ""
+Default: `""`
 
 [[GATEWAY]]
-===== GATEWAY
+===== `GATEWAY`
 
 The gateway address to use if the TFTP server is on a different subnet e.g. `192.168.0.1`
 
-Default: ""
+Default: `""`
 
 [[DISABLE_HDMI]]
-==== DISABLE_HDMI
+==== `DISABLE_HDMI`
 
 The xref:raspberry-pi.adoc#boot-diagnostics-on-the-raspberry-pi-4[HDMI boot diagnostics] display is disabled if `DISABLE_HDMI=1`. Other non-zero values are reserved for future use.
 
 Default: `0`
 
 [[HDMI_DELAY]]
-==== HDMI_DELAY
+==== `HDMI_DELAY`
 
 Skip rendering of the HDMI diagnostics display for up to N seconds (default 5) unless a fatal error occurs. The default behaviour is designed to avoid the bootloader diagnostics screen from briefly appearing during a normal SD/USB boot.
 
 Default: `5`
 
 [[ENABLE_SELF_UPDATE]]
-==== ENABLE_SELF_UPDATE
+==== `ENABLE_SELF_UPDATE`
 
 Enables the bootloader to update itself from a TFTP or USB mass storage device (MSD) boot filesystem.
 
@@ -314,16 +328,16 @@ Notes:
 Default: `1`
 
 [[FREEZE_VERSION]]
-==== FREEZE_VERSION
+==== `FREEZE_VERSION`
 
 Previously this property was only checked by the `rpi-eeprom-update` script. However, now that self-update is enabled the bootloader will also check this property. If set to 1, this overrides `ENABLE_SELF_UPDATE` to stop automatic updates. To disable `FREEZE_VERSION` you will have to use SD card boot with recovery.bin.
 
-*Custom EEPROM update scripts must also check this flag.*
+Custom EEPROM update scripts must also check this flag.
 
 Default: `0`
 
 [[HTTP_HOST]]
-==== HTTP_HOST
+==== `HTTP_HOST`
 
 If network install or HTTP boot is initiated, `boot.img` and `boot.sig` are downloaded from this server.
 
@@ -335,7 +349,7 @@ Don`t include the HTTP scheme or any forward slashes in the hostname.
 Default: `fw-download-alias1.raspberrypi.com`
 
 [[HTTP_PORT]]
-==== HTTP_PORT
+==== `HTTP_PORT`
 
 You can use this property to change the port used for network install and HTTP boot. HTTPS is enabled when using the default host `fw-download-alias1.raspberrypi.com`. If `HTTP_HOST` is changed then HTTPS is disabled and plain HTTP will be used instead.
 
@@ -344,11 +358,11 @@ When HTTPS is disabled, plain HTTP will still be used even if `HTTP_PORT` is cha
 Default: `443` if HTTPS is enabled otherwise `80`
 
 [[HTTP_PATH]]
-==== HTTP_PATH
+==== `HTTP_PATH`
 
 The path used for network install and HTTP boot.
 
-The case of the path *is* significant.
+Case-sensitive.
 Use forward (Linux) slashes for the path separator.
 Leading and trailing forward slashes are not required.
 
@@ -357,7 +371,7 @@ If `HTTP_HOST` is not set, `HTTP_PATH` is ignored and the URL will be `\https://
 Default: `net_install`
 
 [[IMAGER_REPO_URL]]
-==== IMAGER_REPO_URL
+==== `IMAGER_REPO_URL`
 
 The embedded Raspberry Pi Imager application is configured with a json file downloaded at startup.
 
@@ -367,7 +381,7 @@ You can test this with the standard https://www.raspberrypi.com/software/[Raspbe
 Default: `\http://downloads.raspberrypi.org/os_list_imagingutility_v3.json`
 
 [[NET_INSTALL_ENABLED]]
-==== NET_INSTALL_ENABLED
+==== `NET_INSTALL_ENABLED`
 
 When network install is enabled, the bootloader displays the network install screen on boot if it detects a keyboard.
 
@@ -380,7 +394,7 @@ In order to detect the keyboard, network install must initialise the USB control
 Default: `1` on Raspberry Pi 4 and Raspberry Pi 400, and `0` on Compute Module 4.
 
 [[NET_INSTALL_KEYBOARD_WAIT]]
-==== NET_INSTALL_KEYBOARD_WAIT
+==== `NET_INSTALL_KEYBOARD_WAIT`
 
 If network install is enabled, the bootloader attempts to detect a keyboard and the `SHIFT` key to initiate network install. You can change the length of this wait in milliseconds with this property.
 
@@ -391,7 +405,7 @@ NOTE: Testing suggests keyboard and SHIFT detection takes at least 750ms.
 Default: `900`
 
 [[NETCONSOLE]]
-==== NETCONSOLE - advanced logging
+==== `NETCONSOLE` - advanced logging
 
 `NETCONSOLE` duplicates debug messages to the network interface. The IP addresses and ports are defined by the `NETCONSOLE` string.
 
@@ -401,6 +415,7 @@ NOTE: NETCONSOLE blocks until the ethernet link is established or a timeout occu
 
 See https://wiki.archlinux.org/index.php/Netconsole
 
+[source]
 ----
 src_port@src_ip/dev_name,dst_port@dst_ip/dst_mac
 E.g. 6665@169.254.1.1/,6666@/
@@ -414,21 +429,23 @@ In order to simplify parsing, the bootloader requires every field separator to b
 * dst_ip - 255.255.255.255
 * dst_mac - 00:00:00:00:00
 
-One way to view the data is to connect the test Raspberry Pi 4 to another Raspberry Pi running WireShark and select "`udp.srcport == 6665`" as a filter and select `+Analyze -> Follow -> UDP stream+` to view as an ASCII log.
+One way to view the data is to connect the test Raspberry Pi 4 to another Raspberry Pi running WireShark and select "`udp.srcport == 6665`" as a filter and select *Analyze -> Follow -> UDP stream* to view as an ASCII log.
 
-`NETCONSOLE` should not be enabled by default because it may cause network problems. It can be enabled on demand via a GPIO filter e.g.
+`NETCONSOLE` should not be enabled by default because it may cause network problems. It can be enabled on demand via a GPIO filter:
 
+[source]
 ----
 # Enable debug if GPIO 7 is pulled low
 [gpio7=0]
 NETCONSOLE=6665@169.254.1.1/,6666@/
 ----
 
-Default: ""  (not enabled) +
+Default: `""`  (not enabled)
+
 Max length: 32 characters
 
 [[PARTITION]]
-==== PARTITION
+==== `PARTITION`
 
 The `PARTITION` option may be used to specify the boot partition number, if it has not explicitly been set by the `reboot` command (e.g. `sudo reboot N`) or by `boot_partition=N` in `autoboot.txt`.
 This could be used to boot from a rescue partition if the user presses a button.
@@ -441,16 +458,17 @@ PARTITION=2
 Default: 0
 
 [[PSU_MAX_CURRENT]]
-==== PSU_MAX_CURRENT
+==== `PSU_MAX_CURRENT`
+
 Raspberry Pi 5 only.
 
 If set, this property instructions the firmware to skip USB power-delivery negotiation and assume that it is connected to a power supply with the given current rating.
 Typically, this would either be set to `3000` or `5000` i.e. low or high-current capable power supply.
 
-Default: ""
+Default: `""`
 
 [[USB_MSD_EXCLUDE_VID_PID]]
-==== USB_MSD_EXCLUDE_VID_PID
+==== `USB_MSD_EXCLUDE_VID_PID`
 
 A list of up to four VID/PID pairs specifying devices which the bootloader should ignore. If this matches a HUB then the HUB won't be enumerated, causing all downstream devices to be excluded.
 This is intended to allow problematic (e.g. very slow to enumerate) devices to be ignored during boot enumeration. This is specific to the bootloader and is not passed to the OS.
@@ -458,44 +476,51 @@ This is intended to allow problematic (e.g. very slow to enumerate) devices to b
 The format is a comma-separated list of hexadecimal values with the VID as most significant nibble. Spaces are not allowed.
 E.g. `034700a0,a4231234`
 
-Default: ""
+Default: `""`
 
 [[USB_MSD_DISCOVER_TIMEOUT]]
-==== USB_MSD_DISCOVER_TIMEOUT
+==== `USB_MSD_DISCOVER_TIMEOUT`
 
 If no USB mass storage devices are found within this timeout then USB-MSD is stopped and the next boot-mode is selected.
 
-Minimum: `5000` (5 seconds) +
-Default: `20000` (20 seconds) +
+Minimum: `5000` (5 seconds)
+
+Default: `20000` (20 seconds)
 
 [[USB_MSD_LUN_TIMEOUT]]
-==== USB_MSD_LUN_TIMEOUT
+==== `USB_MSD_LUN_TIMEOUT`
 
 How long to wait in milliseconds before advancing to the next LUN e.g. a multi-slot SD-CARD reader. This is still being tweaked but may help speed up boot if old/slow devices are connected as well as a fast USB-MSD device containing the OS.
 
-Minimum: `100` +
+Minimum: `100`
+
 Default: `2000` (2 seconds)
 
 [[USB_MSD_PWR_OFF_TIME]]
-==== USB_MSD_PWR_OFF_TIME
+==== `USB_MSD_PWR_OFF_TIME`
 
 During USB mass storage boot, power to the USB ports is switched off for a short time to ensure the correct operation of USB mass storage devices. Most devices work correctly using the default setting: change this only if you have problems booting from a particular device. Setting `USB_MSD_PWR_OFF_TIME=0` will prevent power to the USB ports being switched off during USB mass storage boot.
 
-Minimum: `250` +
-Maximum: `5000` +
+Minimum: `250`
+
+Maximum: `5000`
+
 Default: `1000` (1 second)
 
 [[USB_MSD_STARTUP_DELAY]]
-==== USB_MSD_STARTUP_DELAY
+==== `USB_MSD_STARTUP_DELAY`
 
 If defined, delays USB enumeration for the given timeout after the USB host controller has initialised. If a USB hard disk drive takes a long time to initialise and triggers USB timeouts then this delay can be used to give the driver additional time to initialise. It may also be necessary to increase the overall USB timeout (`USB_MSD_DISCOVER_TIMEOUT`).
 
-Minimum: `0` +
-Maximum: `30000` (30 seconds) +
+Minimum: `0`
+
+Maximum: `30000` (30 seconds)
+
 Default: `0`
 
 [[VL805]]
-==== VL805
+==== `VL805`
+
 Compute Module 4 only.
 
 If the `VL805` property is set to `1` then the bootloader will search for a VL805 PCIe XHCI controller and attempt to initialise it with VL805 firmware embedded in the bootloader EEPROM. This enables industrial designs to use VL805 XHCI controllers without providing a dedicated SPI EEPROM for the VL805 firmware.
@@ -507,7 +532,7 @@ If the `VL805` property is set to `1` then the bootloader will search for a VL80
 Default: `0`
 
 [[XHCI_DEBUG]]
-==== XHCI_DEBUG
+==== `XHCI_DEBUG`
 
 This property is a bit-field which controls the verbosity of USB debug messages for mass storage boot-mode. Enabling all of these messages generates a huge amount of log data which will slow down booting and may even cause boot to fail. For verbose logs it's best to use `NETCONSOLE`.
 
@@ -546,7 +571,7 @@ XHCI_DEBUG=0x3
 Default: `0x0` (no USB debug messages enabled)
 
 [[config_txt]]
-==== config.txt section
+==== `[config.txt]` section
 
 After reading `config.txt` the GPU firmware `start4.elf` reads the bootloader EEPROM config and checks for a section called `[config.txt]`. If the `[config.txt]` section exists then the contents from the start of this section to the end of the file is appended in memory, to the contents of the `config.txt` file read from the boot partition.  This can be used to automatically apply settings to every operating system, for example, dtoverlays.
 
@@ -557,7 +582,8 @@ WARNING: If an invalid configuration which causes boot to fail is specified, the
 Raspberry Pi 5 requires a `config.txt` file to be present to indicate that the partition is bootable. 
 
 [[boot_ramdisk]]
-==== boot_ramdisk
+==== `boot_ramdisk`
+
 If this property is set to `1` then the bootloader will attempt load a ramdisk file called `boot.img` containing the xref:configuration.adoc#the-boot-folder[boot filesystem]. Subsequent files (e.g. `start4.elf`) are read from the ramdisk instead of the original boot file system.
 
 The primary purpose of `boot_ramdisk` is to support `secure-boot`, however, unsigned `boot.img` files can also be useful to Network Boot or `RPIBOOT` configurations.
@@ -573,7 +599,7 @@ For more information about `secure-boot` and creating `boot.img` files please se
 Default: `0`
 
 [[boot_load_flags]]
-==== boot_load_flags
+==== `boot_load_flags`
 
 Experimental property for custom firmware (bare metal).
 
@@ -584,7 +610,7 @@ Not relevant on Raspberry Pi 5 because there is no `start.elf` file.
 Default: `0x0`
 
 [[uart_2ndstage]]
-==== uart_2ndstage
+==== `uart_2ndstage`
 
 If `uart_2ndstage` is `1` then enable debug logging to the UART. This option also automatically enables UART logging in `start.elf`. This is also described on the xref:config_txt.adoc#boot-options[Boot options] page.
 
@@ -593,14 +619,14 @@ The `BOOT_UART` property also enables bootloader UART logging but does not enabl
 Default: `0`
 
 [[erase_eeprom]]
-==== erase_eeprom
+==== `erase_eeprom`
 
 If `erase_eeprom` is set to `1` then `recovery.bin` will erase the entire SPI EEPROM instead of flashing the bootloader image. This property has no effect during a normal boot.
 
 Default: `0`
 
 [[eeprom_write_protect]]
-==== eeprom_write_protect
+==== `eeprom_write_protect`
 
 Configures the EEPROM `write status register`. This can be set either to mark the entire EEPROM as write-protected, or to clear write-protection.
 
@@ -630,14 +656,14 @@ On Raspberry Pi 5 `/WP` is pulled low by default and consequently write-protect 
 Default: `-1`
 
 [[os_check]]
-==== os_check
+==== `os_check`
 On Raspberry Pi 5 the firmware automatically checks for a compatible Device Tree file before attempting to boot from the current partition. Otherwise, older non-compatible kernels would be loaded and then hang.
 To disable this check (e.g. for bare-metal development), set `os_check=0` in config.txt
 
 Default: `1`
 
 [[bootloader_update]]
-==== bootloader_update
+==== `bootloader_update`
 
 This option may be set to 0 to block self-update without requiring the EEPROM configuration to be updated. This is sometimes useful when updating multiple Raspberry Pis via network boot because this option can be controlled per Raspberry Pi (e.g. via a serial number filter in `config.txt`).
 
@@ -656,19 +682,22 @@ For more information about enabling `secure-boot` please see the https://github.
 
 
 [[program_pubkey]]
-==== program_pubkey
+==== `program_pubkey`
+
 If this property is set to `1` then `recovery.bin` will write the hash of the public key in the EEPROM image to OTP.  Once set, the bootloader will reject EEPROM images signed with different RSA keys or unsigned images.
 
 Default: `0`
 
 [[revoke_devkey]]
-==== revoke_devkey
+==== `revoke_devkey`
+
 If this property is set to `1` then `recovery.bin` will write a value to OTP that prevents the ROM from loading old versions of the second stage bootloader which do not support `secure-boot`. This prevents `secure-boot` from being turned off by reverting to an older release of the bootloader.
 
 Default: `0`
 
 [[program_rpiboot_gpio]]
-==== program_rpiboot_gpio
+==== `program_rpiboot_gpio`
+
 Since there is no dedicated `nRPIBOOT` jumper on Raspberry Pi 4B or Raspberry Pi 400, an alternative GPIO must be used to select `RPIBOOT` mode by pulling the GPIO low. Only one GPIO may be selected and the available options are `2, 4, 5, 7, 8`. This property does not depend on `secure-boot`, but verify that this GPIO configuration does not conflict with any HATs which might pull the GPIO low during boot.
 
 Since for safety this property can only be programmed via `RPIBOOT`, the bootloader EEPROM must first be cleared using `erase_eeprom`. This causes the BCM2711 ROM to failover to `RPIBOOT` mode, which then allows this option to be set.
@@ -676,7 +705,8 @@ Since for safety this property can only be programmed via `RPIBOOT`, the bootloa
 Default: ``
 
 [[program_jtag_lock]]
-==== program_jtag_lock
+==== `program_jtag_lock`
+
 If this property is set to `1` then `recovery.bin` will program an OTP value that prevents VideoCore JTAG from being used. This option requires that `program_pubkey` and `revoke_devkey` are also set. This option can prevent failure analysis, and should only be set after the device has been fully tested.
 
 Default: `0`


### PR DESCRIPTION
* Finishing up some CE loose ends from last week's mental-backlog-burning CE-athon.
* Rename `bcm2711-bootloader` to `eeprom-bootloader` since it applies to both Pi 4 and Pi 5 (and presumably will apply to hypothetical future models as well). EEPROM seems to be the unifying concept, so that's what I've used for the name for now. But I am open to other ideas if anyone objects to the new name.