### PR TITLE
Rename Pico Probe -> Debug Probe

### DIFF
--- a/documentation/asciidoc/microcontrollers/debug-probe/getting-started.adoc
+++ b/documentation/asciidoc/microcontrollers/debug-probe/getting-started.adoc
@@ -6,15 +6,15 @@ Depending on your setup, there are several ways to wire the Debug Probe to a xre
 
 video::4RCZBZsfsek[youtube]
 
-Here we have connected:
+Connect the following:
 
-* The Debug Probe "D" connector to Pico H SWD JST-SH connector
-* The Debug Probe "U" connector has the three-pin JST-SH connector to 0.1-inch header (male)
-** Debug Probe RX connected to Pico H TX pin
-** Debug Probe TX connected to Pico H RX pin
-** Debug Probe GND connected to Pico H GND pin
+* The Debug Probe "D" port to Pico H SWD JST-SH connector
+* The Debug Probe "U" port, with the three-pin JST-SH connector to 0.1-inch header (male):
+** Debug Probe `RX` connected to Pico H `TX` pin
+** Debug Probe `TX` connected to Pico H `RX` pin
+** Debug Probe `GND` connected to Pico H `GND` pin
 
-NOTE: If you have an "original" Raspberry Pi Pico or Pico W (without a JST-SH connector) you can still connect it to a Debug Probe. To do so, solder a male connector to the SWCLK, SWDIO and GND header pins on the board, and connect them to the Debug Probe "D" connector using the alternate 3-pin JST-SH connector to 0.1-inch header (female) cable included with the Debug Probe.
+NOTE: If you have an "original" Raspberry Pi Pico or Pico W (without a JST-SH connector) you can still connect it to a Debug Probe. To do so, solder a male connector to the `SWCLK`, `SWDIO` and `GND` header pins on the board, and connect them to the Debug Probe "D" port using the alternate 3-pin JST-SH connector to 0.1-inch header (female) cable included with the Debug Probe.
 
 image:images/wiring.png[width="70%"]
 

--- a/documentation/asciidoc/microcontrollers/debug-probe/getting-started.adoc
+++ b/documentation/asciidoc/microcontrollers/debug-probe/getting-started.adoc
@@ -14,7 +14,7 @@ Connect the following:
 ** Debug Probe `TX` connected to Pico H `RX` pin
 ** Debug Probe `GND` connected to Pico H `GND` pin
 
-NOTE: If you have an "original" Raspberry Pi Pico or Pico W (without a JST-SH connector) you can still connect it to a Debug Probe. To do so, solder a male connector to the `SWCLK`, `SWDIO` and `GND` header pins on the board, and connect them to the Debug Probe "D" port using the alternate 3-pin JST-SH connector to 0.1-inch header (female) cable included with the Debug Probe.
+NOTE: If you have a non-H Pico or Pico W (without a JST-SH connector) you can still connect it to a Debug Probe. Solder a male connector to the `SWCLK`, `GND`, and `SWDIO` header pins on the board. Using the alternate 3-pin JST-SH connector to 0.1-inch header (female) cable included with the Debug Probe, connect to the Debug Probe "D" port. Connect `SWCLK`, `GND`, and `SWDIO` on the Pico or Pico W to the `SC`, `GND`, and `SD` pins on the Debug Probe, respectively.
 
 image:images/wiring.png[width="70%"]
 

--- a/documentation/asciidoc/microcontrollers/debug-probe/installing-tools.adoc
+++ b/documentation/asciidoc/microcontrollers/debug-probe/installing-tools.adoc
@@ -1,137 +1,63 @@
-== Installing Tools
+== Install tools
 
-Before we get started we need to install some tools.
+To use the Debug Probe, install the following tools.
 
-=== Installing OpenOCD
+=== Install OpenOCD
 
 You need to install OpenOCD.
 
-NOTE: SMP support for debugging on both RP2040 cores is not yet available in the release version of `openocd`. However, support is available in the `rp2040-v0.12.0` branch and will be enabled if you build from source.
+To install OpenOCD, run the following command in a terminal:
 
-==== Linux (and Raspberry Pi)
-
-On Raspberry Pi OS you can install `openocd` directly from the command line.
-
+[source,console]
 ----
 $ sudo apt install openocd
 ----
 
-You need to be running OpenOCD version 0.11.0 or 0.12.0 to have support for the Debug Probe. If you're not running Raspberry Pi OS, or your distribution installs an older version, or require SMP support, you can build and install `openocd` from source.
+To run OpenOCD, use the `openocd` command in your terminal.
 
-Start by installing needed dependencies, 
+==== Install OpenOCD on macOS
 
-----
-$ sudo apt install automake autoconf build-essential texinfo libtool libftdi-dev libusb-1.0-0-dev pkg-config
-----
+First, install the https://brew.sh/[Homebrew] package manager:
 
-and then build OpenOCD.
-
-----
-$ git clone https://github.com/raspberrypi/openocd.git --branch rp2040-v0.12.0 --depth=1 --no-single-branch
-$ cd openocd
-$ ./bootstrap
-$ ./configure 
-$ make -j4
-$ sudo make install
-----
-
-NOTE: If you are building on a Raspberry Pi you can also pass `--enable-sysfsgpio --enable-bcm2835gpio` when you `./configure` to allow bit-banging SWD via the GPIO pins. See Chapters 5 and 6 of https://datasheets.raspberrypi.com/pico/getting-started-with-pico.pdf[Getting Started with Raspberry Pi Pico] for more details.
-
-==== macOS
-
-Install https://brew.sh/[Homebrew] if needed,
-
+[source,console]
 ----
 $ /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)"
 ----
 
-install needed dependencies,
+To install OpenOCD on macOS, run the following commands:
 
+[source,console]
 ----
-$ brew install libtool automake libusb wget pkg-config gcc texinfo 
-----
-
-and then build OpenOCD from source.
-
-----
-$ cd ~/pico
-$ git clone https://github.com/raspberrypi/openocd.git --branch rp2040-v0.12.0 --depth=1
-$ cd openocd
-$ export PATH="/usr/local/opt/texinfo/bin:$PATH"
-$ ./bootstrap
-$ ./configure --disable-werror
-$ make -j4
-$ sudo make install
+$ brew install openocd
 ----
 
-NOTE: If you are using a newer Arm-based Mac, the path to `texinfo` will be `/opt/homebrew/opt/texinfo/bin`.
+To run OpenOCD, use the `openocd` command in your terminal.
 
-NOTE: Unfortunately `disable-werror` is needed because not everything compiles cleanly on macOS
-
-==== MS Windows
-
-A standalone OpenOCD Windows package is available https://github.com/raspberrypi/pico-setup-windows/releases/latest/download/openocd-x64-standalone.zip[for download]. Alternatively it will be installed as part of our https://github.com/raspberrypi/pico-setup-windows/releases/latest[Pico setup for Windows installer] package.
-
-But, if you want to, you can also build OpenOCD from source using https://www.msys2.org/[MSYS2]. Go ahead and download and run the MSYS2 installer, and then update the package database and core system packages,
-
-----
-$ pacman -Syu
-----
-
-NOTE: If MSYS2 closes, start it again (making sure you select the 64-bit version) and run `pacman -Su` to finish the update.
-
-Install required dependencies,
-
-----
-$ pacman -S mingw-w64-x86_64-toolchain git make libtool pkg-config autoconf automake texinfo
-mingw-w64-x86_64-libusb
-----
-
-Pick all when installing the `mingw-w64-x86_64` toolchain by pressing ENTER.
-
-Close MSYS2 and reopen the 64-bit version to make sure the environment picks up GCC,
-
-----
-$ git clone https://github.com/raspberrypi/openocd.git --branch rp2040-v0.12.0 --depth=1
-$ cd openocd
-$ ./bootstrap
-$ ./configure --disable-werror 
-$ make -j4
-----
-
-NOTE: Unfortunately `disable-werror` is needed because not everything compiles cleanly on Windows
-
-NOTE: Manual installation of `openocd` on MS Windows is not recommended.
-
-=== Installing GDB
+=== Install GDB
 
 We also need to install the GNU debugger (GDB).
 
-==== Linux (and Raspberry Pi)
+==== Linux
 
-Install `gdb-multiarch`.
+Install `gdb-multiarch`:
 
+[source,console]
 ----
 $ sudo apt install gdb-multiarch
 ----
 
 ==== macOS
 
-Install https://brew.sh/[Homebrew] if needed,
+Run the following command to install `gdb`:
 
-----
-$ /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)"
-----
-
-then install `gdb`.
-
+[source,console]
 ----
 $ brew install gdb
 ----
 
-NOTE: You can safely ignore the request for "special privileges" messages on installation.
+You can safely ignore the request for "special privileges" messages on installation.
 
-IMPORTANT: If you have an Arm-based (M1-based) Mac `gdb` is not available via Homebrew, instead you will either have to https://gist.github.com/m0sys/711d0ec5e52102c6ba44451caf38bd38[install it from source] or use `lldb` instead of `gdb`. At this time there is https://inbox.sourceware.org/gdb/3185c3b8-8a91-4beb-a5d5-9db6afb93713@Spark/[no official support] from the developers for running GDB on Arm-based Macs. Support for GDB can be found on the https://inbox.sourceware.org/gdb/[GDB mailing list] on Sourceware.org. `lldb` is installed as part of the Xcode Command Line Tools.
+IMPORTANT: GDB does not support `gdb` Arm-based Macs. Instead, either https://gist.github.com/m0sys/711d0ec5e52102c6ba44451caf38bd38[install `gdb` from source] or use `lldb` instead of `gdb`. There is https://inbox.sourceware.org/gdb/3185c3b8-8a91-4beb-a5d5-9db6afb93713@Spark/[no official support] from the developers for running GDB on Arm-based Macs. Support for GDB can be found on the https://inbox.sourceware.org/gdb/[GDB mailing list] on Sourceware.org. `lldb` is installed as part of the Xcode Command Line Tools.
 
 ==== MS Windows
 

--- a/documentation/asciidoc/microcontrollers/debug-probe/introduction.adoc
+++ b/documentation/asciidoc/microcontrollers/debug-probe/introduction.adoc
@@ -12,7 +12,7 @@ The Raspberry Pi Debug Probe is a USB device that provides both a UART serial po
 
 NOTE: For more information on the Raspberry Pi three-pin debug connector see the https://rptl.io/debug-spec[specification].
 
-This makes it easy to use a Raspberry Pi Pico on non-Raspberry Pi platforms such as Windows, Mac, and “normal” Linux computers, where you don’t have a GPIO header to connect directly to the Pico's serial UART or SWD port.
+This makes it easy to use a Raspberry Pi Pico on platforms such as Windows, macOS, and Linux that lack a GPIO header to connect directly to the Pico's serial UART or SWD port.
 
 === The Debug Probe
 
@@ -38,4 +38,4 @@ The Debug Probe has five LEDs, a red LED to indicate power, and four more activi
 
 image::images/debug-leds.png[width="70%"]
 
-NOTE: OpenOCD just switches both DAP LEDs on when the target is connected, and turns them off when it calls `DAP_DISCONNECT`.
+NOTE: OpenOCD switches both DAP LEDs on when the target is connected, and turns them off when it calls `DAP_DISCONNECT`.

--- a/documentation/asciidoc/microcontrollers/debug-probe/swd-connection.adoc
+++ b/documentation/asciidoc/microcontrollers/debug-probe/swd-connection.adoc
@@ -8,8 +8,9 @@ The Pico Debug Probe will let you load binaries via the SWD port and OpenOCD: yo
 
 Once you have built a binary: 
 
+[source,console]
 ----
-$  sudo openocd -f interface/cmsis-dap.cfg -f target/rp2040.cfg -c "adapter speed 5000" -c "program blink.elf verify reset exit"
+$ sudo openocd -f interface/cmsis-dap.cfg -f target/rp2040.cfg -c "adapter speed 5000" -c "program blink.elf verify reset exit"
 ----
 
 NOTE: When you use the Debug Probe to upload a binary the ELF version of the file is used, not the UF2 file that you would use when you drag-and-drop.
@@ -38,14 +39,16 @@ In a debug build you will get more information when you run it under the debugge
 See Chapter 6 of https://datasheets.raspberrypi.com/pico/getting-started-with-pico.pdf[Getting started with Raspberry Pi Pico] for more information.
 ======
 
-Run OpenOCD 'server' ready to attach GDB to:
+To start an OpenOCD server, run the following command:
 
+[source,console]
 ----
 $ sudo openocd -f interface/cmsis-dap.cfg -f target/rp2040.cfg -c "adapter speed 5000"
 ----
 
-Then open a second terminal window, switch to the directory containing your built binary, and start GDB.
+Then open a second terminal window, switch to the directory containing your built binary, and start a debugger to attach it to the OpenOCD server:
 
+[source,console]
 ----
 $ gdb blink.elf
 > target remote localhost:3333
@@ -53,16 +56,7 @@ $ gdb blink.elf
 > continue
 ----
 
-NOTE: On non-Raspberry Pi Linux platforms you should invoke GDB by using `gdb-multiarch blink.elf`.
+GDB doesn't work on all platforms. Use one of the following alternatives instead of `gdb`, depending on your operating system and device:
 
-[NOTE]
-======
-If you are on an Arm-based (M1) Mac without `gdb`, you can make use of `lldb`, which is installed along with the XCode Command Line Tools. The syntax used by `lldb` is https://lldb.llvm.org/use/map.html[slightly different] to `gdb`.
-
-----
-$ lldb blink.elf
-(lldb) gdb-remote 3333
-(lldb) process plugin packet monitor reset
-(lldb) continue
-----
-======
+* On Linux devices that are _not_ Raspberry Pis, use `gdb-multiarch`.
+* On Arm-based macOS devices, use `lldb`.

--- a/documentation/asciidoc/microcontrollers/debug-probe/updating-firmware.adoc
+++ b/documentation/asciidoc/microcontrollers/debug-probe/updating-firmware.adoc
@@ -1,8 +1,8 @@
 == Updating the firmware on the Debug Probe
 
-NOTE: The current version of the Debug Probe firmware is version 1.0.3. If you're running an older version, or if you have accidentally overwritten the firmware on your Debug Probe, the https://github.com/raspberrypi/picoprobe/releases/latest/download/debugprobe.uf2[latest release of the firmware] can be found https://github.com/raspberrypi/picoprobe/releases/latest[on Github].
+NOTE: The current version of the Debug Probe firmware is version 1.0.3. If you're running an older version, or if you have accidentally overwritten the firmware on your Debug Probe, the latest release of the firmware can be found on https://github.com/raspberrypi/debugprobe/releases/latest[GitHub].
 
-From time to time you may need to update the Debug Probe firmware. New firmware for the debug probe will be made available as a UF2 file distributed by Raspberry Pi.
+From time to time you may need to update the Debug Probe firmware. New firmware for the probe will be made available as a UF2 file distributed by Raspberry Pi.
 
 Pinch to remove the top of the Debug Probe enclosure, then push and hold the BOOTSEL button as you plug the Debug Probe into your computer. This will mount an RPI-RP2 volume on your desktop. Drag-and-drop the firmware UF2 onto the RPI-RP2 volume. The firmware will be copied to the Debug Probe and the volume will dismount.
 

--- a/documentation/asciidoc/microcontrollers/raspberry-pi-pico/utilities.adoc
+++ b/documentation/asciidoc/microcontrollers/raspberry-pi-pico/utilities.adoc
@@ -8,10 +8,10 @@ If you have forgotten what has been programmed into your Raspberry Pi Pico, and 
 
 === Debugging using another Raspberry Pi Pico
 
-It is possible to use one Raspberry Pi Pico to debug another Pico. This is possible via picoprobe, an application that allows a Pico to act as a USB → SWD and UART converter. This makes it easy to use a Pico on non-Raspberry Pi platforms such as Windows, Mac, and Linux computers where you don’t have GPIOs to connect directly to your Pico. Full instructions on how to use Picoprobe to do this are available in our 'https://datasheets.raspberrypi.com/pico/getting-started-with-pico.pdf[getting started]' documentation.
+It is possible to use one Raspberry Pi Pico to debug another Pico. This is possible via debugprobe, an application that allows a Pico to act as a USB → SWD and UART converter. This makes it easy to use a Pico on non-Raspberry Pi platforms such as Windows, Mac, and Linux computers where you don’t have GPIOs to connect directly to your Pico. Full instructions on how to use debugprobe to do this are available in our 'https://datasheets.raspberrypi.com/pico/getting-started-with-pico.pdf[getting started]' documentation.
 
-* Download the https://github.com/raspberrypi/picoprobe/releases/latest/download/picoprobe.uf2[UF2 file]
-* Go to the https://github.com/raspberrypi/picoprobe[Picoprobe Github repository]
+* Download the https://github.com/raspberrypi/debugprobe/releases/latest/download/debugprobe.uf2[UF2 file]
+* Go to the https://github.com/raspberrypi/debugprobe[Debug Probe Github repository]
 
 === Resetting Flash memory
 

--- a/documentation/asciidoc/microcontrollers/raspberry-pi-pico/utilities.adoc
+++ b/documentation/asciidoc/microcontrollers/raspberry-pi-pico/utilities.adoc
@@ -10,7 +10,7 @@ If you have forgotten what has been programmed into your Raspberry Pi Pico, and 
 
 It is possible to use one Raspberry Pi Pico to debug another Pico. This is possible via debugprobe, an application that allows a Pico to act as a USB → SWD and UART converter. This makes it easy to use a Pico on non-Raspberry Pi platforms such as Windows, Mac, and Linux computers where you don’t have GPIOs to connect directly to your Pico. Full instructions on how to use debugprobe to do this are available in our 'https://datasheets.raspberrypi.com/pico/getting-started-with-pico.pdf[getting started]' documentation.
 
-* Download the https://github.com/raspberrypi/debugprobe/releases/latest/download/debugprobe.uf2[UF2 file]
+* Download the https://github.com/raspberrypi/debugprobe/releases/latest/download/debugprobe_on_pico.uf2[UF2 file]
 * Go to the https://github.com/raspberrypi/debugprobe[Debug Probe Github repository]
 
 === Resetting Flash memory


### PR DESCRIPTION
* Closes https://github.com/raspberrypi/openocd/issues/94

Documentation rename in tandem with https://github.com/raspberrypi/picoprobe/tree/debugprobe_rename

Turns out the only docs mentions are this and the Getting Started guide section. I'm working on that fix in parallel.

TODO fixes elsewhere:

* Change the "Picoprobe" link on the [product page](https://www.raspberrypi.com/products/debug-probe/) to "debugprobe" (with an updated link pointing to https://github.com/raspberrypi/debugprobe).

* Update the product brief (https://datasheets.raspberrypi.com/debug/raspberry-pi-debug-probe-product-brief.pdf), which contains just one mention of Picoprobe and one adjacent link to the repo. (`The Debug Probe is based on Raspberry Pi Pico hardware and runs the open source Raspberry Pi Picoprobe software (https://github.com/raspberrypi/picoprobe)` -> `The Debug Probe is based on Raspberry Pi Pico hardware and runs the open source Raspberry Pi debugprobe software (https://github.com/raspberrypi/debugprobe)`)

* Update the [Raspberry Pi 3-pin Debug Connector Specification](https://datasheets.raspberrypi.com/debug/debug-connector-specification.pdf), which contains one "Picoprobe" term, but no link. (`the debug dongle, e.g., RP2040 running Picoprobe` -> `the debug dongle, e.g., RP2040 running debugprobe`)



There's also a whole lot of forum posts. Nothing we can do about that.