### PR TITLE
Added warning about correct storage device when saying safe to write

### DIFF
--- a/documentation/asciidoc/computers/getting-started/install.adoc
+++ b/documentation/asciidoc/computers/getting-started/install.adoc
@@ -106,7 +106,7 @@ Finally, respond **Yes** to the "Are you sure you want to continue?" popup to be
 
 image::images/imager/are-you-sure.png[alt="Confirming a reimage of a storage device in Imager."]
 
-If you see an admin prompt asking for permissions to read and write to your storage medium, it's safe to proceed (provided that you have definitely selected the correct storage device earlier).
+If you see an admin prompt asking for permissions to read and write to your storage medium, grant Imager the permissions to proceed.
 
 .Grab a cup of coffee or go for a walk. This could take a few minutes.
 image::images/imager/writing.png[alt="Writing an image to a device in Imager."]

--- a/documentation/asciidoc/computers/getting-started/install.adoc
+++ b/documentation/asciidoc/computers/getting-started/install.adoc
@@ -106,7 +106,7 @@ Finally, respond **Yes** to the "Are you sure you want to continue?" popup to be
 
 image::images/imager/are-you-sure.png[alt="Confirming a reimage of a storage device in Imager."]
 
-If you see an admin prompt asking for permissions to read and write to your storage medium, it's safe to proceed.
+If you see an admin prompt asking for permissions to read and write to your storage medium, it's safe to proceed (provided that you have definitely selected the correct storage device earlier).
 
 .Grab a cup of coffee or go for a walk. This could take a few minutes.
 image::images/imager/writing.png[alt="Writing an image to a device in Imager."]


### PR DESCRIPTION
The documentation tells people it is safe to proceed when they are using admin credentials to write to the target storage device. This is true, but only if they have followed the previous warning/instructions to be sure they have the correct storage device selected, and not ignored the on-screen warning. Since the result of proceeding having ignored these warnings is so disasterous (destruction of data), when explicitly saying something is safe, it should be clear what the caveats to that are, as people often skip earlier sections.