### PR TITLE
Add links to tutorials using the tutorial template

### DIFF
--- a/documentation/asciidoc/computers/configuration/host-wireless-network.adoc
+++ b/documentation/asciidoc/computers/configuration/host-wireless-network.adoc
@@ -1,6 +1,6 @@
 == Host a wireless network on your Raspberry Pi
 
-Your Raspberry Pi can host its own wireless network using a wireless module. If you connect your Raspberry Pi to the internet via the Ethernet port (or a second wireless module), other devices connected to the wireless network can access the internet through your Raspberry Pi.
+Your Raspberry Pi can host its own wireless network using a wireless module. If you connect your Raspberry Pi to the internet via the Ethernet port or a second wireless module, other devices connected to the wireless network can access the internet through the built-in wireless module of your Raspberry Pi.
 
 Consider a wired network that uses the `10.x.x.x` IP block. You can connect your Raspberry Pi to that network and serve wireless clients on a separate network that uses another IP block, such as `192.168.x.x`.
 
@@ -10,6 +10,11 @@ image::images/host-a-network.png[]
 
 
 With this network configuration, wireless clients can all communicate with each other through the Raspberry Pi router. However, clients on the wireless network cannot directly interact with clients on the wired network other than the Raspberry Pi; wireless clients exist in a private network separate from the network that serves wired clients.
+
+[.tutoriallink, link=https://www.raspberrypi.com/tutorials/host-a-hotel-wifi-hotspot/]
+==== Hotel Wi-Fi Hotspot Tutorial
+
+For step-by-step instructions on how to host a wireless network from your Raspberry Pi, check out our hotel Wi-Fi hotspot tutorial.
 
 NOTE: The Raspberry Pi 5, 4, 3, and Raspberry Pi Zero W can host a wireless network using the built-in wireless module. Raspberry Pi models that lack a built-in module support this functionality using a separate wireless dongle.
 

--- a/documentation/asciidoc/computers/remote-access/nfs.adoc
+++ b/documentation/asciidoc/computers/remote-access/nfs.adoc
@@ -6,10 +6,12 @@ For smaller networks, an NFS is perfect for creating a simple NAS (Network-attac
 
 An NFS is perhaps best suited to more permanent network-mounted directories, such as `/home` directories or regularly-accessed shared resources. If you want a network share that guest users can easily connect to, Samba is better suited to the task. This is because tools to temporarily mount and detach from Samba shares are more readily available across old and proprietary operating systems.
 
-Before deploying an NFS, you should be familiar with:
+[.tutoriallink, link=https://www.raspberrypi.com/tutorials/nas-box-raspberry-pi-tutorial/]
+==== Raspberry Pi NAS Tutorial
 
-* Linux file and directory permissions
-* mounting and unmounting filesystems
+For step-by-step instructions on how to host network-attached storage from your Raspberry Pi, check out our NAS tutorial.
+
+CAUTION: Deploying an NFS requires familiarity with Linux file and directory permissions and mounting filesystems.
 
 === Setting up a Basic NFS Server
 

--- a/documentation/asciidoc/computers/remote-access/nfs.adoc
+++ b/documentation/asciidoc/computers/remote-access/nfs.adoc
@@ -11,7 +11,7 @@ An NFS is perhaps best suited to more permanent network-mounted directories, suc
 
 For step-by-step instructions on how to host network-attached storage from your Raspberry Pi, check out our NAS tutorial.
 
-CAUTION: Deploying an NFS requires familiarity with Linux file and directory permissions and mounting filesystems.
+CAUTION: Deploying an NFS requires familiarity with Linux file permissions and mounting filesystems.
 
 === Setting up a Basic NFS Server
 


### PR DESCRIPTION
* Closes https://github.com/raspberrypi/documentation/issues/3083
* Using https://github.com/raspberrypi/documentation/pull/3082
* Unfortunately the template has a minor issue right now: content following the template, including headers and body text, "bleeds" into the right side of the template display. After some experimentation with page breaks, horizontal breaks, forced whitespace, and forced line breaks, I discovered that admonitions won't "bleed" -- so I've placed the tutorial links directly before admonitions in this PR. I held off on linking to the camera tutorial since I couldn't find a good admonition to precede in the flow of that section; hopefully we can address the issue before merging.

Screenshots because it's hard to use your imagination:

<img width="716" alt="Screenshot 2024-02-15 at 09 08 00" src="https://github.com/raspberrypi/documentation/assets/10657588/e3528777-0ff6-4a43-af37-ad91902470aa">
<img width="724" alt="Screenshot 2024-02-15 at 09 08 11" src="https://github.com/raspberrypi/documentation/assets/10657588/e56fc298-5854-48bb-badd-48cc4c71b304">
