### PR TITLE
Add documentation on HDMI audio disable

### DIFF
--- a/documentation/asciidoc/computers/config_txt/audio.adoc
+++ b/documentation/asciidoc/computers/config_txt/audio.adoc
@@ -21,3 +21,13 @@ Audio dither (see disable_audio_dither above) is normally disabled when the audi
 === `pwm_sample_bits`
 
 The `pwm_sample_bits` command adjusts the bit depth of the analogue audio output. The default bit depth is `11`. Selecting bit depths below `8` will result in nonfunctional audio, as settings below `8` result in a PLL frequency too low to support. This is generally only useful as a demonstration of how bit depth affects quantisation noise.
+
+== HDMI audio
+
+By default, HDMI audio output is enabled on all Raspberry Pi models with HDMI output. 
+
+To disable HDMI audio output, append `,noaudio` to the end of the `dtoverlay=vc4-kms-v3d` line in xref:../computers/config_txt.adoc#what-is-config-txt[`/boot/firmware/config.txt`]:
+
+----
+dtoverlay=vc4-kms-v3d,noaudio
+----

--- a/documentation/asciidoc/computers/config_txt/audio.adoc
+++ b/documentation/asciidoc/computers/config_txt/audio.adoc
@@ -31,3 +31,4 @@ To disable HDMI audio output, append `,noaudio` to the end of the `dtoverlay=vc4
 ----
 dtoverlay=vc4-kms-v3d,noaudio
 ----
+

--- a/documentation/asciidoc/computers/config_txt/video.adoc
+++ b/documentation/asciidoc/computers/config_txt/video.adoc
@@ -6,17 +6,17 @@ In order to support dual 4k displays, the Raspberry Pi 4 has updated video hardw
 
 The HDMI settings used to be configured by firmware via settings in `config.txt`; now the settings are configured by KMS via xref:configuration.adoc#hdmi-configuration[settings] in `cmdline.txt`.
 
-==== HDMI Pipeline for Raspberry Pi 4
+==== HDMI Pipeline for Raspberry Pi 4 and 5
 
-In order to support dual displays, and modes up to 4k60, the Raspberry Pi 4 has updated the HDMI composition pipeline hardware in a number of ways. One of the major changes is that it generates 2 output pixels for every clock cycle.
+In order to support dual displays and modes up to 4k60, the Raspberry Pi 4 and 5 generate 2 output pixels for every clock cycle.
 
 Every HDMI mode has a list of timings that control all the parameters around sync pulse durations. These are typically defined via a pixel clock, and then a number of active pixels, a front porch, sync pulse, and back porch for each of the horizontal and vertical directions.
 
-Running everything at 2 pixels per clock means that the Raspberry Pi 4 cannot support a timing where _any_ of the horizontal timings are not divisible by 2. The firmware and Linux kernel will filter out any mode that does not fulfil this criteria.
+Running everything at 2 pixels per clock means that the Raspberry Pi 4 and 5 cannot support a timing where _any_ of the horizontal timings are not divisible by 2. The firmware and Linux kernel filter out any mode that does not fulfil this criteria.
 
-There is only one mode in the CEA and DMT standards that falls into this category - DMT mode 81, which is 1366x768 @ 60Hz. This mode has odd values for the horizontal sync and back porch timings. It's also an unusual mode for having a width that isn't divisible by 8.
+There is only one incompatible mode in the CEA and DMT standards: DMT mode 81, 1366x768 @ 60Hz. This mode has odd-numbered values for the horizontal sync and back porch timings and a width that indivisible by 8.
 
-If your monitor has this resolution, then the Raspberry Pi 4 will automatically drop down to the next mode that is advertised by the monitor; this is typically 1280x720.
+If your monitor has this resolution, Raspberry Pi 4 or 5 automatically drops down to the next mode advertised by the monitor; typically 1280x720.
 
 === Composite video mode
 
@@ -45,7 +45,7 @@ NOTE: Composite video output is not available on Raspberry Pi 400.
 
 ==== `enable_tvout`
 
-Set to `1` to enable composite video output, or `0` to disable. On Raspberry Pi 4 and 5, composite output is only available if you set this to `1`, which also disables HDMI output. Composite output is not available on the Raspberry Pi 400.
+Set to `1` to enable composite video output and `0` to disable. On Raspberry Pi 4 and 5, composite output is only available if you set this to `1`, which also disables HDMI output. Composite output is not available on the Raspberry Pi 400.
 
 [%header,cols="1,1"]
 
@@ -62,37 +62,46 @@ Set to `1` to enable composite video output, or `0` to disable. On Raspberry Pi 
 
 On all models except Raspberry Pi 4 and 5, HDMI output needs to be disabled in order for composite output to be enabled. HDMI output is disabled when no HDMI display is connected / detected. Set `enable_tvout=0` to prevent composite being enabled when HDMI is disabled.
 
-To enable composite output (on all models of Raspberry Pi) you also need to append `,composite` to the end of the `dtoverlay=vc4-kms-v3d` line in xref:../computers/config_txt.adoc#what-is-config-txt[`/boot/firmware/config.txt`]:
+To enable composite output, append `,composite` to the end of the `dtoverlay=vc4-kms-v3d` line in xref:../computers/config_txt.adoc#what-is-config-txt[`/boot/firmware/config.txt`]:
 
 ----
 dtoverlay=vc4-kms-v3d,composite
 ----
 
-By default this will output composite NTSC video. To choose a different mode, you need to append
+By default, this outputs composite NTSC video. To choose a different mode, instead append the following to the single line in `/boot/firmware/cmdline.txt`:
 
 ----
-vc4.tv_norm=video_mode
+vc4.tv_norm=<video_mode>
 ----
 
-to the single line in `/boot/firmware/cmdline.txt`, where `video_mode` is one of `NTSC`, `NTSC-J`, `NTSC-443`, `PAL`, `PAL-M`, `PAL-N`, `PAL60` or `SECAM`.
+Replace the `<video_mode>` placeholder with one of the following values:
+
+* `NTSC`
+* `NTSC-J`
+* `NTSC-443`
+* `PAL`
+* `PAL-M`
+* `PAL-N`
+* `PAL60`
+* `SECAM`
 
 === LCD displays and touchscreens
 
 ==== `ignore_lcd`
 
-By default the Raspberry Pi Touch Display is used when it is detected on the I2C bus. `ignore_lcd=1` will skip this detection phase, and therefore the LCD display will not be used.
+By default, the Raspberry Pi Touch Display is used when detected on the I2C bus. `ignore_lcd=1` skips this detection phase. This prevents the LCD display from being used.
 
 ==== `disable_touchscreen`
 
-Enable/disable the touchscreen.
+Enables and disables the touchscreen.
 
-`disable_touchscreen=1` will disable the touchscreen on the official Raspberry Pi Touch Display.
+`disable_touchscreen=1` disables the touchscreen component of the official Raspberry Pi Touch Display.
 
 === Generic display options
 
 ==== `disable_fw_kms_setup`
 
-By default, the firmware parses the EDID of any HDMI attached display, picks an appropriate video mode, then passes the resolution and frame rate of the mode, along with overscan parameters, to the Linux kernel via settings on the kernel command line. In rare circumstances, this can have the effect of choosing a mode that is not in the EDID, and may be incompatible with the device. You can use `disable_fw_kms_setup=1` to disable the passing of these parameters and avoid this problem. The Linux video mode system (KMS) will then parse the EDID itself and pick an appropriate mode.
+By default, the firmware parses the EDID of any HDMI attached display, picks an appropriate video mode, then passes the resolution and frame rate of the mode (and overscan parameters) to the Linux kernel via settings on the kernel command line. In rare circumstances, the firmware can choose a mode not in the EDID that may be incompatible with the device. Use `disable_fw_kms_setup=1` to disable passing video mode parameters, which can avoid this problem. The Linux video mode system (KMS) instead parses the EDID itself and picks an appropriate mode.
 
-NOTE: On Raspberry Pi 5 this parameter defaults to `1`
+NOTE: On Raspberry Pi 5, this parameter defaults to `1`.
 

--- a/documentation/asciidoc/computers/legacy_config_txt/video.adoc
+++ b/documentation/asciidoc/computers/legacy_config_txt/video.adoc
@@ -1299,7 +1299,7 @@ These values are valid if `hdmi_group=2` (DMT):
 | 1366x768
 | 60Hz
 | 16:9
-| xref:config_txt.adoc#hdmi-pipeline-for-raspberry-pi-4[NOT on Raspberry Pi 4]
+| xref:config_txt.adoc#hdmi-pipeline-for-raspberry-pi-4-and-5[NOT on Raspberry Pi 4 and 5]
 
 | 82
 | 1920x1080


### PR DESCRIPTION
* Closes https://github.com/raspberrypi/documentation/issues/3506
* Fixes minor stylistic issues with video documentation
* Updates a Raspberry Pi 4-specific HDMI pipeline section to also include the Pi 5, which also uses a similar pipeline and should be subject to the same minor issue.