### PR TITLE
Update gstreamer.adoc

### DIFF
--- a/documentation/asciidoc/computers/camera/gstreamer.adoc
+++ b/documentation/asciidoc/computers/camera/gstreamer.adoc
@@ -52,7 +52,7 @@ gst-launch-1.0 udpsrc address=192.168.0.3 port=5000 caps=application/x-rtp ! rtp
 
 [,bash]
 ----
-gst-launch-1.0 libcamerasrc ! capsfilter caps=video/x-raw,width=1280,height=720,format=NV12 ! v4l2convert ! v4l2h264enc extra-controls="controls,repeat_sequence_header=1" ! h264parse ! rtph264pay ! udpsink host=localhost port=5000
+gst-launch-1.0 libcamerasrc ! capsfilter caps=video/x-raw,width=1280,height=720,format=NV12 ! v4l2convert ! v4l2h264enc extra-controls="controls,repeat_sequence_header=1" ! 'video/x-h264,level=(string)4.1' ! h264parse ! rtph264pay ! udpsink host=localhost port=5000
 ----
 
 and on the client we use the same playback pipeline as previously.


### PR DESCRIPTION
Without this addition, the following error will occur.

ERROR: from element /GstPipeline:pipeline0/GstLibcameraSrc:libcamerasrc0: Internal data stream error. Additional debug info:
../src/gstreamer/gstlibcamerasrc.cpp(310): processRequest (): /GstPipeline:pipeline0/GstLibcameraSrc:libcamerasrc0: streaming stopped, reason error (-5)

and there will be an exception in /var/log/kern.log