### PR TITLE
Update regex to use valid escape sequences

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,8 @@ And install the [Ruby bundler](https://bundler.io/):
 $ gem install bundler
 ```
 
+If you're using a system version of Python 3.12, you may also need to run the Python 3.12 certificate-installation script. Find the Python3.12 folder on your machine, and run `Install Certificates.command`.
+
 ##### Set up Homebrew Version of Ruby
 
 Because macOS provides its own version of Ruby, Homebrew doesn't automatically set up symlinks to access the version you just installed with the `ruby` command. But after a successful install, Homebrew outputs the commands you'll need to run to set up the symlink yourself. If you use the default macOS `zsh` shell on Apple Silicon, you can set up the symlink with the following command:

--- a/scripts/create_build_adoc.py
+++ b/scripts/create_build_adoc.py
@@ -13,9 +13,9 @@ def check_no_markdown(filename):
         if re.search('```\n.*?\n```', asciidoc):
             raise Exception("{} uses triple-backticks for markup - please use four-hyphens instead".format(filename))
         # strip out code blocks
-        asciidoc = re.sub('----\n.*?\n----', '', asciidoc, flags=re.DOTALL)
+        asciidoc = re.sub(r'----\n.*?\n----', '', asciidoc, flags=re.DOTALL)
         # strip out pass-through blocks
-        asciidoc = re.sub('\+\+\+\+\n.*?\n\+\+\+\+', '', asciidoc, flags=re.DOTALL)
+        asciidoc = re.sub(r'\+\+\+\+\n.*?\n\+\+\+\+', '', asciidoc, flags=re.DOTALL)
         if re.search('(?:^|\n)#+', asciidoc):
             raise Exception("{} contains a Markdown-style header (i.e. '#' rather than '=')".format(filename))
         if re.search(r'(\[.+?\]\(.+?\))', asciidoc):
@@ -57,19 +57,19 @@ if __name__ == "__main__":
         template_vars = {
             'github_edit_link': os.path.join(site_config['githuburl'], 'blob', site_config['githubbranch_edit'], src_adoc)
         }
-        edit_text = re.sub('{{\s*(\w+)\s*}}', lambda m: template_vars[m.group(1)], edit_template)
+        edit_text = re.sub(r'{{\s*(\w+)\s*}}', lambda m: template_vars[m.group(1)], edit_template)
 
     new_contents = ''
     seen_header = False
     with open(src_adoc) as in_fh:
         for line in in_fh.readlines():
-            if re.match('^=+ ', line) is not None:
+            if re.match(r'^=+ ', line) is not None:
                 if not seen_header:
                     seen_header = True
                     if github_edit is not None:
                         line += edit_text + "\n\n"
             else:
-                m = re.match('^(include::)(.+)(\[\]\n?)$', line)
+                m = re.match(r'^(include::)(.+)(\[\]\n?)$', line)
                 if m:
                     line = m.group(1) + os.path.join('{includedir}/{parentdir}', m.group(2)) + m.group(3)
             new_contents += line

--- a/scripts/create_build_adoc_include.py
+++ b/scripts/create_build_adoc_include.py
@@ -12,9 +12,9 @@ def check_no_markdown(filename):
         if re.search('```\n.*?\n```', asciidoc):
             raise Exception("{} uses triple-backticks for markup - please use four-hyphens instead".format(filename))
         # strip out code blocks
-        asciidoc = re.sub('----\n.*?\n----', '', asciidoc, flags=re.DOTALL)
+        asciidoc = re.sub(r'----\n.*?\n----', '', asciidoc, flags=re.DOTALL)
         # strip out pass-through blocks
-        asciidoc = re.sub('\+\+\+\+\n.*?\n\+\+\+\+', '', asciidoc, flags=re.DOTALL)
+        asciidoc = re.sub(r'\+\+\+\+\n.*?\n\+\+\+\+', '', asciidoc, flags=re.DOTALL)
         if re.search('(?:^|\n)#+', asciidoc):
             raise Exception("{} contains a Markdown-style header (i.e. '#' rather than '=')".format(filename))
         if re.search(r'(\[.+?\]\(.+?\))', asciidoc):
@@ -37,13 +37,13 @@ if __name__ == "__main__":
         template_vars = {
             'github_edit_link': os.path.join(site_config['githuburl'], 'blob', site_config['githubbranch_edit'], src_adoc)
         }
-        edit_text = re.sub('{{\s*(\w+)\s*}}', lambda m: template_vars[m.group(1)], edit_template)
+        edit_text = re.sub(r'{{\s*(\w+)\s*}}', lambda m: template_vars[m.group(1)], edit_template)
 
     with open(src_adoc) as in_fh:
         new_contents = ''
         seen_header = False
         for line in in_fh.readlines():
-            if re.match('^=+ ', line) is not None:
+            if re.match(r'^=+ ', line) is not None:
                 if not seen_header:
                     seen_header = True
                     if github_edit is not None:


### PR DESCRIPTION
Python wants a specific syntax when using escape sequences in `re.` commands. We used to be able to get away with it, but they switched the type of warning they use for these, which means we can't really ignore it anymore. The updates the offending regex accordingly to use raw strings.