### PR TITLE
Update version number of debug probe firmware and improve copy of both versions of instructions

### DIFF
--- a/documentation/asciidoc/microcontrollers/debug-probe/updating-firmware.adoc
+++ b/documentation/asciidoc/microcontrollers/debug-probe/updating-firmware.adoc
@@ -1,10 +1,15 @@
 == Updating the firmware on the Debug Probe
 
-NOTE: The current version of the Debug Probe firmware is version 1.0.3. If you're running an older version, or if you have accidentally overwritten the firmware on your Debug Probe, the latest release of the firmware can be found on https://github.com/raspberrypi/debugprobe/releases/latest[GitHub].
+Firmware for the Debug Probe is available as a UF2 file distributed by Raspberry Pi.
 
-From time to time you may need to update the Debug Probe firmware. New firmware for the probe will be made available as a UF2 file distributed by Raspberry Pi.
+The latest version of the Debug Probe firmware is version 2. If you're running an older version, or if you have accidentally overwritten the firmware on your Debug Probe, you can find the latest release of the firmware in https://github.com/raspberrypi/debugprobe/releases/latest[the debugprobe GitHub repository].
 
-Pinch to remove the top of the Debug Probe enclosure, then push and hold the BOOTSEL button as you plug the Debug Probe into your computer. This will mount an RPI-RP2 volume on your desktop. Drag-and-drop the firmware UF2 onto the RPI-RP2 volume. The firmware will be copied to the Debug Probe and the volume will dismount.
+Download `debugprobe.uf2` from the latest release.
 
-Your Debug Probe will reboot. You are now running an updated version of the Debug Probe firmware.
+Pinch to remove the top of the Debug Probe enclosure.
 
+Push and hold the BOOTSEL button as you plug the Debug Probe into your computer to mount a volume called "RPI-RP2".
+
+Copy `debugprobe.uf2` onto the "RPI-RP2" volume. The volume will dismount automatically after the file finishes copying onto the device.
+
+Your Debug Probe will reboot and now runs an updated version of the Debug Probe firmware. It is now ready for debugging.

--- a/documentation/asciidoc/microcontrollers/raspberry-pi-pico/utilities.adoc
+++ b/documentation/asciidoc/microcontrollers/raspberry-pi-pico/utilities.adoc
@@ -8,10 +8,19 @@ If you have forgotten what has been programmed into your Raspberry Pi Pico, and 
 
 === Debugging using another Raspberry Pi Pico
 
-It is possible to use one Raspberry Pi Pico to debug another Pico. This is possible via debugprobe, an application that allows a Pico to act as a USB → SWD and UART converter. This makes it easy to use a Pico on non-Raspberry Pi platforms such as Windows, Mac, and Linux computers where you don’t have GPIOs to connect directly to your Pico. Full instructions on how to use debugprobe to do this are available in our 'https://datasheets.raspberrypi.com/pico/getting-started-with-pico.pdf[getting started]' documentation.
+You can use one Raspberry Pi Pico to debug another Pico. This is possible via `debugprobe`, an application that allows a Pico to act as a USB → SWD and UART converter.
 
-* Download the https://github.com/raspberrypi/debugprobe/releases/latest/download/debugprobe_on_pico.uf2[UF2 file]
-* Go to the https://github.com/raspberrypi/debugprobe[Debug Probe Github repository]
+You can find the latest release of the firmware in https://github.com/raspberrypi/debugprobe/releases/latest[the debugprobe GitHub repository].
+
+Download `debugprobe_on_pico.uf2` from the latest release.
+
+Push and hold the BOOTSEL button as you plug the debugger Pico into your computer to mount a volume called "RPI-RP2".
+
+Copy `debugprobe_on_pico.uf2` onto the volume. The volume will dismount automatically after the file finishes copying onto the device.
+
+Your Pico will reboot and now runs an updated version of the `debugprobe` firmware. It is now ready for debugging.
+
+TIP: For instructions on how to use the debugger, see https://datasheets.raspberrypi.com/pico/getting-started-with-pico.pdf[Getting Started with Pico].
 
 === Resetting Flash memory
 


### PR DESCRIPTION
* Bumps version number of `debugprobe` firmware to 2.
* Improves copy to match similar recent changes in the Getting Started with Pico guide.