### PR TITLE
Fix series-1 plus-model confusion in getting started section

### DIFF
--- a/documentation/asciidoc/computers/getting-started/setting-up.adoc
+++ b/documentation/asciidoc/computers/getting-started/setting-up.adoc
@@ -115,7 +115,7 @@ Raspberry Pi models have the following display connectivity:
 |HDMI, audio and composite out via 3.5mm http://en.wikipedia.org/wiki/Phone_connector_(audio)#TRRS_standards[TRRS] jack
 
 |Raspberry Pi 1 Model A+
-|HDMI, RCA connector
+|HDMI, audio and composite out via 3.5mm http://en.wikipedia.org/wiki/Phone_connector_(audio)#TRRS_standards[TRRS] jack
 
 |Raspberry Pi Zero (all models)
 |mini HDMI


### PR DESCRIPTION
Turns out both + models had TRRS! Only the original model 1s had RCA. And those aren't mentioned here because that would just bloat the table unnecessarily 😄