### PR TITLE
Swap order of page title to put important info first

### DIFF
--- a/scripts/create_build_adoc.py
+++ b/scripts/create_build_adoc.py
@@ -84,4 +84,4 @@ if __name__ == "__main__":
 :figure-caption!:
 
 {}
-""".format(output_subdir, includes_dir, '{} - {}'.format(site_config['title'], index_title), index_title, new_contents))
+""".format(output_subdir, includes_dir, '{} - {}'.format(index_title, site_config['title']), index_title, new_contents))

--- a/scripts/create_build_adoc_doxygen.py
+++ b/scripts/create_build_adoc_doxygen.py
@@ -82,4 +82,4 @@ if __name__ == "__main__":
 :figure-caption!:
 
 {}
-""".format(output_subdir, includes_dir, '{} - {}'.format(site_config['title'], index_title), index_title, new_contents))
+""".format(output_subdir, includes_dir, '{} - {}'.format(index_title, site_config['title']), index_title, new_contents))

--- a/tests/test_create_build_adoc.py
+++ b/tests/test_create_build_adoc.py
@@ -36,7 +36,7 @@ class TestCreateBuildAdoc(unittest.TestCase):
         expected = ''':parentdir: microcontrollers
 :page-layout: docs
 :includedir: {0}
-:doctitle: Raspberry Pi Documentation - The C/C++ SDK
+:doctitle: The C/C++ SDK - Raspberry Pi Documentation 
 :page-sub_title: The C/C++ SDK
 :sectanchors:
 :figure-caption!:

--- a/tests/test_create_build_adoc.py
+++ b/tests/test_create_build_adoc.py
@@ -36,7 +36,7 @@ class TestCreateBuildAdoc(unittest.TestCase):
         expected = ''':parentdir: microcontrollers
 :page-layout: docs
 :includedir: {0}
-:doctitle: The C/C++ SDK - Raspberry Pi Documentation 
+:doctitle: The C/C++ SDK - Raspberry Pi Documentation
 :page-sub_title: The C/C++ SDK
 :sectanchors:
 :figure-caption!:

--- a/tests/test_create_build_adoc_doxygen.py
+++ b/tests/test_create_build_adoc_doxygen.py
@@ -38,7 +38,7 @@ class TestCreateBuildAdocDoxygen(unittest.TestCase):
         expected = ''':parentdir: pico-sdk
 :page-layout: docs
 :includedir: {0}
-:doctitle: Raspberry Pi Documentation - group__channel__config
+:doctitle: group__channel__config - Raspberry Pi Documentation
 :page-sub_title: group__channel__config
 :sectanchors:
 :figure-caption!:


### PR DESCRIPTION
Response to some feedback:

```
Every page starts with "Raspberry Pi Documentation" and when you have several tabs open it's hard to figure out which tab has the document that I want to refer to because most web browsers won't show the full title in the tab bar - in my case the title gets cut-off at "Raspberry Pi Documentation -".

E.g I have these pages open:

"Raspberry Pi Documentation - Raspberry Pi Debug Probe"
"Raspberry Pi Documentation - Processors"
"Raspberry Pi Documentation - Configuration"

It might be best to change the naming to something like this:

"Raspberry Pi Debug Probe - Raspberry Pi Documentation"
"Processors - Raspberry Pi Documentation"
"Configuration - Raspberry Pi Documentation"

I think this would make navigating the docs a bit easier when you have multiple open. 🙂
```

This has annoyed me as well. We have the technology. Thoughts?