### PR TITLE
Fix typo in external-storage.adoc

### DIFF
--- a/documentation/asciidoc/computers/configuration/external-storage.adoc
+++ b/documentation/asciidoc/computers/configuration/external-storage.adoc
@@ -91,7 +91,7 @@ Add the following line in the `fstab` file:
 
 [source,console]
 ----
-$ UID=5C24-1453 /mnt/mydisk fstype defaults,auto,users,rw,nofail 0 0
+$ UUID=5C24-1453 /mnt/mydisk fstype defaults,auto,users,rw,nofail 0 0
 ----
 
 Replace `fstype` with the type of your file system, which you found when you went through the steps above, for example: `ntfs`.


### PR DESCRIPTION
Fix UUID typo (add extra "U") in the fstab line under the "Setting up automatic mounting" section.