### PR TITLE
Add anchor point for Raspberry Pi 5 power OS tooltip

### DIFF
--- a/documentation/asciidoc/computers/raspberry-pi/power-supplies.adoc
+++ b/documentation/asciidoc/computers/raspberry-pi/power-supplies.adoc
@@ -4,7 +4,7 @@ The power supply requirements differ by Raspberry Pi model. All models require a
 
 The current consumed by each Raspberry Pi depends on the peripherals connected.
 
-=== Recommended power supplies
+=== [[powering-raspberry-pi-5]]Recommended power supplies
 
 For Raspberry Pi 1, Raspberry Pi 2, and Raspberry Pi 3, we recommend the https://www.raspberrypi.com/products/micro-usb-power-supply/[2.5A micro USB supply]. For Raspberry Pi 4 and Raspberry Pi 400, we recommend the https://www.raspberrypi.com/products/type-c-power-supply/[3A USB-C Supply for Raspberry Pi 4]. For Raspberry Pi 5, we recommend the https://www.raspberrypi.com/products/27w-power-supply/[27W USB-C Power Supply].
 


### PR DESCRIPTION
* Closes https://github.com/raspberrypi/documentation/issues/3573
* OS links to https://www.raspberrypi.com/documentation/computers/raspberry-pi-5.html#powering-raspberry-pi-5
* currently redirects to https://www.raspberrypi.com/documentation/computers/raspberry-pi.html#powering-raspberry-pi-5 (note that the base page redirects, but the anchor point remains the same)
* This anchor point doesn't exist, so you just get dumped at the top of the page
* should go to https://www.raspberrypi.com/documentation/computers/raspberry-pi.html#recommended-power-supplies

* Adds an explicit additional anchor point a la https://docs.asciidoctor.org/asciidoc/latest/attributes/id/#add-additional-anchors-to-a-section
