### PR TITLE
Minor updates to Remote Access

### DIFF
--- a/documentation/asciidoc/computers/remote-access/find-your-ip-address.adoc
+++ b/documentation/asciidoc/computers/remote-access/find-your-ip-address.adoc
@@ -97,7 +97,7 @@ In the example above, the Raspberry Pi uses Wi-Fi to access the internet. Check 
 
 === Resolve `raspberrypi.local` with mDNS
 
-On Raspberry Pi OS, multicast DNS is supported out-of-the-box by the Avahi service.
+Raspberry Pi OS supports multicast DNS as part of the Avahi service.
 
 If your device supports mDNS, you can reach your Raspberry Pi by using its hostname and the `.local` suffix.
 The default hostname on a fresh Raspberry Pi OS install is `raspberrypi`, so by default any Raspberry Pi running Raspberry Pi OS responds to:
@@ -114,9 +114,7 @@ PING raspberrypi.local (192.168.1.131): 56 data bytes
 64 bytes from 192.168.1.131: icmp_seq=0 ttl=255 time=2.618 ms
 ----
 
-If you change the system hostname of the Raspberry Pi (e.g., by editing `/etc/hostname`), Avahi also changes the `.local` mDNS address.
-
-If you don't remember the hostname of the Raspberry Pi, you can install Avahi on another device, then use https://linux.die.net/man/1/avahi-browse[`avahi-browse`] to browse all the hosts and services on your local network.
+TIP: If you change the system hostname of the Raspberry Pi with Raspberry Pi Configuration, `raspi-config`, or by manually editing `/etc/hostname`, Avahi changes the `.local` mDNS address. If you don't remember the hostname of the Raspberry Pi, you can install Avahi on another device, then use https://linux.die.net/man/1/avahi-browse[`avahi-browse`] to browse all the hosts and services on your local network.
 
 === Check your router's list of devices
 

--- a/documentation/asciidoc/computers/remote-access/find-your-ip-address.adoc
+++ b/documentation/asciidoc/computers/remote-access/find-your-ip-address.adoc
@@ -114,7 +114,7 @@ PING raspberrypi.local (192.168.1.131): 56 data bytes
 64 bytes from 192.168.1.131: icmp_seq=0 ttl=255 time=2.618 ms
 ----
 
-TIP: If you change the system hostname of the Raspberry Pi with Raspberry Pi Configuration, `raspi-config`, or by manually editing `/etc/hostname`, Avahi changes the `.local` mDNS address. If you don't remember the hostname of the Raspberry Pi, you can install Avahi on another device, then use https://linux.die.net/man/1/avahi-browse[`avahi-browse`] to browse all the hosts and services on your local network.
+TIP: If you change the system hostname of your Raspberry Pi using Raspberry Pi Configuration, `raspi-config`, or `/etc/hostname`, Avahi updates the `.local` mDNS address. If you don't remember the hostname of your Raspberry Pi, you can install Avahi on another device, then use https://linux.die.net/man/1/avahi-browse[`avahi-browse`] to browse all the hosts and services on your local network.
 
 === Check your router's list of devices
 

--- a/documentation/asciidoc/computers/remote-access/introduction.adoc
+++ b/documentation/asciidoc/computers/remote-access/introduction.adoc
@@ -14,7 +14,7 @@ SSH (**S**ecure **SH**ell) provides secure access to a terminal session on your 
 
 === Share files between devices over the local network
 
-Services like xref:remote-access.adoc#nfs[NFS] (Network File Share), xref:remote-access.adoc#scp[SCP] (Secure Copy Protocol), xref:remote-access.adoc#samba[Samba], and xref:remote-access.adoc#rsync[`rsync`] enable you to share files between devices on the local network without directly controlling the remote device. These services can be useful when you need to access data stored on one device from another device.
+Services like xref:remote-access.adoc#nfs[NFS] (Network File System), xref:remote-access.adoc#scp[SCP] (Secure Copy Protocol), xref:remote-access.adoc#samba[Samba], and xref:remote-access.adoc#rsync[`rsync`] enable you to share files between devices on the local network without directly controlling the remote device. These services can be useful when you need to access data stored on one device from another device.
 
 === Remote control over the Internet
 

--- a/documentation/asciidoc/computers/remote-access/raspberry-pi-connect.adoc
+++ b/documentation/asciidoc/computers/remote-access/raspberry-pi-connect.adoc
@@ -1,6 +1,6 @@
 [[raspberry-pi-connect]]
 == Screen share with Raspberry Pi Connect
 
-You can access the desktop of a Raspberry Pi remotely from another computer or device on the same network using Raspberry Pi Connect.
+You can access the desktop of a Raspberry Pi remotely from another device using Raspberry Pi Connect. Raspberry Pi Connect shares your screen in a browser window and handles configuration for you, so you don't have to find your Raspberry Pi's local IP address or modify your local network.
 
 For more information, see xref:../services/connect.adoc[the Connect documentation].

--- a/documentation/asciidoc/computers/remote-access/raspberry-pi-connect.adoc
+++ b/documentation/asciidoc/computers/remote-access/raspberry-pi-connect.adoc
@@ -1,6 +1,6 @@
 [[raspberry-pi-connect]]
 == Screen share with Raspberry Pi Connect
 
-You can access the desktop of a Raspberry Pi remotely from another device using Raspberry Pi Connect. Raspberry Pi Connect shares your screen in a browser window and handles configuration for you, so you don't have to find your Raspberry Pi's local IP address or modify your local network.
+You can access the desktop of a Raspberry Pi remotely from a browser on another device using Raspberry Pi Connect. Raspberry Pi Connect handles configuration automatically, so you don't have to find your Raspberry Pi's local IP address or modify your local network.
 
 For more information, see xref:../services/connect.adoc[the Connect documentation].

--- a/documentation/asciidoc/computers/remote-access/rsync.adoc
+++ b/documentation/asciidoc/computers/remote-access/rsync.adoc
@@ -10,7 +10,7 @@ Before you can configure `rsync`, determine values for the following:
 * `<pi_folder_name>`: the name of the folder you want to copy files from on your Raspberry Pi
 * `<pc_folder_name>`: the name of the folder you would like to synchronise on your personal computer
 
-To configure `rsync` to share files, complete the following steps on your personal computer, replacing placeholders in the commands with the values you determined above:
+To configure `rsync` to synchronise files, complete the following steps on your personal computer, replacing placeholders in the commands with the values you determined above:
 
 . Create the folder you would like to synchronise to:
 +
@@ -22,7 +22,7 @@ $ mkdir <pc_folder_name>
 +
 [source,console]
 ----
-$ rsync -avz -e ssh <pi_username>@<pi_ip_address>:<pi_folder_name>/ <folder_name>/
+$ rsync -avz -e ssh <pi_username>@<pi_ip_address>:<pi_folder_name>/ <pc_folder_name>/
 ----
 
 This command copies all files from the selected folder on your Raspberry Pi to the selected folder on your personal computer. If you run the command multiple times, `rsync` keeps track of the files you have already downloaded and skips them. If you delete or modify an already synchronised file on the Raspberry Pi, `rsync` updates the files on your personal computer accordingly.

--- a/documentation/asciidoc/computers/remote-access/ssh.adoc
+++ b/documentation/asciidoc/computers/remote-access/ssh.adoc
@@ -18,7 +18,7 @@ By default, Raspberry Pi OS disables the SSH server. Enable SSH in one of the fo
 
 To configure SSH on a completely new installation of Raspberry Pi OS:
 
-. Follow the instructions in the xref:../computers/getting-started.adoc#install-using-imager[Install with Imager] guide.
+. Follow the instructions in the xref:../computers/getting-started.adoc#raspberry-pi-imager[Install with Imager] guide.
 . During the **OS Customisation** step, navigate to the **Services** tab.
 . Tick the checkbox to **Enable SSH**.
 . Select **password authentication** to log in using the same username and password you use while physically using your Raspberry Pi. Select **Allow public-key authentication only** to xref:remote-access.adoc#configure-ssh-without-a-password[configure an SSH key] for passwordless login.

--- a/documentation/asciidoc/computers/remote-access/ssh.adoc
+++ b/documentation/asciidoc/computers/remote-access/ssh.adoc
@@ -18,7 +18,7 @@ By default, Raspberry Pi OS disables the SSH server. Enable SSH in one of the fo
 
 To configure SSH on a completely new installation of Raspberry Pi OS:
 
-. Follow the instructions in the xref:computers/getting-started.adoc#install-using-imager[Install with Imager] guide.
+. Follow the instructions in the xref:../computers/getting-started.adoc#install-using-imager[Install with Imager] guide.
 . During the **OS Customisation** step, navigate to the **Services** tab.
 . Tick the checkbox to **Enable SSH**.
 . Select **password authentication** to log in using the same username and password you use while physically using your Raspberry Pi. Select **Allow public-key authentication only** to xref:remote-access.adoc#configure-ssh-without-a-password[configure an SSH key] for passwordless login.

--- a/documentation/asciidoc/computers/remote-access/ssh.adoc
+++ b/documentation/asciidoc/computers/remote-access/ssh.adoc
@@ -18,7 +18,7 @@ By default, Raspberry Pi OS disables the SSH server. Enable SSH in one of the fo
 
 To configure SSH on a completely new installation of Raspberry Pi OS:
 
-. Follow the instructions in thexref:computers/getting-started.adoc#install-using-imager[Install with Imager] guide.
+. Follow the instructions in the xref:computers/getting-started.adoc#install-using-imager[Install with Imager] guide.
 . During the **OS Customisation** step, navigate to the **Services** tab.
 . Tick the checkbox to **Enable SSH**.
 . Select **password authentication** to log in using the same username and password you use while physically using your Raspberry Pi. Select **Allow public-key authentication only** to xref:remote-access.adoc#configure-ssh-without-a-password[configure an SSH key] for passwordless login.

--- a/documentation/asciidoc/computers/remote-access/ssh.adoc
+++ b/documentation/asciidoc/computers/remote-access/ssh.adoc
@@ -14,6 +14,15 @@ By default, Raspberry Pi OS disables the SSH server. Enable SSH in one of the fo
 . Select *Enabled* next to *SSH*.
 . Click *OK*.
 
+==== While flashing a fresh OS image
+
+To configure SSH on a completely new installation of Raspberry Pi OS:
+
+. Follow the instructions in thexref:computers/getting-started.adoc#install-using-imager[Install with Imager] guide.
+. During the **OS Customisation** step, navigate to the **Services** tab.
+. Tick the checkbox to **Enable SSH**.
+. Select **password authentication** to log in using the same username and password you use while physically using your Raspberry Pi. Select **Allow public-key authentication only** to xref:remote-access.adoc#configure-ssh-without-a-password[configure an SSH key] for passwordless login.
+
 ==== From the terminal
 
 . Enter `sudo raspi-config` in a terminal window.
@@ -86,12 +95,12 @@ $ geany &
 
 To remotely access your Raspberry Pi without providing a password each time you connect, use an SSH keypair.
 
-==== Preconfigure a boot image with Raspberry Pi Imager
+==== Preconfigure an OS image with Raspberry Pi Imager
 
-When configuring a boot image with Raspberry Pi Imager, you can preconfigure SSH keys. You can use a new SSH keypair or an existing SSH key.
+When configuring a boot image with Raspberry Pi Imager, you can preconfigure SSH keys. You can generate a new SSH keypair or an existing SSH key.
 
 . Follow the xref:getting-started.adoc#raspberry-pi-imager[install using Imager] guide to configure your boot image.
-. During the OS Customisation step, navigate to the Services tab and select the *Enable SSH* checkbox.
+. During the *OS Customisation* step, navigate to the *Services* tab and tick the *Enable SSH* checkbox.
 . Select the *Allow public-key authentication only* radio button. If you already have an SSH public key stored in `~/.ssh/id_rsa.pub`, Imager automatically uses that public key to prefill the text box. If Imager doesn't find an SSH public key, you can click the *RUN SSH-KEYGEN* button to generate a new keypair.
 
 ==== Manually configure an SSH key
@@ -111,7 +120,7 @@ If you see files named `id_ed25519.pub`, `id_rsa.pub`, or `id_dsa.pub`, you alre
 
 ==== Generate new SSH keypair
 
-TIP: This guide provides instructions to generate a new RSA key. For additional security, you can instead generate a http://ed25519.cr.yp.to/[Ed25519] key. Replace `rsa` with `ed25519` in your public and private key file names and the instructions should work the same.
+TIP: This guide provides instructions to generate a new RSA key. For additional security, you can instead generate a http://ed25519.cr.yp.to/[Ed25519] key. Pass `-t ed25519` to `ssh-keygen` and replace `rsa` with `ed25519` when referencing your public and private key file names to use an Ed25519 key.
 
 To generate a new SSH keypair, enter the following command:
 
@@ -159,7 +168,7 @@ $ ssh-add ~/.ssh/id_rsa
 ----
 
 [[copy-your-public-key-to-your-raspberry-pi]]
-==== Copy the public key to your Raspberry Pi
+==== Copy a public key to your Raspberry Pi
 
 On the computer you use to remotely connect to the Raspberry Pi, use the following command to securely copy your public key to the Raspberry Pi:
 
@@ -168,9 +177,38 @@ On the computer you use to remotely connect to the Raspberry Pi, use the followi
 $ ssh-copy-id <username>@<ip address>
 ----
 
-When prompted, enter the password for your user account on the Raspberry Pi.
+When prompted, enter the password for your user account on the Raspberry Pi. 
+You can now connect to your Raspberry Pi without entering a password.
 
-TIP: If your operating system does not support `ssh-copy-id`, you can copy your public key with xref:remote-access.adoc#scp[`scp`] or a network share instead.
+==== Manually copy a public key to your Raspberry Pi
 
-You can now connect without entering a password.
+If your operating system does not support `ssh-copy-id`, you can instead copy your public key with xref:remote-access.adoc#scp[`scp`].
 
+First, create the directory where Linux expects to find keys on your Raspberry Pi: 
+
+[source,console]
+----
+$ mkdir -p .ssh/authorized_keys
+----
+
+Then, configure the proper permissions for the directories:
+
+[source,console]
+----
+$ chmod 700 .ssh
+----
+
+[source,console]
+----
+$ chmod 644 .ssh/authorized_keys
+----
+
+Finally, on your usual computer, copy the keys to the Raspberry Pi using `scp`:
+
+[source,console]
+----
+$ scp .ssh/id_rsa.pub <username>@<ip address>:.ssh/authorized_keys/
+----
+
+When prompted, enter the password for your user account on the Raspberry Pi. 
+You can now connect to your Raspberry Pi without entering a password.


### PR DESCRIPTION
Small updates to a few remote access sections based on some late-arriving comments on a previous PR (in all fairness, I _did_ merge it pretty quickly). Mostly minor wording tweaks, but I did decide to expand an admonition in the SSH section (manual key copy) into a full section to better help users who lack access to a certain Linux utility.