### PR TITLE
Document rpi-connect 1.1's vnc command

### DIFF
--- a/documentation/asciidoc/services/connect/use.adoc
+++ b/documentation/asciidoc/services/connect/use.adoc
@@ -111,7 +111,6 @@ To re-enable screen sharing, do one of the following:
 * click the Connect system tray icon and select **Allow screen sharing**
 * run the terminal command `rpi-connect vnc on`
 
-NOTE: You can also use the terminal command `rpi-connect vnc on` to re-enable screen sharing.
 
 === Manage your Raspberry Pis
 

--- a/documentation/asciidoc/services/connect/use.adoc
+++ b/documentation/asciidoc/services/connect/use.adoc
@@ -109,7 +109,7 @@ image::images/no-connect-button-ui.png[width="80%"]
 
 To re-enable screen sharing, click the Connect system tray icon and select **Allow screen sharing**.
 
-IMPORTANT: Connect automatically enables screen sharing after a reboot. To permanently disable screen sharing, sign out of Connect.
+NOTE: You can also use the terminal command `rpi-connect vnc on` to re-enable screen sharing.
 
 === Manage your Raspberry Pis
 

--- a/documentation/asciidoc/services/connect/use.adoc
+++ b/documentation/asciidoc/services/connect/use.adoc
@@ -107,7 +107,9 @@ In the Connect portal, the **Connect** button and the **Screen sharing** label n
 
 image::images/no-connect-button-ui.png[width="80%"] 
 
-To re-enable screen sharing, click the Connect system tray icon and select **Allow screen sharing**.
+To re-enable screen sharing, do one of the following:
+* click the Connect system tray icon and select **Allow screen sharing**
+* run the terminal command `rpi-connect vnc on`
 
 NOTE: You can also use the terminal command `rpi-connect vnc on` to re-enable screen sharing.
 


### PR DESCRIPTION
With the release of rpi-connect 1.1.0, we no longer automatically enable screen sharing on restart if the user has disabled it. If they find themselves locked out of Connect, they can use the rpi-connect CLI to re-enable it.
