### PR TITLE
Relocate kernel build files to /firmware also in the cross-compiling section

### DIFF
--- a/documentation/asciidoc/computers/linux_kernel/building.adoc
+++ b/documentation/asciidoc/computers/linux_kernel/building.adoc
@@ -305,15 +305,15 @@ Finally, copy the kernel and Device Tree blobs onto the SD card, making sure to 
 
 [,bash]
 ----
-sudo cp mnt/fat32/$KERNEL.img mnt/fat32/$KERNEL-backup.img
-sudo cp arch/arm/boot/zImage mnt/fat32/$KERNEL.img
+sudo cp mnt/fat32/firmware/$KERNEL.img mnt/fat32/firmware/$KERNEL-backup.img
+sudo cp arch/arm/boot/zImage mnt/fat32/firmware/$KERNEL.img
 # Choose one of the following based on the kernel version
   # For kernels up to 6.4:
-  sudo cp arch/arm/boot/dts/*.dtb mnt/fat32/
+  sudo cp arch/arm/boot/dts/*.dtb mnt/fat32/firmware/
   # For kernel 6.5 and above:
-  sudo cp arch/arm/boot/dts/broadcom/*.dtb mnt/fat32/
-sudo cp arch/arm/boot/dts/overlays/*.dtb* mnt/fat32/overlays/
-sudo cp arch/arm/boot/dts/overlays/README mnt/fat32/overlays/
+  sudo cp arch/arm/boot/dts/broadcom/*.dtb mnt/fat32/firmware/
+sudo cp arch/arm/boot/dts/overlays/*.dtb* mnt/fat32/firmware/overlays/
+sudo cp arch/arm/boot/dts/overlays/README mnt/fat32/firmware/overlays/
 sudo umount mnt/fat32
 sudo umount mnt/ext4
 ----
@@ -322,11 +322,11 @@ sudo umount mnt/ext4
 
 [,bash]
 ----
-sudo cp mnt/fat32/$KERNEL.img mnt/fat32/$KERNEL-backup.img
-sudo cp arch/arm64/boot/Image mnt/fat32/$KERNEL.img
-sudo cp arch/arm64/boot/dts/broadcom/*.dtb mnt/fat32/
-sudo cp arch/arm64/boot/dts/overlays/*.dtb* mnt/fat32/overlays/
-sudo cp arch/arm64/boot/dts/overlays/README mnt/fat32/overlays/
+sudo cp mnt/fat32/firmware/$KERNEL.img mnt/fat32/firmware/$KERNEL-backup.img
+sudo cp arch/arm64/boot/Image mnt/fat32/firmware/$KERNEL.img
+sudo cp arch/arm64/boot/dts/broadcom/*.dtb mnt/fat32/firmware/
+sudo cp arch/arm64/boot/dts/overlays/*.dtb* mnt/fat32/firmware/overlays/
+sudo cp arch/arm64/boot/dts/overlays/README mnt/fat32/firmware/overlays/
 sudo umount mnt/fat32
 sudo umount mnt/ext4
 ----


### PR DESCRIPTION
In the recent change, kernel images and other build files are relocated to /boot/firmware, however, the description in cross-compiling section have not been updated accordingly.