### PR TITLE
Add some details of custom CA certs

### DIFF
--- a/documentation/asciidoc/computers/raspberry-pi/boot-http.adoc
+++ b/documentation/asciidoc/computers/raspberry-pi/boot-http.adoc
@@ -40,6 +40,55 @@ rpi-eeprom-digest -i pieeprom.upd -o pieeprom.sig
 rpi-eeprom-digest -i boot.img -o boot.sig -k myprivkey.pem
 ----
 
+=== Certificates
+
+For security the Network install feature uses HTTPS to download the image from the Raspberry Pi website. It uses our own CA root included in the bootloader so it can verify it's talking to the correct host.
+
+Since the 5th April 2024, 2712 devices have had the ability to add their own custom CA certificate to the eeprom to securely download images from their own web sites. To achieve this, the DER encoded certificate is added with the new `--cacertder` option in the `rpi-eeprom-config` tool.
+
+To ensure that the certificate is not modified, a hash of the certificate must be placed in the eeprom config settings and a key used to guard against tampering.
+
+----
+# Generate a DER encoded certificate
+openssl x509 -in your_ca_root_cert.pem -out cert.der -outform DER
+
+# generate the hash of the certificate
+sha256sum cert.der
+701bd97f67b0f5483a9734e6e5cf72f9a123407b346088638f597878563193fc  cert.der
+----
+
+Update boot.conf to include the hash of the certificate
+
+----
+[all]
+BOOT_UART=1
+POWER_OFF_ON_HALT=0
+BOOT_ORDER=0xf461
+
+[gpio8=0]
+BOOT_ORDER=0xf7
+NET_INSTALL_ENABLED=0
+HTTP_HOST=yourserver.org
+HTTP_PATH=path/to/files
+HTTP_CACERT_HASH=701bd97f67b0f5483a9734e6e5cf72f9a123407b346088638f597878563193fc
+----
+
+NOTE: If `HTTP_CACERT_HASH` is specified it assumes that you want to use HTTPS and changes to use port 443 for the download.
+
+----
+# Add everything to the eeprom
+../tools/rpi-eeprom-config -c boot.conf -p public_key.pem -o pieeprom.bin --cacertder cert.der pieeprom.original.bin
+../tools/rpi-eeprom-digest -k private_key.pem -i pieeprom.bin -o pieeprom.sig
+----
+
+On boot it should use HTTPS instead of HTTP.
+
+----
+Loading boot.img ...
+HTTP: GET request for https://yourserver.org:443/path/to/files/boot.sig
+HTTP: GET request for https://yourserver.org:443/path/to/files/boot.img
+----
+
 === Secure boot
 
 If secure boot is enabled, then the Raspberry Pi can only run code signed by the customer's private key. So if you want to use network install or HTTP boot mode with secure boot, you must sign `boot.img` and generate `boot.sig` with your own key and host these files somewhere for download. The public key in the EEPROM will be used to verify the image.

--- a/documentation/asciidoc/computers/raspberry-pi/boot-http.adoc
+++ b/documentation/asciidoc/computers/raspberry-pi/boot-http.adoc
@@ -14,13 +14,15 @@ HTTP_HOST=downloads.raspberrypi.org
 NET_INSTALL_ENABLED=0
 ```
 
-boot.img and its associated boot.sig file is a ram disk containg a boot file system, see xref:raspberry-pi.adoc#boot_ramdisk[boot_ramdisk] for more details.
+`boot.img` and the `boot.sig` signature file is a ram disk containing a boot file system. For more details, see xref:raspberry-pi.adoc#boot_ramdisk[boot_ramdisk].
 
 HTTP in the `BOOT_ORDER` will be ignored if secure boot is enabled and xref:raspberry-pi.adoc#HTTP_HOST[HTTP_HOST] is not set.
 
 === Requirements
 
-To use HTTP boot, xref:raspberry-pi.adoc#bootloader_update_stable[update the bootloader] to a bootloader dated 10th March 2022 or later. HTTP boot only works over Ethernet, so you need to connect your Raspberry Pi to your network via an Ethernet cable, e.g. to a socket on the back of your router. Custom CA certificates are supported on 2712 devices with a bootlader dated 5th April 2024 or later.
+To use HTTP boot, xref:raspberry-pi.adoc#bootloader_update_stable[update] to a bootloader released 10th March 2022 or later. HTTP boot requires a wired Ethernet connection.
+
+To use custom CA certificates, xref:raspberry-pi.adoc#bootloader_update_stable[update the bootloader] to a bootloader released 5th April 2024 or later. Only devices running the BCM2712 CPU support custom CA certificates.
 
 === Keys
 
@@ -79,8 +81,8 @@ $ sudo rpi-eeprom-config --edit
 
 Configure the following settings in the `[gpio8=0]` section, replacing:
 
-* `<your_website>` with your website, e.g. `raspberrypi.com`
-* `<path_to_image>` with the path to your OS image hosted on your website, e.g. `path/to/image`
+* `<your_website>` with xref:raspberry-pi.adoc#HTTP_HOST[your website], e.g. `yourserver.org`
+* `<path_to_files>` with the xref:raspberry-pi.adoc#HTTP_PATH[path to your OS image] hosted on your website, e.g. `path/to/files`
 * `<hash>` with the hash value you generated above, e.g. `701bd97f67b0f5483a9734e6e5cf72f9a123407b346088638f597878563193fc`
 
 ----
@@ -93,13 +95,13 @@ BOOT_ORDER=0xf461
 BOOT_ORDER=0xf7
 NET_INSTALL_ENABLED=0
 HTTP_HOST=<your_website>
-HTTP_PATH=<path_to_image>
+HTTP_PATH=<path_to_files>
 HTTP_CACERT_HASH=<hash>
 ----
 
-NOTE: If you specify a `HTTP_CACERT_HASH`, https downloads are enabled and port 443 is used instead of port 80.
+When you specify a `HTTP_CACERT_HASH`, Network Install downloads the image using HTTPS over port 443 instead of HTTP over port 80.
 
-Finally, use to load everything into EEPROM:
+Finally, use the following commands to load everything into EEPROM:
 
 [source,console]
 ----

--- a/documentation/asciidoc/computers/raspberry-pi/boot-http.adoc
+++ b/documentation/asciidoc/computers/raspberry-pi/boot-http.adoc
@@ -14,6 +14,8 @@ HTTP_HOST=downloads.raspberrypi.org
 NET_INSTALL_ENABLED=0
 ```
 
+boot.img and its associated boot.sig file is a ram disk containg a boot file system, see xref:raspberry-pi.adoc#boot_ramdisk[boot_ramdisk] for more details.
+
 HTTP in the `BOOT_ORDER` will be ignored if secure boot is enabled and xref:raspberry-pi.adoc#HTTP_HOST[HTTP_HOST] is not set.
 
 === Requirements

--- a/documentation/asciidoc/computers/raspberry-pi/boot-http.adoc
+++ b/documentation/asciidoc/computers/raspberry-pi/boot-http.adoc
@@ -22,7 +22,7 @@ HTTP in the `BOOT_ORDER` will be ignored if secure boot is enabled and xref:rasp
 
 To use HTTP boot, xref:raspberry-pi.adoc#bootloader_update_stable[update] to a bootloader released 10th March 2022 or later. HTTP boot requires a wired Ethernet connection.
 
-To use custom CA certificates, xref:raspberry-pi.adoc#bootloader_update_stable[update the bootloader] to a bootloader released 5th April 2024 or later. Only devices running the BCM2712 CPU support custom CA certificates.
+To use custom CA certificates, xref:raspberry-pi.adoc#bootloader_update_stable[update] to a bootloader released 5th April 2024 or later. Only devices running the BCM2712 CPU support custom CA certificates.
 
 === Keys
 

--- a/documentation/asciidoc/computers/raspberry-pi/boot-http.adoc
+++ b/documentation/asciidoc/computers/raspberry-pi/boot-http.adoc
@@ -18,7 +18,7 @@ HTTP in the `BOOT_ORDER` will be ignored if secure boot is enabled and xref:rasp
 
 === Requirements
 
-To use HTTP boot, xref:raspberry-pi.adoc#bootloader_update_stable[update the bootloader] to a bootloader dated 10th March 2022 or later. HTTP boot only works over Ethernet, so you need to connect your Raspberry Pi to your network via an Ethernet cable, e.g. to a socket on the back of your router.
+To use HTTP boot, xref:raspberry-pi.adoc#bootloader_update_stable[update the bootloader] to a bootloader dated 10th March 2022 or later. HTTP boot only works over Ethernet, so you need to connect your Raspberry Pi to your network via an Ethernet cable, e.g. to a socket on the back of your router. Custom CA certificates are supported on 2712 devices with a bootlader dated 5th April 2024 or later.
 
 === Keys
 
@@ -95,14 +95,14 @@ HTTP_PATH=<path_to_image>
 HTTP_CACERT_HASH=<hash>
 ----
 
-NOTE: If you specify a `HTTP_CACERT_HASH`, Network Install downloads the image using HTTPS over port 443.
+NOTE: If you specify a `HTTP_CACERT_HASH`, https downloads are enabled and port 443 is used instead of port 80.
 
 Finally, use to load everything into EEPROM:
 
 [source,console]
 ----
-$ rpi-eeprom-config -c boot.conf -p public_key.pem -o pieeprom.bin --cacertder cert.der pieeprom.original.bin
-$ rpi-eeprom-digest -k private_key.pem -i pieeprom.bin -o pieeprom.sig
+$ rpi-eeprom-config -c boot.conf -p mypubkey.pem -o pieeprom.bin --cacertder cert.der pieeprom.original.bin
+$ rpi-eeprom-digest -k myprivkey.pem -i pieeprom.bin -o pieeprom.sig
 ----
 
 During network boot, your Raspberry Pi should use HTTPS instead of HTTP. You can check the boot output for the HTTPS URL:

--- a/documentation/asciidoc/computers/raspberry-pi/boot-http.adoc
+++ b/documentation/asciidoc/computers/raspberry-pi/boot-http.adoc
@@ -109,7 +109,7 @@ $ rpi-eeprom-config -c boot.conf -p mypubkey.pem -o pieeprom.bin --cacertder cer
 $ rpi-eeprom-digest -k myprivkey.pem -i pieeprom.bin -o pieeprom.sig
 ----
 
-During network boot, your Raspberry Pi should use HTTPS instead of HTTP. You can check the boot output for the HTTPS URL:
+During network boot, your Raspberry Pi should use HTTPS instead of HTTP. To see the full HTTPS URL resolved by Network Install for the download, check the boot output:
 
 ----
 Loading boot.img ...

--- a/documentation/asciidoc/computers/raspberry-pi/boot-http.adoc
+++ b/documentation/asciidoc/computers/raspberry-pi/boot-http.adoc
@@ -99,7 +99,7 @@ HTTP_PATH=<path_to_files>
 HTTP_CACERT_HASH=<hash>
 ----
 
-When you specify a `HTTP_CACERT_HASH`, Network Install downloads the image using HTTPS over port 443 instead of HTTP over port 80.
+When you specify a `HTTP_CACERT_HASH`, Network Install downloads the image using HTTPS over port 443. Without a hash, Network install downloads the image using HTTP over port 80.
 
 Finally, use the following commands to load everything into EEPROM:
 

--- a/documentation/asciidoc/computers/raspberry-pi/boot-http.adoc
+++ b/documentation/asciidoc/computers/raspberry-pi/boot-http.adoc
@@ -42,22 +42,44 @@ rpi-eeprom-digest -i boot.img -o boot.sig -k myprivkey.pem
 
 === Certificates
 
-For security the Network install feature uses HTTPS to download the image from the Raspberry Pi website. It uses our own CA root included in the bootloader so it can verify it's talking to the correct host.
+For security, Network Install uses HTTPS to download OS images from the Raspberry Pi website. This feature uses our own CA root included in the bootloader to verify the host.
 
-Since the 5th April 2024, 2712 devices have had the ability to add their own custom CA certificate to the eeprom to securely download images from their own web sites. To achieve this, the DER encoded certificate is added with the new `--cacertder` option in the `rpi-eeprom-config` tool.
+You can add your own custom CA certificate to the EEPROM to securely download images from your own website. Use the `--cacertder` option of the `rpi-eeprom-config` tool to add the DER-encoded certificate.
 
-To ensure that the certificate is not modified, a hash of the certificate must be placed in the eeprom config settings and a key used to guard against tampering.
+To ensure that the certificate is not modified, place a hash of the certificate in the EEPROM config settings.
+
+Run the following command to generate a DER-encoded certificate:
+
+[source,console]
+----
+$ openssl x509 -in your_ca_root_cert.pem -out cert.der -outform DER
+----
+
+Then, run the following command to generate a SHA-256 hash of the certificate:
+
+[source,console]
+----
+$ sha256sum cert.der
+----
+
+You should see output similar to the following:
 
 ----
-# Generate a DER encoded certificate
-openssl x509 -in your_ca_root_cert.pem -out cert.der -outform DER
-
-# generate the hash of the certificate
-sha256sum cert.der
 701bd97f67b0f5483a9734e6e5cf72f9a123407b346088638f597878563193fc  cert.der
 ----
 
-Update boot.conf to include the hash of the certificate
+Next, update `boot.conf` to include the hash of the certificate:
+
+[source,console]
+----
+$ sudo rpi-eeprom-config --edit
+----
+
+Configure the following settings in the `[gpio8=0]` section, replacing:
+
+* `<your_website>` with your website, e.g. `raspberrypi.com`
+* `<path_to_image>` with the path to your OS image hosted on your website, e.g. `path/to/image`
+* `<hash>` with the hash value you generated above, e.g. `701bd97f67b0f5483a9734e6e5cf72f9a123407b346088638f597878563193fc`
 
 ----
 [all]
@@ -68,20 +90,22 @@ BOOT_ORDER=0xf461
 [gpio8=0]
 BOOT_ORDER=0xf7
 NET_INSTALL_ENABLED=0
-HTTP_HOST=yourserver.org
-HTTP_PATH=path/to/files
-HTTP_CACERT_HASH=701bd97f67b0f5483a9734e6e5cf72f9a123407b346088638f597878563193fc
+HTTP_HOST=<your_website>
+HTTP_PATH=<path_to_image>
+HTTP_CACERT_HASH=<hash>
 ----
 
-NOTE: If `HTTP_CACERT_HASH` is specified it assumes that you want to use HTTPS and changes to use port 443 for the download.
+NOTE: If you specify a `HTTP_CACERT_HASH`, Network Install downloads the image using HTTPS over port 443.
 
+Finally, use to load everything into EEPROM:
+
+[source,console]
 ----
-# Add everything to the eeprom
-../tools/rpi-eeprom-config -c boot.conf -p public_key.pem -o pieeprom.bin --cacertder cert.der pieeprom.original.bin
-../tools/rpi-eeprom-digest -k private_key.pem -i pieeprom.bin -o pieeprom.sig
+$ rpi-eeprom-config -c boot.conf -p public_key.pem -o pieeprom.bin --cacertder cert.der pieeprom.original.bin
+$ rpi-eeprom-digest -k private_key.pem -i pieeprom.bin -o pieeprom.sig
 ----
 
-On boot it should use HTTPS instead of HTTP.
+During network boot, your Raspberry Pi should use HTTPS instead of HTTP. You can check the boot output for the HTTPS URL:
 
 ----
 Loading boot.img ...


### PR DESCRIPTION
You can now add your own CA cert to the eeprom to support HTTPS download.

Fixes #3642