### PR TITLE
Add syntax highlighting for labelled code snippets

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -41,9 +41,6 @@ sass:
 asciidoctor:
     template_dir: build/jekyll/_templates
 
-# syntax highlighting
-highlighter: rouge
-
 # Exclude from processing.
 # The following items will not be processed, by default. Create a custom list
 # to override the default setting.

--- a/_config.yml
+++ b/_config.yml
@@ -41,6 +41,9 @@ sass:
 asciidoctor:
     template_dir: build/jekyll/_templates
 
+# syntax highlighting
+highlighter: rouge
+
 # Exclude from processing.
 # The following items will not be processed, by default. Create a custom list
 # to override the default setting.

--- a/jekyll-assets/_includes/head.html
+++ b/jekyll-assets/_includes/head.html
@@ -18,6 +18,7 @@
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@docsearch/css@3"/>
 <link rel="stylesheet" href="{{ site.baseurl }}/css/style.css?ver={{ site.time | date: '%s' }}">
 <link rel="stylesheet" href="{{ site.baseurl }}/css/tabs.css?ver={{ site.time | date: '%s' }}">
+<link rel="stylesheet" href="{{ site.baseurl }}/css/syntax-highlighting.css?ver={{ site.time | date: '%s' }}">
 <script async src="https://www.googletagmanager.com/gtag/js?id=UA-180927933-8"></script>
 <script>
   window.dataLayer = window.dataLayer || [];

--- a/jekyll-assets/css/syntax-highlighting.css
+++ b/jekyll-assets/css/syntax-highlighting.css
@@ -1,0 +1,70 @@
+.highlight pre { background-color: #404040 }
+.highlight .hll { background-color: #404040 }
+.highlight .c { color: #999999; font-style: italic } /* Comment */
+.highlight .err { color: #a61717; background-color: #e3d2d2 } /* Error */
+.highlight .g { color: #d0d0d0 } /* Generic */
+.highlight .k { color: #6ab825; font-weight: bold } /* Keyword */
+.highlight .l { color: #d0d0d0 } /* Literal */
+.highlight .n { color: #d0d0d0 } /* Name */
+.highlight .o { color: #d0d0d0 } /* Operator */
+.highlight .x { color: #d0d0d0 } /* Other */
+.highlight .p { color: #d0d0d0 } /* Punctuation */
+.highlight .cm { color: #999999; font-style: italic } /* Comment.Multiline */
+.highlight .cp { color: #cd2828; font-weight: bold } /* Comment.Preproc */
+.highlight .c1 { color: #999999; font-style: italic } /* Comment.Single */
+.highlight .cs { color: #e50808; font-weight: bold; background-color: #520000 } /* Comment.Special */
+.highlight .gd { color: #d22323 } /* Generic.Deleted */
+.highlight .ge { color: #d0d0d0; font-style: italic } /* Generic.Emph */
+.highlight .gr { color: #d22323 } /* Generic.Error */
+.highlight .gh { color: #ffffff; font-weight: bold } /* Generic.Heading */
+.highlight .gi { color: #589819 } /* Generic.Inserted */
+.highlight .go { color: #cccccc } /* Generic.Output */
+.highlight .gp { color: #aaaaaa } /* Generic.Prompt */
+.highlight .gs { color: #d0d0d0; font-weight: bold } /* Generic.Strong */
+.highlight .gu { color: #ffffff; text-decoration: underline } /* Generic.Subheading */
+.highlight .gt { color: #d22323 } /* Generic.Traceback */
+.highlight .kc { color: #6ab825; font-weight: bold } /* Keyword.Constant */
+.highlight .kd { color: #6ab825; font-weight: bold } /* Keyword.Declaration */
+.highlight .kn { color: #6ab825; font-weight: bold } /* Keyword.Namespace */
+.highlight .kp { color: #6ab825 } /* Keyword.Pseudo */
+.highlight .kr { color: #6ab825; font-weight: bold } /* Keyword.Reserved */
+.highlight .kt { color: #6ab825; font-weight: bold } /* Keyword.Type */
+.highlight .ld { color: #d0d0d0 } /* Literal.Date */
+.highlight .m { color: #3677a9 } /* Literal.Number */
+.highlight .s { color: #ed9d13 } /* Literal.String */
+.highlight .na { color: #bbbbbb } /* Name.Attribute */
+.highlight .nb { color: #24909d } /* Name.Builtin */
+.highlight .nc { color: #447fcf; text-decoration: underline } /* Name.Class */
+.highlight .no { color: #40ffff } /* Name.Constant */
+.highlight .nd { color: #ffa500 } /* Name.Decorator */
+.highlight .ni { color: #d0d0d0 } /* Name.Entity */
+.highlight .ne { color: #bbbbbb } /* Name.Exception */
+.highlight .nf { color: #447fcf } /* Name.Function */
+.highlight .nl { color: #d0d0d0 } /* Name.Label */
+.highlight .nn { color: #447fcf; text-decoration: underline } /* Name.Namespace */
+.highlight .nx { color: #d0d0d0 } /* Name.Other */
+.highlight .py { color: #d0d0d0 } /* Name.Property */
+.highlight .nt { color: #6ab825; font-weight: bold } /* Name.Tag */
+.highlight .nv { color: #40ffff } /* Name.Variable */
+.highlight .ow { color: #6ab825; font-weight: bold } /* Operator.Word */
+.highlight .w { color: #666666 } /* Text.Whitespace */
+.highlight .mf { color: #3677a9 } /* Literal.Number.Float */
+.highlight .mh { color: #3677a9 } /* Literal.Number.Hex */
+.highlight .mi { color: #3677a9 } /* Literal.Number.Integer */
+.highlight .mo { color: #3677a9 } /* Literal.Number.Oct */
+.highlight .sb { color: #ed9d13 } /* Literal.String.Backtick */
+.highlight .sc { color: #ed9d13 } /* Literal.String.Char */
+.highlight .sd { color: #ed9d13 } /* Literal.String.Doc */
+.highlight .s2 { color: #ed9d13 } /* Literal.String.Double */
+.highlight .se { color: #ed9d13 } /* Literal.String.Escape */
+.highlight .sh { color: #ed9d13 } /* Literal.String.Heredoc */
+.highlight .si { color: #ed9d13 } /* Literal.String.Interpol */
+.highlight .sx { color: #ffa500 } /* Literal.String.Other */
+.highlight .sr { color: #ed9d13 } /* Literal.String.Regex */
+.highlight .s1 { color: #ed9d13 } /* Literal.String.Single */
+.highlight .ss { color: #ed9d13 } /* Literal.String.Symbol */
+.highlight .bp { color: #24909d } /* Name.Builtin.Pseudo */
+.highlight .vc { color: #40ffff } /* Name.Variable.Class */
+.highlight .vg { color: #40ffff } /* Name.Variable.Global */
+.highlight .vi { color: #40ffff } /* Name.Variable.Instance */
+.highlight .il { color: #3677a9 } /* Literal.Number.Integer.Long */

--- a/jekyll-assets/css/syntax-highlighting.css
+++ b/jekyll-assets/css/syntax-highlighting.css
@@ -70,7 +70,7 @@
 .highlight .il { color: #3677a9 } /* Literal.Number.Integer.Long */
 
 .highlight .gp, .highlight .gp + .w {
-	/* Disable text selection highlighting for console snippets
+	/* Disable text selection highlighting for the '$ ' prefix at the beginning of console snippets (if it exists -- otherwise has no effect)
    * Credit: https://stackoverflow.com/a/4407335/1558022 with modifications by Nate Contino */
   -webkit-touch-callout: none; /* iOS Safari */
     -webkit-user-select: none; /* Safari */

--- a/jekyll-assets/css/syntax-highlighting.css
+++ b/jekyll-assets/css/syntax-highlighting.css
@@ -68,3 +68,15 @@
 .highlight .vg { color: #40ffff } /* Name.Variable.Global */
 .highlight .vi { color: #40ffff } /* Name.Variable.Instance */
 .highlight .il { color: #3677a9 } /* Literal.Number.Integer.Long */
+
+.highlight .gp, .highlight .gp + .w {
+	/* Disable text selection highlighting for console snippets
+   * Credit: https://stackoverflow.com/a/4407335/1558022 with modifications by Nate Contino */
+  -webkit-touch-callout: none; /* iOS Safari */
+    -webkit-user-select: none; /* Safari */
+     -khtml-user-select: none; /* Konqueror HTML */
+       -moz-user-select: none; /* Firefox */
+        -ms-user-select: none; /* Internet Explorer/Edge */
+            user-select: none; /* Non-prefixed version, currently
+                                  supported by Chrome and Opera */
+}

--- a/jekyll-assets/scripts/copy-to-clipboard.js
+++ b/jekyll-assets/scripts/copy-to-clipboard.js
@@ -51,10 +51,18 @@ window.addEventListener('load', function() {
         // if the code snippet represents a console snippet
         if (trigger.parentNode.querySelector('pre').querySelector('code') != null && trigger.parentNode.querySelector('pre').querySelector('code').getAttribute('data-lang') == 'console') {
           var text = trigger.parentNode.querySelector('pre').textContent
+          // for each line of the code snippet
+          var text_split_into_lines = text.split('\n');
+
           // trim the '$ ' from the clipboard copy so users don't have to trim it themselves
-          if (text.startsWith('$ ')) {
-            text = text.substring(2) // string guaranteed to be at least 2 tokens long if it already has '$ ' at beginning
-          }
+          text_split_into_lines = text_split_into_lines.map(function(x) {
+            if (x.startsWith('$ ')) {
+              return x.substring(2);
+            }
+          })
+
+          // re-assemble the snippet into multiple lines
+          text = text_split_into_lines.join('\n');
         } else {
           var text = trigger.parentNode.querySelector('pre').textContent;
 

--- a/jekyll-assets/scripts/copy-to-clipboard.js
+++ b/jekyll-assets/scripts/copy-to-clipboard.js
@@ -48,7 +48,17 @@ window.addEventListener('load', function() {
       if (trigger.parentNode.querySelector('div.line')) {
         var text = extractDoxygenCode(trigger.parentNode);
       } else {
-        var text = trigger.parentNode.querySelector('pre').textContent;
+        // if the code snippet represents a console snippet
+        if (trigger.parentNode.querySelector('pre').querySelector('code') != null && trigger.parentNode.querySelector('pre').querySelector('code').getAttribute('data-lang') == 'console') {
+          var text = trigger.parentNode.querySelector('pre').textContent
+          // trim the '$ ' from the clipboard copy so users don't have to trim it themselves
+          if (text.startsWith('$ ')) {
+            text = text.substring(2) // string guaranteed to be at least 2 tokens long if it already has '$ ' at beginning
+          }
+        } else {
+          var text = trigger.parentNode.querySelector('pre').textContent;
+
+        }
       }
       return text;
     },

--- a/jekyll-assets/scripts/copy-to-clipboard.js
+++ b/jekyll-assets/scripts/copy-to-clipboard.js
@@ -48,9 +48,10 @@ window.addEventListener('load', function() {
       if (trigger.parentNode.querySelector('div.line')) {
         var text = extractDoxygenCode(trigger.parentNode);
       } else {
+        var text = trigger.parentNode.querySelector('pre').textContent
+        
         // if the code snippet represents a console snippet
         if (trigger.parentNode.querySelector('pre').querySelector('code') != null && trigger.parentNode.querySelector('pre').querySelector('code').getAttribute('data-lang') == 'console') {
-          var text = trigger.parentNode.querySelector('pre').textContent
           // for each line of the code snippet
           var text_split_into_lines = text.split('\n');
 
@@ -64,9 +65,6 @@ window.addEventListener('load', function() {
 
           // re-assemble the snippet into multiple lines
           text = text_split_into_lines.join('\n');
-        } else {
-          var text = trigger.parentNode.querySelector('pre').textContent;
-
         }
       }
       return text;

--- a/jekyll-assets/scripts/copy-to-clipboard.js
+++ b/jekyll-assets/scripts/copy-to-clipboard.js
@@ -59,6 +59,7 @@ window.addEventListener('load', function() {
             if (x.startsWith('$ ')) {
               return x.substring(2);
             }
+            else return x;
           })
 
           // re-assemble the snippet into multiple lines

--- a/scripts/create_build_adoc.py
+++ b/scripts/create_build_adoc.py
@@ -82,6 +82,7 @@ if __name__ == "__main__":
 :page-sub_title: {}
 :sectanchors:
 :figure-caption!:
+:source-highlighter: rouge
 
 {}
 """.format(output_subdir, includes_dir, '{} - {}'.format(index_title, site_config['title']), index_title, new_contents))


### PR DESCRIPTION
Not sure why we didn't have this before. Opening this because it makes longer snippets infinitely more readable.

Couple of examples:

Smol:

<img width="1333" alt="Screenshot 2024-05-17 at 09 53 16" src="https://github.com/raspberrypi/documentation/assets/10657588/8ee5d3a9-6ad3-4fdb-b05a-722e0027ce98">


Large:

<img width="1347" alt="Screenshot 2024-05-17 at 09 55 29" src="https://github.com/raspberrypi/documentation/assets/10657588/4ed4fcb3-7052-41ea-bd81-99a5b10f263b">

Minor cost (70 lines of CSS). Not particularly breakable (worst case, snippets just end up not-highlighted). Uses rouge, which we already use to highlight syntax in our PDF documentation.

Not all of our snippets are correctly marked, but this makes it easier to spot unmarked snippets and fix them.

Also fixes https://github.com/raspberrypi/documentation/issues/3556 by rendering the '$ ' at the beginning of `console`-marked snippets as uncopyable and trimming it from the text returned by the 'copy' button (in a safe non-explodey manner).