### PR TITLE
Make tabbing consistent in json example, fix syntax, remove default pi username assumption

### DIFF
--- a/documentation/asciidoc/computers/camera/rpicam_apps_post_processing.adoc
+++ b/documentation/asciidoc/computers/camera/rpicam_apps_post_processing.adoc
@@ -4,7 +4,7 @@
 
 For example, the **negate** stage turns light pixels dark and dark pixels light. Because the negate stage is basic, requiring no configuration, `negate.json` just names the stage:
 
-[json]
+[source,json]
 ----
 {
     "negate": {}
@@ -20,7 +20,7 @@ $ rpicam-hello --post-process-file negate.json
 
 To run multiple post-processing stages, create a JSON file that contains multiple stages as top-level keys. For example, to the following configuration runs the Sobel stage, then the negate stage:
 
-[json]
+[source,json]
 ----
 {
     "sobel_cv":
@@ -52,7 +52,7 @@ The `negate` stage has no user-configurable parameters.
 
 Default `negate.json` file:
 
-[json]
+[source,json]
 ----
 {
     "negate" : {}
@@ -113,7 +113,7 @@ Processing a single image takes between two and three seconds for a 12MP image o
 
 Default `drc.json` file for DRC:
 
-[json]
+[source,json]
 ----
 {
     "hdr" : {
@@ -152,7 +152,7 @@ image::images/drc.jpg[Image with DRC processing]
 
 Default `hdr.json` file for HDR:
 
-[json]
+[source,json]
 ----
 {
     "hdr" : {
@@ -214,7 +214,7 @@ You can configure this stage with the following parameters, passing dimensions a
 
 Default `motion_detect.json` configuration file:
 
-[json]
+[source,json]
 ----
 {
     "motion_detect" : {

--- a/documentation/asciidoc/computers/camera/rpicam_apps_post_processing_opencv.adoc
+++ b/documentation/asciidoc/computers/camera/rpicam_apps_post_processing_opencv.adoc
@@ -16,7 +16,7 @@ You can configure this stage with the following parameters:
 
 Default `sobel_cv.json` file:
 
-[source,javascript]
+[source,json]
 ----
 {
     "sobel_cv" : {

--- a/documentation/asciidoc/computers/camera/rpicam_apps_post_processing_opencv.adoc
+++ b/documentation/asciidoc/computers/camera/rpicam_apps_post_processing_opencv.adoc
@@ -16,7 +16,7 @@ You can configure this stage with the following parameters:
 
 Default `sobel_cv.json` file:
 
-[json]
+[source,javascript]
 ----
 {
     "sobel_cv" : {
@@ -51,7 +51,7 @@ The `face_detect_cv` stage runs only during preview and video capture. It ignore
 
 Default `face_detect_cv.json` file:
 
-[cols="1,3"]
+[source,json]
 ----
 {
     "face_detect_cv" : {
@@ -99,16 +99,16 @@ You can configure this stage with the following parameters:
 
 Default `annotate_cv.json` file:
 
-[json]
+[source,json]
 ----
 {
     "annotate_cv" : {
-    	"text" : "Frame %frame exp %exp ag %ag dg %dg",
-    	"fg" : 255,
-    	"bg" : 0,
-    	"scale" : 1.0,
-    	"thickness" : 2,
-    	"alpha" : 0.3
+        "text" : "Frame %frame exp %exp ag %ag dg %dg",
+        "fg" : 255,
+        "bg" : 0,
+        "scale" : 1.0,
+        "thickness" : 2,
+        "alpha" : 0.3
     }
 }
 ----

--- a/documentation/asciidoc/computers/camera/rpicam_apps_post_processing_tflite.adoc
+++ b/documentation/asciidoc/computers/camera/rpicam_apps_post_processing_tflite.adoc
@@ -28,7 +28,7 @@ You can configure this stage with the following parameters:
 
 Example `object_classify_tf.json` file:
 
-[json]
+[source,json]
 ----
 {
     "object_classify_tf" : {
@@ -36,17 +36,17 @@ Example `object_classify_tf.json` file:
         "refresh_rate" : 30,
         "threshold_high" : 0.6,
         "threshold_low" : 0.4,
-        "model_file" : "/home/pi/models/mobilenet_v1_1.0_224_quant.tflite",
-        "labels_file" : "/home/pi/models/labels.txt",
+        "model_file" : "/home/<username>/models/mobilenet_v1_1.0_224_quant.tflite",
+        "labels_file" : "/home/<username>/models/labels.txt",
         "display_labels" : 1
     },
     "annotate_cv" : {
-    	"text" : "",
-    	"fg" : 255,
-    	"bg" : 0,
-    	"scale" : 1.0,
-    	"thickness" : 2,
-    	"alpha" : 0.3
+        "text" : "",
+        "fg" : 255,
+        "bg" : 0,
+        "scale" : 1.0,
+        "thickness" : 2,
+        "alpha" : 0.3
     }
 }
 ----
@@ -88,7 +88,7 @@ You can configure the `plot_pose_cv` stage with the following parameters:
 
 Example `pose_estimation_tf.json` file:
 
-[json]
+[source,json]
 ----
 {
     "pose_estimation_tf" : {
@@ -96,7 +96,7 @@ Example `pose_estimation_tf.json` file:
         "model_file" : "posenet_mobilenet_v1_100_257x257_multi_kpt_stripped.tflite"
     },
     "plot_pose_cv" : {
-	   "confidence_threshold" : -0.5
+       "confidence_threshold" : -0.5
     }
 }
 ----
@@ -143,20 +143,20 @@ You can configure the `object_detect_draw_cv` stage with the following parameter
 
 Example `object_detect_tf.json` file:
 
-[json]
+[source,json]
 ----
 {
     "object_detect_tf" : {
-    	"number_of_threads" : 2,
-    	"refresh_rate" : 10,
-    	"confidence_threshold" : 0.5,
-    	"overlap_threshold" : 0.5,
-    	"model_file" : "/home/pi/models/coco_ssd_mobilenet_v1_1.0_quant_2018_06_29/detect.tflite",
-    	"labels_file" : "/home/pi/models/coco_ssd_mobilenet_v1_1.0_quant_2018_06_29/labelmap.txt",
-    	"verbose" : 1
+        "number_of_threads" : 2,
+        "refresh_rate" : 10,
+        "confidence_threshold" : 0.5,
+        "overlap_threshold" : 0.5,
+        "model_file" : "/home/<username>/models/coco_ssd_mobilenet_v1_1.0_quant_2018_06_29/detect.tflite",
+        "labels_file" : "/home/<username>/models/coco_ssd_mobilenet_v1_1.0_quant_2018_06_29/labelmap.txt",
+        "verbose" : 1
     },
     "object_detect_draw_cv" : {
-	   "line_thickness" : 2
+       "line_thickness" : 2
     }
 }
 ----
@@ -193,16 +193,16 @@ You can configure this stage with the following parameters:
 
 Example `segmentation_tf.json` file:
 
-[json]
+[source,json]
 ----
 {
     "segmentation_tf" : {
-    	"number_of_threads" : 2,
-    	"refresh_rate" : 10,
-    	"model_file" : "/home/pi/models/lite-model_deeplabv3_1_metadata_2.tflite",
-    	"labels_file" : "/home/pi/models/segmentation_labels.txt",
-    	"draw" : 1,
-    	"verbose" : 1
+        "number_of_threads" : 2,
+        "refresh_rate" : 10,
+        "model_file" : "/home/<username>/models/lite-model_deeplabv3_1_metadata_2.tflite",
+        "labels_file" : "/home/<username>/models/segmentation_labels.txt",
+        "draw" : 1,
+        "verbose" : 1
     }
 }
 ----

--- a/documentation/asciidoc/computers/camera/rpicam_options_common.adoc
+++ b/documentation/asciidoc/computers/camera/rpicam_options_common.adoc
@@ -29,11 +29,7 @@ libcamera build: v0.0.0+3058-c29143f7
 
 Lists the detected cameras attached to your Raspberry Pi and their available sensor modes. Does not accept a value.
 
-Sensor mode identifiers have the following form:
-
-----
-S<Bayer order><Bit-depth>_<Optional packing> : <Resolution list>
-----
+Sensor mode identifiers have the following form: `S<Bayer order><Bit-depth>_<Optional packing> : <Resolution list>`
 
 Crop is specified in native sensor pixels (even in pixel binning mode) as `(<x>, <y>)/<Width>×<Height>`. `(x, y)` specifies the location of the crop window of size `width × height` in the sensor array.
 


### PR DESCRIPTION
Tabs -> spaces, because our site displays tabs as like 8 spaces
Downgraded one snippet to monospace inline text because it's not really a snippet