### PR TITLE
Clean up wording, bulleted lists, and code snippets in raspi-config and noninteractive section

### DIFF
--- a/documentation/asciidoc/computers/configuration/raspi-config.adoc
+++ b/documentation/asciidoc/computers/configuration/raspi-config.adoc
@@ -1,6 +1,8 @@
 [[raspi-config]]
 == `raspi-config`
 
+TIP: Raspberry Pi Desktop users can also access a graphical version of this application at **Preferences** > **Raspberry Pi Configuration**.
+
 `raspi-config` helps you configure your Raspberry Pi. To open the configuration tool, run the following command:
 
 [source,console]
@@ -8,26 +10,22 @@
 $ sudo raspi-config
 ----
 
-NOTE: If you are using the Raspberry Pi desktop, you can use the graphical `Raspberry Pi Configuration` application from the `Preferences` menu to configure your Raspberry Pi.
-
-You should then see a blue screen with options in a grey box:
+You should see a blue screen with options in a grey box:
 
 image::images/raspi-config.png[raspi-config main screen]
 
-NOTE: The menu shown may differ slightly.
+=== Usage
 
-Use the `up` and `down` arrow keys to move the highlighted selection between the options available. Pressing the `right` arrow key will jump out of the Options menu and take you to the `<Select>` and `<Finish>` buttons. Pressing `left` will take you back to the options. Alternatively, you can use the `Tab` key to switch between these.
+Use the **Up** and **Down** arrow keys to move the highlighted selection between the options available.
 
-Generally speaking, `raspi-config` aims to enable the user to make the most common configuration changes. This may result in automated edits to xref:config_txt.adoc#what-is-config-txt[`/boot/firmware/config.txt`] and various standard Linux configuration files. Some options require a reboot to take effect. If you changed any of these, `raspi-config` will ask if you wish to reboot when you select the `<Finish>` button.
+Press the **Right** arrow key or press **Tab** to access the `<Select>` and `<Finish>` buttons. Press **Left** or press **Tab** to return to the options.
 
-NOTE: In long lists of option values (like the list of timezone cities), you can also type a letter to skip to that section of the list. For example, entering `L` will skip you to Lisbon, just two options away from London, to save you scrolling all the way through the alphabet.
+`raspi-config` automates edits to xref:config_txt.adoc#what-is-config-txt[`/boot/firmware/config.txt`] and various Linux configuration files. Some options require a reboot to take effect. If you changed any of these, `raspi-config` asks you to reboot when you exit.
+
+TIP: In long lists of option values (like the list of timezone cities), type a letter to skip to that section of the list. For example, enter `L` to skip to Lisbon.
 
 [[menu-options]]
 === List of options
-
-NOTE: Due to the continuous development of the `raspi-config` tool, the list of options below may not be completely up-to-date. Also please be aware that different models of Raspberry Pi may have different options available.
-
-NOTE: All options are available via a non-interactive command line interface. See the section on the <<raspi-config-cli,`raspi-config` command line interface>> for more information.
 
 ==== System options
 
@@ -405,6 +403,8 @@ $ sudo raspi-config nonint do_browser <chromium-browser/firefox>
 
 [[underscan-nonint]]
 ===== Underscan
+
+NOTE: Not available when running Wayland.
 
 If the initial text shown on the screen disappears off the edge, enable overscan to adjust the border. On some displays, particularly monitors, disabling overscan will make the picture fill the whole screen and remove the black border.
 

--- a/documentation/asciidoc/computers/configuration/raspi-config.adoc
+++ b/documentation/asciidoc/computers/configuration/raspi-config.adoc
@@ -1,13 +1,12 @@
 [[raspi-config]]
-== The `raspi-config` Tool
+== `raspi-config`
 
-`raspi-config` is the Raspberry Pi configuration tool, originally written by https://github.com/asb[Alex Bradbury]. To open the configuration tool, type the following on the command line:
+`raspi-config` helps you configure your Raspberry Pi. To open the configuration tool, run the following command:
 
+[source,console]
 ----
-sudo raspi-config
+$ sudo raspi-config
 ----
-
-The `sudo` is required because you will be changing files that you do not own as the regular user.
 
 NOTE: If you are using the Raspberry Pi desktop, you can use the graphical `Raspberry Pi Configuration` application from the `Preferences` menu to configure your Raspberry Pi.
 
@@ -47,9 +46,7 @@ Specify the audio output destination.
 [[change-user-password]]
 ===== Password
 
-You can change the 'default' user password.
-
-NOTE: Originally, the default user on early versions of Raspberry Pi OS was `pi` with the password `raspberry`. The default user is now set while configuring the OS image or on first boot using a configuration wizard.
+Change your password.
 
 [[hostname]]
 ===== Hostname
@@ -84,7 +81,7 @@ image::images/raspi-display.png[raspi-config display options]
 [[underscan]]
 ===== Underscan
 
-NOTE: This option isn't available if you're using the Wayland backend.
+NOTE: Not available when running Wayland.
 
 If the initial text shown on the screen disappears off the edge, you need to enable overscan to bring the border back. On some displays, particularly monitors, disabling overscan will make the picture fill the whole screen and will remove the black border.
 
@@ -108,7 +105,7 @@ Enable or disable 4Kp60 resolution for HDMI outputs.
 [[interfacing-options]]
 ==== Interface options
 
-In this submenu there are the following options to enable/disable: SSH, VNC, SPI, I2C, Serial port, 1-wire, and Remote GPIO.
+Use this submenu to enable and disable various physical and virtual interfaces.
 
 image::images/raspi-interface.png[raspi-config interface options]
 
@@ -155,9 +152,9 @@ image::images/raspi-perf.png[raspi-config performance options]
 [[overclock]]
 ===== Overclock
 
-On some models it is possible to overclock your Raspberry Pi's CPU using this tool. The overclocking you can achieve will vary; overclocking too high may result in instability. Selecting this option shows the following warning:
+Some models can overclock the CPU using this tool. Overclocking potential varies between individual Raspberry Pi devices. Overclocking too high may result in instability.
 
-*Be aware that overclocking may reduce the lifetime of your Raspberry Pi.* If overclocking at a certain level causes system instability, try a more modest overclock. Hold down the Shift key during boot to temporarily disable overclocking.
+WARNING: *Overclocking may reduce the lifetime of your Raspberry Pi.* If overclocking at a certain level causes system instability, try a more modest overclock. Hold down the *Shift* key during boot to temporarily disable overclocking.
 
 [[memory-split]]
 ===== GPU memory
@@ -170,12 +167,12 @@ Enable or disable a read-only filesystem.
 
 ===== Fan
 
-Set the behaviour of a GPIO connected fan.
+Customise the behaviour of a GPIO connected fan.
 
 [[localisation-options]]
 ==== Localisation options
 
-The localisation submenu gives you these options to choose from: keyboard layout, time zone, locale, and wireless LAN country code.
+Use localisation submenu to control location and country-related options.
 
 image::images/raspi-l18n.png[raspi-config localisation options]
 
@@ -203,14 +200,12 @@ This option sets the country code for your wireless network.
 
 image::images/raspi-adv.png[raspi-config advanced options]
 
-NOTE: The options documented here will change depending on the model of Raspberry Pi that you're using, and whether you're using the Wayland or X11 backend. In the current version of Raspberry Pi OS Bookworm, the Raspberry Pi 4, Pi 400 and Pi 5 use Wayland by default; other models of Raspberry Pi use X11 by default.
-
 [[expand-filesystem]]
 ===== Expand filesystem
 
-This option will expand your installation to fill the whole SD card, giving you more space to use for files. You will need to reboot the Raspberry Pi to make this available. 
+Expands your installation to fill the entire storage device, giving you more space to use for files. You must reboot the Raspberry Pi to make this available.
 
-WARNING: There is no confirmation step: selecting the option begins the partition expansion immediately.
+WARNING: There is no confirmation step. Selecting the option begins the partition expansion immediately.
 
 ===== Network interface names
 
@@ -222,22 +217,21 @@ Configure the network's proxy settings.
 
 ===== Boot order
 
-On Raspberry Pi 4 and 5, you can specify whether to boot from USB or network if the SD card isn't inserted. For more information, see xref:raspberry-pi.adoc#raspberry-pi-bootloader-configuration[bootloader configuration].
+On Raspberry Pi 4 and later, you can specify whether to boot from USB or network if the SD card isn't inserted. For more information, see xref:raspberry-pi.adoc#raspberry-pi-bootloader-configuration[bootloader configuration].
 
 ===== Bootloader version
 
-On the Raspberry Pi 4 and 5, you can tell the system to use the very latest boot ROM software, or revert to the factory default if the latest version causes problems.
+On the Raspberry Pi 4 and later, you can switch to the latest boot ROM software. Alternatively, you can revert to the factory default if the latest version causes problems.
 
 ===== Wayland
 
-Use this option to switch between the X11 and Wayland backends. The Wayland backend was introduced in Bookworm, X11 was used in older versions of Raspberry Pi OS.
+Use this option to switch between the X11 and Wayland backends. Prior to Raspberry Pi OS Bookworm, Raspberry Pi OS used X11.
 
 NOTE: To use Wayland on Raspberry Pi models prior to Raspberry Pi 4, you must also add `wayland=on` to `/boot/firmware/cmdline.txt`.
 
 ===== Audio config
 
-Use this option to switch between the PulseAudio and PipeWire audio backends. The PipeWire backend was introduced in Bookworm. PulseAudio was used in older versions of Rasperry Pi OS.
-
+Use this option to switch between the PulseAudio and PipeWire audio backends. Prior to Raspberry Pi OS Bookworm, Raspberry Pi OS used PulseAudio.
 
 [[update]]
 ==== Update
@@ -247,35 +241,27 @@ Update this tool to the latest version.
 [[about]]
 ==== About raspi-config
 
-Selecting this option shows the following text:
-
-----
-This tool provides a straightforward way of doing initial configuration of the Raspberry Pi.
-Although it can be run at any time, some of the options may have difficulties if you have heavily customised your installation.
-----
+Selecting this option displays a description of `raspi-config`.
 
 [[finish]]
 ==== Finish
 
-Use this option when you have completed your changes. You will be asked whether you want to reboot or not. When implementing changes for the first time, it's best to reboot. There will be a delay in rebooting if you have chosen to resize your SD card.
+Use this option when you have completed your changes. You will be asked whether you want to reboot or not. When implementing changes for the first time, it's best to reboot. If you chose to resize your SD card, rebooting may take longer than usual.
 
 [[raspi-config-cli]]
-== The `raspi-config` Command Line Interface
+== The `raspi-config` CLI
 
-The `raspi-config` tool can also be run in a non-interactive mode, which is useful for setting up a Raspberry Pi image for distribution.
+The `raspi-config` tool supports non-interactive command line options and flags instead of the interactive menu. These options can be useful when configuring a Raspberry Pi image for distribution.
 
+[source,console]
 ----
-sudo raspi-config nonint <command> <arguments>
+$ sudo raspi-config nonint <command> <arguments> [optional-argument]
 ----
 
-The `sudo` is required because you will be changing files that are not owned by the default user.
-
-NOTE: There is no consistent meaning for `0` and `1` in arguments. Each function will document what `0` and `1` mean for that particular function.
+NOTE: The meaning of `0` and `1` varies between options. Always check the documentation before passing a value to an option.
 
 [[raspi-config-cli-commands]]
 === List of options
-
-NOTE: The `raspi-config` tool is under continuous development, and the list of options below may not be completely up to date. Please be aware that different models of Raspberry Pi may have different options available.
 
 ==== System options
 
@@ -283,58 +269,76 @@ NOTE: The `raspi-config` tool is under continuous development, and the list of o
 
 Allows setting of the wireless LAN SSID and passphrase.
 
+[source,console]
 ----
-sudo raspi-config nonint do_wifi_ssid_passphrase <ssid> <passphrase> [hidden] [plain]
+$ sudo raspi-config nonint do_wifi_ssid_passphrase <ssid> <passphrase> [hidden] [plain]
 ----
 
-Hidden: `0` = visible, `1` = hidden. Defaults to visible.
+Pass a wireless network name (SSID) and passphrase, if required. The following flags are optional:
 
-Plain: If plain is `1` (the default), the passphrase is quoted.
+The `<hidden>` option indicates the visibility of the SSID. If the network broadcasts an open SSID, pass `0` or omit the option. If your SSID is hidden, pass `1`. Defaults to `0`.
+
+The `<plain>` option indicates whether or not you intend to pass the passphrase as plaintext. If your passphrase includes a space or a special character like `!`, you must pass `0` and use quotes around your passphrase. Otherwise, you can pass `1` or omit the option. Defaults to `1`.  To pass this option, you must specify a value for `<hidden>`.
 
 Example:
 
+Connect to a non-hidden network named `myssid` with the passphrase `mypassphrase`:
+
+[source,console]
 ----
-sudo raspi-config nonint do_wifi_ssid_passphrase myssid mypassphrase
-sudo raspi-config nonint do_wifi_ssid_passphrase myssid mypassphrase 1 # Hidden SSID
-sudo raspi-config nonint do_wifi_ssid_passphrase myssid '"mypassphrase"' 0 0 # Visible SSID, passphrase quoted
+$ sudo raspi-config nonint do_wifi_ssid_passphrase myssid mypassphrase
+----
+
+Connect to a hidden network named `myssid` with the passphrase `mypassphrase`:
+[source,console]
+----
+$ sudo raspi-config nonint do_wifi_ssid_passphrase myssid mypassphrase 1
+----
+
+Connect to a non-hidden network named `myssid` with the passphrase `my passphrase`:
+
+[source,console]
+----
+$ sudo raspi-config nonint do_wifi_ssid_passphrase myssid "my passphrase" 0 0
 ----
 
 ===== Audio
 
 Specify the audio output destination.
 
+[source,console]
 ----
-sudo raspi-config nonint do_audio <N>
+$ sudo raspi-config nonint do_audio <N>
 ----
 
-====== Raspberry Pi 4B
+On Raspberry Pi 4B, you can use the following options:
 
-- `0` - bcm2835 Headphones
-- `1` - vc4-hdmi-0
-- `2` - vc4-hdmi-1
+* `0`: bcm2835 headphone jack
+* `1`: vc4-hdmi-0
+* `2`: vc4-hdmi-1
 
-NOTE: You may need to run the interactive version of `raspi-config` to determine the appropriate numbers to use with this option.
+For a full list of possible `<N>` values, see the abbreviations used in the interactive `raspi-config` version of this option.
 
 [[change-user-password-nonint]]
 ===== Password
 
-You can change the 'default' user password.
+Change your password.
 
-NOTE: Under old versions of Raspberry Pi OS, the default user was `pi` with the password `raspberry`. The default user is now set while configuring the OS image, or on first boot using a configuration wizard.
-
+[source,console]
 ----
-sudo raspi-config nonint do_change_pass
+$ sudo raspi-config nonint do_change_pass
 ----
 
-NOTE: This does not check for the interactive flag, and will show full-screen messages.
+NOTE: This function uses a full-screen interactive interface, even when run from a CLI option.
 
 [[hostname-nonint]]
 ===== Hostname
 
 Set the visible name for this Raspberry Pi on a network.
 
+[source,console]
 ----
-sudo raspi-config nonint do_hostname <hostname>
+$ sudo raspi-config nonint do_hostname <hostname>
 ----
 
 [[boot-options-nonint]]
@@ -342,54 +346,59 @@ sudo raspi-config nonint do_hostname <hostname>
 
 Select whether to boot to console or desktop and whether you need to log in or not.
 
+[source,console]
 ----
-sudo raspi-config nonint do_boot_behaviour <B1/B2/B3/B4>
+$ sudo raspi-config nonint do_boot_behaviour <B1/B2/B3/B4>
 ----
 
-- `B1` - Boot to console, requiring login
-- `B2` - Boot to console, logging in automatically
-- `B3` - Boot to desktop, requiring login
-- `B4` - Boot to desktop, logging in automatically
+* `B1`: boot to console, requiring login
+* `B2`: boot to console, logging in automatically
+* `B3`: boot to desktop, requiring login
+* `B4`: boot to desktop, logging in automatically
 
 ===== Network at boot
 
 Use this option to wait for a network connection before letting boot proceed.
 
+[source,console]
 ----
-sudo raspi-config nonint do_boot_wait <0/1>
+$ sudo raspi-config nonint do_boot_wait <0/1>
 ----
 
-- `0` - Boot without waiting for network connection
-- `1` - Boot after waiting for network connection
+* `0`: boot without waiting for network connection
+* `1`: boot after waiting for network connection
 
 ===== Splash screen
 
 Enable or disable the splash screen displayed at boot time.
 
+[source,console]
 ----
-sudo raspi-config nonint do_boot_splash <0/1>
+$ sudo raspi-config nonint do_boot_splash <0/1>
 ----
 
-- `0` - Enable splash screen
-- `1` - Disable splash screen
+* `0`: enable splash screen
+* `1`: disable splash screen
 
 ===== Power LED
 
 If the model of Raspberry Pi permits it, you can change the behaviour of the power LED using this option.
 
+[source,console]
 ----
-sudo raspi-config nonint do_leds <0/1>
+$ sudo raspi-config nonint do_leds <0/1>
 ----
 
-- `0` - Flash for disk activity
-- `1` - Be on constantly
+* `0`: flash for disk activity
+* `1`: keep the power LED lit at all times
 
 ===== Browser
 
 Change the default web browser. Choosing a web browser that isn't currently installed won't work.
 
+[source,console]
 ----
-sudo raspi-config nonint do_browser <chromium-browser/firefox>
+$ sudo raspi-config nonint do_browser <chromium-browser/firefox>
 ----
 
 ==== Display options
@@ -397,58 +406,69 @@ sudo raspi-config nonint do_browser <chromium-browser/firefox>
 [[underscan-nonint]]
 ===== Underscan
 
-If the initial text shown on the screen disappears off the edge, you need to enable overscan to bring the border back. On some displays, particularly monitors, disabling overscan will make the picture fill the whole screen and remove the black border.
+If the initial text shown on the screen disappears off the edge, enable overscan to adjust the border. On some displays, particularly monitors, disabling overscan will make the picture fill the whole screen and remove the black border.
 
+[source,console]
 ----
-sudo raspi-config nonint do_overscan_kms <device> <enabled>
+$ sudo raspi-config nonint do_overscan_kms <device> <enabled>
 ----
 
-Device: `1` = HDMI-1, `2` = HDMI-2
+Device:
 
-Enabled: `0` = Enable overscan, `1` = Disable overscan
+* `1`: HDMI-1
+* `2`: HDMI-2
+
+Enabled:
+
+* `0`: enable overscan
+* `1`: disable overscan
 
 ===== Screen blanking
 
 Enable or disable screen blanking.
 
+[source,console]
 ----
-sudo raspi-config nonint do_blanking <0/1>
+$ sudo raspi-config nonint do_blanking <0/1>
 ----
 
-- `0` - Enable screen blanking
-- `1` - Disable screen blanking
+* `0`: enable screen blanking
+* `1`: disable screen blanking
 
 [[resolution-nonint]]
 ===== VNC resolution
 
-Define the video resolution to use in xref:configuration.adoc#setting-up-a-headless-raspberry-pi[headless] setups.
+Define the video resolution to use for VNC in xref:configuration.adoc#setting-up-a-headless-raspberry-pi[headless] setups.
 
+[source,console]
 ----
-sudo raspi-config nonint do_vnc_resolution <width>x<height>
+$ sudo raspi-config nonint do_vnc_resolution <width>x<height>
 ----
 
 ===== Composite
 
 Enable or disable composite video output.
 
-On Raspberry Pi 4, use:
+On Raspberry Pi 4:
 
+[source,console]
 ----
-sudo raspi-config nonint do_pi4video <V1/V2/V3>
-----
-
-- `V1` - Enable 4Kp60 HDMI output
-- `V2` - Enable composite video output
-- `V3` - Disable 4Kp60 and composite output
-
-On other models of Raspberry Pi, use:
-
-----
-sudo raspi-config nonint do_composite <0/1>
+$ sudo raspi-config nonint do_pi4video <V1/V2/V3>
 ----
 
-- `0` - Enable composite video
-- `1` - Disable composite video
+* `V1`: enable 4Kp60 HDMI output
+* `V2`: enable composite video output
+* `V3`: disable 4Kp60 and composite output
+
+On other models:
+
+[source,console]
+----
+$ sudo raspi-config nonint do_composite <0/1>
+----
+
+* `0`: enable composite video
+* `1`: disable composite video
 
 [[interfacing-options-nonint]]
 ==== Interface options
@@ -456,155 +476,167 @@ sudo raspi-config nonint do_composite <0/1>
 [[ssh-nonint]]
 ===== SSH
 
-Enable/disable remote command line access to your Raspberry Pi using SSH.
+Enable/disable remote terminal access to your Raspberry Pi using SSH.
 
-SSH allows you to remotely access the command line of the Raspberry Pi from another computer. SSH is disabled by default. Read more about using SSH on the xref:remote-access.adoc#ssh[SSH documentation page]. If connecting your Raspberry Pi directly to a public network, you should not enable SSH unless you have set up secure passwords for all users.
+SSH allows you to remotely access the command line of the Raspberry Pi from another computer. For more information about SSH, see the xref:remote-access.adoc#ssh[SSH documentation].
 
+[source,console]
 ----
-sudo raspi-config nonint do_ssh <0/1>
+$ sudo raspi-config nonint do_ssh <0/1>
 ----
 
-- `0` - Enable SSH
-- `1` - Disable SSH
+* `0`: enable SSH
+* `1`: disable SSH
 
 [[VNC-nonint]]
 ===== VNC
 
-Enable/disable a virtual network computing server.
+Enable/disable a Virtual Network Computing (VNC) server. For more information about VNC, see the xref:remote-access.adoc#vnc[VNC documentation].
 
+[source,console]
 ----
-sudo raspi-config nonint do_vnc <0/1>
+$ sudo raspi-config nonint do_vnc <0/1>
 ----
 
-- `0` - Enable VNC
-- `1` - Disable VNC
+* `0`: enable VNC
+* `1`: disable VNC
 
 [[spi-nonint]]
 ===== SPI
 
 Enable/disable SPI interfaces and automatic loading of the SPI kernel module.
 
+[source,console]
 ----
-sudo raspi-config nonint do_spi <0/1>
+$ sudo raspi-config nonint do_spi <0/1>
 ----
 
-- `0` - Enable SPI
-- `1` - Disable SPI
+* `0`: enable SPI
+* `1`: disable SPI
 
 [[i2c-nonint]]
 ===== I2C
 
 Enable/disable I2C interfaces and automatic loading of the I2C kernel module.
 
+[source,console]
 ----
-sudo raspi-config nonint do_i2c <0/1>
+$ sudo raspi-config nonint do_i2c <0/1>
 ----
 
-- `0` - Enable I2C
-- `1` - Disable I2C
+* `0`: enable I2C
+* `1`: disable I2C
 
 [[serial-nonint]]
 ===== Serial Port
 
 Enable/disable the serial connection hardware.
 
+[source,console]
 ----
-sudo raspi-config nonint do_serial_hw <0/1/2>
+$ sudo raspi-config nonint do_serial_hw <0/1/2>
 ----
 
-- `0` - Enable serial port
-- `1` - Disable serial port
+* `0`: enable serial port
+* `1`: disable serial port
 
 [[serial-console-nonint]]
 ===== Serial console
 
 Enable/disable shell and kernel messages on the serial connection.
 
+[source,console]
 ----
-raspi-config nonint do_serial_cons <0/1/2>
+$ raspi-config nonint do_serial_cons <0/1/2>
 ----
 
-- `0` - Enable console over serial port
-- `1` - Disable console over serial port
+* `0`: enable console over serial port
+* `1`: disable console over serial port
 
 [[one-wire-nonint]]
 ===== 1-wire
 
 Enable/disable the Dallas 1-wire interface. This is usually used for DS18B20 temperature sensors.
 
+[source,console]
 ----
-sudo raspi-config nonint do_onewire <0/1>
+$ sudo raspi-config nonint do_onewire <0/1>
 ----
 
-- `0` - Enable 1-wire
-- `1` - Disable 1-wire
+* `0`: enable 1-wire
+* `1`: disable 1-wire
 
 ===== Remote GPIO
 
 Enable or disable remote access to the GPIO pins.
 
+[source,console]
 ----
-sudo raspi-config nonint do_rgpio <0/1>
+$ sudo raspi-config nonint do_rgpio <0/1>
 ----
 
-- `0` - Enable remote GPIO
-- `1` - Disable remote GPIO
+* `0`: enable remote GPIO
+* `1`: disable remote GPIO
 
 ==== Performance options
 
 [[overclock-nonint]]
 ===== Overclock
 
-On some models it is possible to overclock your Raspberry Pi's CPU using this tool. The overclocking you can achieve will vary, and overclocking too high may result in instability. Selecting this option shows the following warning:
+Some models can overclock the CPU using this tool. Overclocking potential varies between individual Raspberry Pi devices. Overclocking too high may result in instability.
 
-*Be aware that overclocking may reduce the lifetime of your Raspberry Pi.* If overclocking at a certain level causes system instability, try a more modest overclock. Hold down the Shift key during boot to temporarily disable overclocking.
+WARNING: *Overclocking may reduce the lifetime of your Raspberry Pi.* If overclocking at a certain level causes system instability, try a more modest overclock. Hold down the *Shift* key during boot to temporarily disable overclocking.
 
+[source,console]
 ----
-sudo raspi-config nonint do_overclock <setting>
+$ sudo raspi-config nonint do_overclock <setting>
 ----
 
-Setting is one of:
+This command accepts the following `<setting>` values:
 
- - `None` - The default
- - `Modest` - Overclock to 50% of the maximum
- - `Medium` - Overclock to 75% of the maximum
- - `High` - Overclock to 100% of the maximum
- - `Turbo` - Overclock to 125% of the maximum
+* `None`: no overclock (default)
+* `Modest`: overclock to 50% of the maximum
+* `Medium`: overclock to 75% of the maximum
+* `High`: overclock to 100% of the maximum
+* `Turbo`: overclock to 125% of the maximum
 
 [[memory-split-nonint]]
 ===== GPU memory
 
 Change the amount of memory made available to the GPU.
 
+[source,console]
 ----
-sudo raspi-config nonint do_memory_split <megabytes>
+$ sudo raspi-config nonint do_memory_split <megabytes>
 ----
 
 ===== Overlay file system
 
 Enable or disable a read-only filesystem.
 
+[source,console]
 ----
-sudo raspi-config nonint do_overlayfs <0/1>
+$ sudo raspi-config nonint do_overlayfs <0/1>
 ----
 
-- `0` - Enable overlay filesystem
-- `1` - Disable overlay filesystem
+* `0`: enable overlay filesystem
+* `1`: disable overlay filesystem
 
 ===== Fan
 
 Set the behaviour of a GPIO connected fan.
 
+[source,console]
 ----
-sudo raspi-config nonint do_fan <0/1> [gpio] [onTemp]
+$ sudo raspi-config nonint do_fan <0/1> [gpio] [onTemp]
 ----
 
-- `0` - Enable fan
-- `1` - Disable fan
+* `0`: enable fan
+* `1`: disable fan
 
 `gpio` defaults to `14`.
 
-`onTemp` defaults to `80` °C.
+`onTemp` defaults to `80` **degrees Celsius**.
 
 [[localisation-options-nonint]]
 ==== Localisation options
@@ -614,38 +646,47 @@ sudo raspi-config nonint do_fan <0/1> [gpio] [onTemp]
 
 Select a locale, for example `en_GB.UTF-8 UTF-8`.
 
+[source,console]
 ----
-sudo raspi-config nonint do_change_locale <locale>
+$ sudo raspi-config nonint do_change_locale <locale>
 ----
+
+For a full list of possible `<locale>` values, see the abbreviations used in the interactive `raspi-config` version of this option.
 
 [[change-timezone-nonint]]
 ===== Time zone
 
-Select your local time zone, starting with the region, e.g. Europe, then selecting a city, e.g. London. Type a letter to skip down the list to that point in the alphabet.
+Sets your local time zone, starting with the region then selecting a city, e.g. "Europe/London".
 
+[source,console]
 ----
-sudo raspi-config nonint do_change_timezone <timezone>
-sudo raspi-config nonint do_change_timezone America/Los_Angeles
+$ sudo raspi-config nonint do_change_timezone <timezone>
 ----
+
+For a full list of possible `<timezone>` values, see the abbreviations used in the interactive `raspi-config` version of this option.
 
 [[change-keyboard-layout-nonint]]
 ===== Keyboard
 
-This option opens another menu which allows you to select your keyboard layout. Changes usually take effect immediately, but may require a reboot.
+Sets your keyboard layout. Changes usually take effect immediately, but may require a reboot.
 
+[source,console]
 ----
-sudo raspi-config nonint do_configure_keyboard <keymap>
-sudo raspi-config nonint do_configure_keyboard us
+$ sudo raspi-config nonint do_configure_keyboard <keymap>
 ----
+
+For a full list of possible `<keymap>` values, see the the abbreviations used in the interactive `raspi-config` version of this option.
 
 ===== WLAN country
 
-This option sets the country code for your wireless network.
+Sets the country code for your wireless network.
 
+[source,console]
 ----
-sudo raspi-config nonint do_wifi_country <country>
-sudo raspi-config nonint do_wifi_country US
+$ sudo raspi-config nonint do_wifi_country <country>
 ----
+
+For a full list of possible `<country>` values, see the abbreviations used in the interactive `raspi-config` version of this option.
 
 [[advanced-options-nonint]]
 ==== Advanced options
@@ -653,83 +694,93 @@ sudo raspi-config nonint do_wifi_country US
 [[expand-filesystem-nonint]]
 ===== Expand filesystem
 
-This option will expand your installation to fill the whole SD card, giving you more space to use for files. You will need to reboot the Raspberry Pi to make this available. 
+This option will expand your installation to fill the whole storage device, giving you more space to use for files. You will need to reboot the Raspberry Pi to make this available.
 
 WARNING: There is no confirmation step: selecting the option begins the partition expansion immediately.
 
+[source,console]
 ----
-sudo raspi-config nonint do_expand_rootfs
+$ sudo raspi-config nonint do_expand_rootfs
 ----
 
 ===== Network interface names
 
 Enable or disable predictable network interface names.
 
+[source,console]
 ----
-sudo raspi-config nonint do_net_names <0/1>
+$ sudo raspi-config nonint do_net_names <0/1>
 ----
 
-- `0` - Enable predictable network interface names
-- `1` - Disable predictable network interface names
+* `0`: enable predictable network interface names
+* `1`: disable predictable network interface names
 
 ===== Network proxy settings
 
 Configure the network's proxy settings.
 
+[source,console]
 ----
-sudo raspi-config nonint do_proxy <SCHEMES> <ADDRESS>
+$ sudo raspi-config nonint do_proxy <SCHEMES> <ADDRESS>
 ----
 
 ===== Boot order
 
 On the Raspberry Pi 4 and 5, you can specify whether to boot from USB or network if the SD card isn't inserted. See the xref:raspberry-pi.adoc#raspberry-pi-bootloader-configuration[bootloader configuration] section for more information.
 
+[source,console]
 ----
-sudo raspi-config nonint do_boot_order <B1/B2/B3>
+$ sudo raspi-config nonint do_boot_order <B1/B2/B3>
 ----
 
- - `B1` - SD card boot - boot from SD card if available, otherwise boot from USB
- - `B2` - USB boot - boot from USB if available, otherwise boot from SD card
- - `B3` - Network boot - boot from network if SD card boot fails
+Depending on your device, you can choose from the following options:
+
+* `B1`: SD card boot - boot from SD card if available, otherwise boot from NVMe, otherwise boot from USB
+* `B2`: NVMe/USB boot - boot from NVMe if available, otherwise boot from USB if available, otherwise boot from SD card
+* `B3`: Network boot - boot from SD card _if inserted_, otherwise boot from network
 
 ===== Bootloader version
 
-On Raspberry Pi 4 and 5, you can tell the system to use the very latest boot ROM software, or revert to the factory default if the latest version causes problems.
+On the Raspberry Pi 4 and later, you can switch to the latest boot ROM software. Alternatively, you can revert to the factory default if the latest version causes problems.
 
+[source,console]
 ----
-sudo raspi-config nonint do_boot_rom <E1/E2>
+$ sudo raspi-config nonint do_boot_rom <E1/E2>
 ----
 
-- `E1` - Use the latest boot ROM
-- `E2` - Use the factory default
+* `E1`: use the latest boot ROM
+* `E2`: use the factory default
 
 ===== Wayland
 
 Use this option to switch between the X11 and Wayland backends. On the Raspberry Pi 4 and 5, Wayland is used by default; on other models of Raspberry Pi, X11 is used by default. 
 
+[source,console]
 ----
-sudo raspi-config nonint do_wayland <W1/W2>
+$ sudo raspi-config nonint do_wayland <W1/W2>
 ----
 
-- `W1` - Use the X11 backend
-- `W2` - Use the Wayland backend
+* `W1`: use the X11 backend
+* `W2`: use the Wayland backend
 
 ===== Audio config
 
 Use this option to switch between the PulseAudio and PipeWire audio backends.
 
+[source,console]
 ----
-sudo raspi-config nonint do_audioconf <1/2>
+$ sudo raspi-config nonint do_audioconf <1/2>
 ----
 
-- `1` - Use the PulseAudio backend
-- `2` - Use the PipeWire backend
+* `1`: use the PulseAudio backend
+* `2`: use the PipeWire backend
 
 [[update-nonint]]
 ==== Update
 
 Update this tool to the latest version.
 
+[source,console]
 ----
-sudo raspi-config nonint do_update
+$ sudo raspi-config nonint do_update
 ----

--- a/documentation/asciidoc/computers/configuration/raspi-config.adoc
+++ b/documentation/asciidoc/computers/configuration/raspi-config.adoc
@@ -1,9 +1,9 @@
 [[raspi-config]]
 == `raspi-config`
 
-TIP: Raspberry Pi Desktop users can also access a graphical version of this application at **Preferences** > **Raspberry Pi Configuration**.
+TIP: Raspberry Pi Desktop users can access a graphical version of this application at **Preferences** > **Raspberry Pi Configuration**. However, some advanced configuration is only available in `raspi-config`.
 
-`raspi-config` helps you configure your Raspberry Pi. To open the configuration tool, run the following command:
+`raspi-config` helps you configure your Raspberry Pi.  Available options may differ between Raspberry Pi models. To open the configuration tool, run the following command:
 
 [source,console]
 ----
@@ -14,8 +14,6 @@ You should see a blue screen with options in a grey box:
 
 image::images/raspi-config.png[raspi-config main screen]
 
-=== Usage
-
 Use the **Up** and **Down** arrow keys to move the highlighted selection between the options available.
 
 Press the **Right** arrow key or press **Tab** to access the `<Select>` and `<Finish>` buttons. Press **Left** or press **Tab** to return to the options.
@@ -25,231 +23,229 @@ Press the **Right** arrow key or press **Tab** to access the `<Select>` and `<Fi
 TIP: In long lists of option values (like the list of timezone cities), type a letter to skip to that section of the list. For example, enter `L` to skip to Lisbon.
 
 [[menu-options]]
-=== List of options
-
-==== System options
+=== System options
 
 The system options submenu allows you to make configuration changes to various parts of the boot, login and networking process, along with some other system level changes.
 
 image::images/raspi-system.png[raspi-config system options]
 
-===== Wireless LAN
+==== Wireless LAN
 
-Allows setting of the wireless LAN SSID and passphrase.
+Configure Wi-Fi SSID and passphrase.
 
-===== Audio
+==== Audio
 
 Specify the audio output destination.
 
 [[change-user-password]]
-===== Password
+==== Password
 
 Change your password.
 
 [[hostname]]
-===== Hostname
+==== Hostname
 
-Set the visible name for this Raspberry Pi on a network.
+Set the visible xref:remote-access.adoc#resolve-raspberrypi-local-with-mdns[mDNS] name for this Raspberry Pi on a network.
 
 [[boot-options]]
-===== Boot/auto login
+==== Boot/auto login
 
-From this submenu you can select whether to boot to console or desktop, and whether you need to log in or not. If you select automatic login, you will be logged in with your current username.
+Select whether to boot to console or desktop, and whether or not your Raspberry Pi automatically logs into your current user account when powered on.
 
-===== Network at boot
+==== Network at boot
 
-Use this option to wait for a network connection before letting boot proceed.
+Wait for a network connection before proceeding with boot.
 
-===== Splash screen
+==== Splash screen
 
-Enable or disable the splash screen displayed at boot time
+Enable or disable the splash screen displayed at boot time.
 
-===== Power LED
+==== Power LED
 
-If the model of Raspberry Pi you are using permits it, you can change the behaviour of the power LED using this option.
+If your Raspberry Pi model allows, change the behaviour of the power LED.
 
-===== Browser
+==== Browser
 
-Use this option to change the default web browser. Choosing a web browser that isn't currently installed won't work.
+Change the default web browser.
 
-==== Display options
+=== Display options
 
 image::images/raspi-display.png[raspi-config display options]
 
 [[underscan]]
-===== Underscan
+==== Underscan
 
 NOTE: Not available when running Wayland.
 
-If the initial text shown on the screen disappears off the edge, you need to enable overscan to bring the border back. On some displays, particularly monitors, disabling overscan will make the picture fill the whole screen and will remove the black border.
+If the initial text shown on the screen disappears off the edge, enable overscan to adjust the border. On some displays, particularly monitors, disabling overscan will make the picture fill the whole screen and remove the black border.
 
-===== Screen blanking
+==== Screen blanking
 
 Enable or disable screen blanking.
 
 [[resolution]]
-===== VNC resolution
+==== VNC resolution
 
 Define the video resolution to use in xref:configuration.adoc#setting-up-a-headless-raspberry-pi[headless] setups.
 
-===== Composite
+==== Composite
 
 Enable or disable composite video.
 
-===== 4Kp60 HDMI
+==== 4Kp60 HDMI
 
 Enable or disable 4Kp60 resolution for HDMI outputs.
 
 [[interfacing-options]]
-==== Interface options
+=== Interface options
 
-Use this submenu to enable and disable various physical and virtual interfaces.
+Enable and disable various physical and virtual interfaces.
 
 image::images/raspi-interface.png[raspi-config interface options]
 
 [[ssh]]
-===== SSH
+==== SSH
 
-Enable/disable remote command-line access to your Raspberry Pi using SSH.
+Enable or disable remote terminal access to your Raspberry Pi using SSH.
 
 SSH allows you to remotely access the command line of the Raspberry Pi from another computer. SSH is disabled by default. Read more about using SSH on the xref:remote-access.adoc#ssh[SSH documentation page]. If connecting your Raspberry Pi directly to a public network, you should not enable SSH unless you have set up secure passwords for all users.
 
 [[VNC]]
-===== VNC
+==== VNC
 
-Enable/disable the WayVNC or RealVNC virtual network computing server.
+Enable or disable the WayVNC or RealVNC virtual network computing server.
 
 [[spi]]
-===== SPI
+==== SPI
 
-Enable/disable SPI interfaces and automatic loading of the SPI kernel module.
+Enable or disable SPI interfaces and automatic loading of the SPI kernel module.
 
 [[i2c]]
-===== I2C
+==== I2C
 
-Enable/disable I2C interfaces and automatic loading of the I2C kernel module.
+Enable or disable I2C interfaces and automatic loading of the I2C kernel module.
 
 [[serial]]
-===== Serial port
+==== Serial port
 
-Enable/disable shell and kernel messages on the serial connection.
+Enable or disable shell and kernel messages on the serial connection.
 
 [[one-wire]]
-===== 1-Wire
+==== 1-Wire
 
-Enable/disable the Dallas 1-wire interface. This is usually used for DS18B20 temperature sensors.
+Enable or disable the Dallas 1-wire interface, often used for DS18B20 temperature sensors.
 
-===== Remote GPIO
+==== Remote GPIO
 
 Enable or disable remote access to the GPIO pins.
 
-==== Performance options
+=== Performance options
 
 image::images/raspi-perf.png[raspi-config performance options]
 
 [[overclock]]
-===== Overclock
+==== Overclock
 
-Some models can overclock the CPU using this tool. Overclocking potential varies between individual Raspberry Pi devices. Overclocking too high may result in instability.
+If your Raspberry Pi model allows, overclock the CPU. Overclocking potential varies between individual Raspberry Pi devices, even within the same model. Overclocking too high may result in instability.
 
 WARNING: *Overclocking may reduce the lifetime of your Raspberry Pi.* If overclocking at a certain level causes system instability, try a more modest overclock. Hold down the *Shift* key during boot to temporarily disable overclocking.
 
 [[memory-split]]
-===== GPU memory
+==== GPU memory
 
 Change the amount of memory made available to the GPU.
 
-===== Overlay file system
+==== Overlay file system
 
 Enable or disable a read-only filesystem.
 
-===== Fan
+==== Fan
 
-Customise the behaviour of a GPIO connected fan.
+Customise the behaviour of the GPIO-connected https://www.raspberrypi.com/products/raspberry-pi-4-case-fan/[Raspberry Pi 4 Case Fan]. Does not effect the fans in the https://www.raspberrypi.com/products/raspberry-pi-5-case/[Raspberry Pi 5 Case for Raspberry Pi 5] or https://www.raspberrypi.com/products/active-cooler/[Raspberry Pi 5 Active Cooler], which connect using a special four-pin fan header.
 
 [[localisation-options]]
-==== Localisation options
+=== Localisation options
 
-Use localisation submenu to control location and country-related options.
+Configure location and country-related options.
 
 image::images/raspi-l18n.png[raspi-config localisation options]
 
 [[change-locale]]
-===== Locale
+==== Locale
 
 Select a locale, for example `en_GB.UTF-8 UTF-8`.
 
 [[change-timezone]]
-===== Time zone
+==== Time zone
 
-Select your local time zone, starting with the region, e.g. Europe, then selecting a city, e.g. London. Type a letter to skip down the list to that point in the alphabet.
+Sets your local time zone, starting with the region then selecting a city, e.g. "Europe/London". Type a letter to jump to that letter in the list.
 
 [[change-keyboard-layout]]
-===== Keyboard
+==== Keyboard
 
-This option opens another menu which allows you to select your keyboard layout. Changes usually take effect immediately, but may require a reboot.
+Opens another menu where you can select your keyboard layout. Changes usually take effect immediately, but may require a reboot. Type a letter to jump to that letter in the list.
 
-===== WLAN country
+==== WLAN country
 
-This option sets the country code for your wireless network.
+Sets the country code for your wireless network.
 
 [[advanced-options]]
-==== Advanced options
+=== Advanced options
 
 image::images/raspi-adv.png[raspi-config advanced options]
 
 [[expand-filesystem]]
-===== Expand filesystem
+==== Expand filesystem
 
-Expands your installation to fill the entire storage device, giving you more space to use for files. You must reboot the Raspberry Pi to make this available.
+Expands your OS partition to fill the whole storage device, giving you more space to use for files. Reboot your Raspberry Pi to complete this action. Normally, Raspberry Pi OS runs this action on first boot. This option can be useful if you clone your OS to a separate storage device with more storage than the original.
 
 WARNING: There is no confirmation step. Selecting the option begins the partition expansion immediately.
 
-===== Network interface names
+==== Network interface names
 
 Enable or disable predictable network interface names.
 
-===== Network proxy settings
+==== Network proxy settings
 
 Configure the network's proxy settings.
 
-===== Boot order
+==== Boot order
 
-On Raspberry Pi 4 and later, you can specify whether to boot from USB or network if the SD card isn't inserted. For more information, see xref:raspberry-pi.adoc#raspberry-pi-bootloader-configuration[bootloader configuration].
+On Raspberry Pi 4 and later, specify whether to boot from USB or network if the SD card isn't inserted. For more information, see xref:raspberry-pi.adoc#raspberry-pi-bootloader-configuration[bootloader configuration].
 
-===== Bootloader version
+==== Bootloader version
 
-On the Raspberry Pi 4 and later, you can switch to the latest boot ROM software. Alternatively, you can revert to the factory default if the latest version causes problems.
+On the Raspberry Pi 4 and later, switch to the latest boot ROM software. Alternatively, you can revert to the factory default if the latest version causes problems.
 
-===== Wayland
+==== Wayland
 
-Use this option to switch between the X11 and Wayland backends. Prior to Raspberry Pi OS Bookworm, Raspberry Pi OS used X11.
+Switch between the X11 and Wayland backends. Raspberry Pi 4 and later use Wayland by default; other models of Raspberry Pi use X11 by default.
 
 NOTE: To use Wayland on Raspberry Pi models prior to Raspberry Pi 4, you must also add `wayland=on` to `/boot/firmware/cmdline.txt`.
 
-===== Audio config
+==== Audio config
 
-Use this option to switch between the PulseAudio and PipeWire audio backends. Prior to Raspberry Pi OS Bookworm, Raspberry Pi OS used PulseAudio.
+Switch between the PulseAudio and PipeWire audio backends. Prior to Raspberry Pi OS Bookworm, Raspberry Pi OS used PulseAudio.
 
 [[update]]
-==== Update
+=== Update
 
 Update this tool to the latest version.
 
 [[about]]
-==== About raspi-config
+=== About raspi-config
 
-Selecting this option displays a description of `raspi-config`.
+Display a description of `raspi-config`.
 
 [[finish]]
-==== Finish
+=== Finish
 
-Use this option when you have completed your changes. You will be asked whether you want to reboot or not. When implementing changes for the first time, it's best to reboot. If you chose to resize your SD card, rebooting may take longer than usual.
+Exits `raspi-config`. If you made changes that require a reboot, `raspi-config` prompts you to reboot. When implementing changes for the first time, it's best to reboot. If you chose to resize your SD card, rebooting may take longer than usual.
 
 [[raspi-config-cli]]
-== The `raspi-config` CLI
+== non-interactive `raspi-config`
 
-The `raspi-config` tool supports non-interactive command line options and flags instead of the interactive menu. These options can be useful when configuring a Raspberry Pi image for distribution.
+The `raspi-config` tool also supports non-interactive options and flags that change options entirely on the command line with no visual component. Available options may differ between Raspberry Pi models.
 
 [source,console]
 ----
@@ -259,13 +255,12 @@ $ sudo raspi-config nonint <command> <arguments> [optional-argument]
 NOTE: The meaning of `0` and `1` varies between options. Always check the documentation before passing a value to an option.
 
 [[raspi-config-cli-commands]]
-=== List of options
 
-==== System options
+=== System options
 
-===== Wireless LAN
+==== Wireless LAN
 
-Allows setting of the wireless LAN SSID and passphrase.
+Configure Wi-Fi SSID and passphrase.
 
 [source,console]
 ----
@@ -278,29 +273,30 @@ The `<hidden>` option indicates the visibility of the SSID. If the network broad
 
 The `<plain>` option indicates whether or not you intend to pass the passphrase as plaintext. If your passphrase includes a space or a special character like `!`, you must pass `0` and use quotes around your passphrase. Otherwise, you can pass `1` or omit the option. Defaults to `1`.  To pass this option, you must specify a value for `<hidden>`.
 
-Example:
+For example, run the following commands to connect to a:
 
-Connect to a non-hidden network named `myssid` with the passphrase `mypassphrase`:
-
+* non-hidden network named `myssid` with the passphrase `mypassphrase`:
++
 [source,console]
 ----
 $ sudo raspi-config nonint do_wifi_ssid_passphrase myssid mypassphrase
 ----
 
-Connect to a hidden network named `myssid` with the passphrase `mypassphrase`:
+* hidden network named `myssid` with the passphrase `mypassphrase`:
++
 [source,console]
 ----
 $ sudo raspi-config nonint do_wifi_ssid_passphrase myssid mypassphrase 1
 ----
 
-Connect to a non-hidden network named `myssid` with the passphrase `my passphrase`:
-
+* non-hidden network named `myssid` with the passphrase `my passphrase`:
++
 [source,console]
 ----
 $ sudo raspi-config nonint do_wifi_ssid_passphrase myssid "my passphrase" 0 0
 ----
 
-===== Audio
+==== Audio
 
 Specify the audio output destination.
 
@@ -315,10 +311,10 @@ On Raspberry Pi 4B, you can use the following options:
 * `1`: vc4-hdmi-0
 * `2`: vc4-hdmi-1
 
-For a full list of possible `<N>` values, see the abbreviations used in the interactive `raspi-config` version of this option.
+For a full list of possible `<N>` values, see the numbers used in the interactive `raspi-config` version of this option.
 
 [[change-user-password-nonint]]
-===== Password
+==== Password
 
 Change your password.
 
@@ -330,9 +326,9 @@ $ sudo raspi-config nonint do_change_pass
 NOTE: This function uses a full-screen interactive interface, even when run from a CLI option.
 
 [[hostname-nonint]]
-===== Hostname
+==== Hostname
 
-Set the visible name for this Raspberry Pi on a network.
+Set the visible xref:remote-access.adoc#resolve-raspberrypi-local-with-mdns[mDNS] name for this Raspberry Pi on a network.
 
 [source,console]
 ----
@@ -340,9 +336,9 @@ $ sudo raspi-config nonint do_hostname <hostname>
 ----
 
 [[boot-options-nonint]]
-===== Boot/auto login
+==== Boot/auto login
 
-Select whether to boot to console or desktop and whether you need to log in or not.
+Select whether to boot to console or desktop, and whether or not your Raspberry Pi automatically logs into your current user account when powered on.
 
 [source,console]
 ----
@@ -354,9 +350,9 @@ $ sudo raspi-config nonint do_boot_behaviour <B1/B2/B3/B4>
 * `B3`: boot to desktop, requiring login
 * `B4`: boot to desktop, logging in automatically
 
-===== Network at boot
+==== Network at boot
 
-Use this option to wait for a network connection before letting boot proceed.
+Wait for a network connection before letting boot proceed.
 
 [source,console]
 ----
@@ -366,7 +362,7 @@ $ sudo raspi-config nonint do_boot_wait <0/1>
 * `0`: boot without waiting for network connection
 * `1`: boot after waiting for network connection
 
-===== Splash screen
+==== Splash screen
 
 Enable or disable the splash screen displayed at boot time.
 
@@ -378,9 +374,9 @@ $ sudo raspi-config nonint do_boot_splash <0/1>
 * `0`: enable splash screen
 * `1`: disable splash screen
 
-===== Power LED
+==== Power LED
 
-If the model of Raspberry Pi permits it, you can change the behaviour of the power LED using this option.
+If your Raspberry Pi model allows, change the behaviour of the power LED.
 
 [source,console]
 ----
@@ -390,7 +386,7 @@ $ sudo raspi-config nonint do_leds <0/1>
 * `0`: flash for disk activity
 * `1`: keep the power LED lit at all times
 
-===== Browser
+==== Browser
 
 Change the default web browser. Choosing a web browser that isn't currently installed won't work.
 
@@ -399,10 +395,10 @@ Change the default web browser. Choosing a web browser that isn't currently inst
 $ sudo raspi-config nonint do_browser <chromium-browser/firefox>
 ----
 
-==== Display options
+=== Display options
 
 [[underscan-nonint]]
-===== Underscan
+==== Underscan
 
 NOTE: Not available when running Wayland.
 
@@ -423,7 +419,7 @@ Enabled:
 * `0`: enable overscan
 * `1`: disable overscan
 
-===== Screen blanking
+==== Screen blanking
 
 Enable or disable screen blanking.
 
@@ -436,7 +432,7 @@ $ sudo raspi-config nonint do_blanking <0/1>
 * `1`: disable screen blanking
 
 [[resolution-nonint]]
-===== VNC resolution
+==== VNC resolution
 
 Define the video resolution to use for VNC in xref:configuration.adoc#setting-up-a-headless-raspberry-pi[headless] setups.
 
@@ -445,7 +441,7 @@ Define the video resolution to use for VNC in xref:configuration.adoc#setting-up
 $ sudo raspi-config nonint do_vnc_resolution <width>x<height>
 ----
 
-===== Composite
+==== Composite
 
 Enable or disable composite video output.
 
@@ -471,12 +467,12 @@ $ sudo raspi-config nonint do_composite <0/1>
 * `1`: disable composite video
 
 [[interfacing-options-nonint]]
-==== Interface options
+=== Interface options
 
 [[ssh-nonint]]
-===== SSH
+==== SSH
 
-Enable/disable remote terminal access to your Raspberry Pi using SSH.
+Enable or disable remote terminal access to your Raspberry Pi using SSH.
 
 SSH allows you to remotely access the command line of the Raspberry Pi from another computer. For more information about SSH, see the xref:remote-access.adoc#ssh[SSH documentation].
 
@@ -489,9 +485,9 @@ $ sudo raspi-config nonint do_ssh <0/1>
 * `1`: disable SSH
 
 [[VNC-nonint]]
-===== VNC
+==== VNC
 
-Enable/disable a Virtual Network Computing (VNC) server. For more information about VNC, see the xref:remote-access.adoc#vnc[VNC documentation].
+Enable or disable a Virtual Network Computing (VNC) server. For more information about VNC, see the xref:remote-access.adoc#vnc[VNC documentation].
 
 [source,console]
 ----
@@ -502,9 +498,9 @@ $ sudo raspi-config nonint do_vnc <0/1>
 * `1`: disable VNC
 
 [[spi-nonint]]
-===== SPI
+==== SPI
 
-Enable/disable SPI interfaces and automatic loading of the SPI kernel module.
+Enable or disable SPI interfaces and automatic loading of the SPI kernel module.
 
 [source,console]
 ----
@@ -515,9 +511,9 @@ $ sudo raspi-config nonint do_spi <0/1>
 * `1`: disable SPI
 
 [[i2c-nonint]]
-===== I2C
+==== I2C
 
-Enable/disable I2C interfaces and automatic loading of the I2C kernel module.
+Enable or disable I2C interfaces and automatic loading of the I2C kernel module.
 
 [source,console]
 ----
@@ -528,9 +524,9 @@ $ sudo raspi-config nonint do_i2c <0/1>
 * `1`: disable I2C
 
 [[serial-nonint]]
-===== Serial Port
+==== Serial Port
 
-Enable/disable the serial connection hardware.
+Enable or disable the serial connection hardware.
 
 [source,console]
 ----
@@ -541,9 +537,9 @@ $ sudo raspi-config nonint do_serial_hw <0/1/2>
 * `1`: disable serial port
 
 [[serial-console-nonint]]
-===== Serial console
+==== Serial console
 
-Enable/disable shell and kernel messages on the serial connection.
+Enable or disable shell and kernel messages on the serial connection.
 
 [source,console]
 ----
@@ -554,9 +550,9 @@ $ raspi-config nonint do_serial_cons <0/1/2>
 * `1`: disable console over serial port
 
 [[one-wire-nonint]]
-===== 1-wire
+==== 1-wire
 
-Enable/disable the Dallas 1-wire interface. This is usually used for DS18B20 temperature sensors.
+Enable or disable the Dallas 1-wire interface. This is usually used for DS18B20 temperature sensors.
 
 [source,console]
 ----
@@ -566,7 +562,7 @@ $ sudo raspi-config nonint do_onewire <0/1>
 * `0`: enable 1-wire
 * `1`: disable 1-wire
 
-===== Remote GPIO
+==== Remote GPIO
 
 Enable or disable remote access to the GPIO pins.
 
@@ -578,12 +574,12 @@ $ sudo raspi-config nonint do_rgpio <0/1>
 * `0`: enable remote GPIO
 * `1`: disable remote GPIO
 
-==== Performance options
+=== Performance options
 
 [[overclock-nonint]]
-===== Overclock
+==== Overclock
 
-Some models can overclock the CPU using this tool. Overclocking potential varies between individual Raspberry Pi devices. Overclocking too high may result in instability.
+If your Raspberry Pi model allows, overclock the CPU. Overclocking potential varies between individual Raspberry Pi devices, even within the same model. Overclocking too high may result in instability.
 
 WARNING: *Overclocking may reduce the lifetime of your Raspberry Pi.* If overclocking at a certain level causes system instability, try a more modest overclock. Hold down the *Shift* key during boot to temporarily disable overclocking.
 
@@ -601,7 +597,7 @@ This command accepts the following `<setting>` values:
 * `Turbo`: overclock to 125% of the maximum
 
 [[memory-split-nonint]]
-===== GPU memory
+==== GPU memory
 
 Change the amount of memory made available to the GPU.
 
@@ -610,7 +606,7 @@ Change the amount of memory made available to the GPU.
 $ sudo raspi-config nonint do_memory_split <megabytes>
 ----
 
-===== Overlay file system
+==== Overlay file system
 
 Enable or disable a read-only filesystem.
 
@@ -622,9 +618,9 @@ $ sudo raspi-config nonint do_overlayfs <0/1>
 * `0`: enable overlay filesystem
 * `1`: disable overlay filesystem
 
-===== Fan
+==== Fan
 
-Set the behaviour of a GPIO connected fan.
+Customise the behaviour of the GPIO-connected https://www.raspberrypi.com/products/raspberry-pi-4-case-fan/[Raspberry Pi 4 Case Fan]. Does not effect the fans in the https://www.raspberrypi.com/products/raspberry-pi-5-case/[Raspberry Pi 5 Case for Raspberry Pi 5] or https://www.raspberrypi.com/products/active-cooler/[Raspberry Pi 5 Active Cooler], which connect using a special four-pin fan header.
 
 [source,console]
 ----
@@ -639,10 +635,10 @@ $ sudo raspi-config nonint do_fan <0/1> [gpio] [onTemp]
 `onTemp` defaults to `80` **degrees Celsius**.
 
 [[localisation-options-nonint]]
-==== Localisation options
+=== Localisation options
 
 [[change-locale-nonint]]
-===== Locale
+==== Locale
 
 Select a locale, for example `en_GB.UTF-8 UTF-8`.
 
@@ -654,9 +650,9 @@ $ sudo raspi-config nonint do_change_locale <locale>
 For a full list of possible `<locale>` values, see the abbreviations used in the interactive `raspi-config` version of this option.
 
 [[change-timezone-nonint]]
-===== Time zone
+==== Time zone
 
-Sets your local time zone, starting with the region then selecting a city, e.g. "Europe/London".
+Set your local time zone, starting with the region then selecting a city, e.g. "Europe/London".
 
 [source,console]
 ----
@@ -666,9 +662,9 @@ $ sudo raspi-config nonint do_change_timezone <timezone>
 For a full list of possible `<timezone>` values, see the abbreviations used in the interactive `raspi-config` version of this option.
 
 [[change-keyboard-layout-nonint]]
-===== Keyboard
+==== Keyboard
 
-Sets your keyboard layout. Changes usually take effect immediately, but may require a reboot.
+Set your keyboard layout. Changes usually take effect immediately, but may require a reboot.
 
 [source,console]
 ----
@@ -677,9 +673,9 @@ $ sudo raspi-config nonint do_configure_keyboard <keymap>
 
 For a full list of possible `<keymap>` values, see the the abbreviations used in the interactive `raspi-config` version of this option.
 
-===== WLAN country
+==== WLAN country
 
-Sets the country code for your wireless network.
+Set the country code for your wireless network.
 
 [source,console]
 ----
@@ -689,12 +685,12 @@ $ sudo raspi-config nonint do_wifi_country <country>
 For a full list of possible `<country>` values, see the abbreviations used in the interactive `raspi-config` version of this option.
 
 [[advanced-options-nonint]]
-==== Advanced options
+=== Advanced options
 
 [[expand-filesystem-nonint]]
-===== Expand filesystem
+==== Expand filesystem
 
-This option will expand your installation to fill the whole storage device, giving you more space to use for files. You will need to reboot the Raspberry Pi to make this available.
+Expand your OS partition to fill the whole storage device, giving you more space to use for files. Reboot the Raspberry Pi to complete this action. Normally, Raspberry Pi OS runs this action on first boot. This option can be useful if you clone your OS to a separate storage device with more storage than the original.
 
 WARNING: There is no confirmation step: selecting the option begins the partition expansion immediately.
 
@@ -703,7 +699,7 @@ WARNING: There is no confirmation step: selecting the option begins the partitio
 $ sudo raspi-config nonint do_expand_rootfs
 ----
 
-===== Network interface names
+==== Network interface names
 
 Enable or disable predictable network interface names.
 
@@ -715,7 +711,7 @@ $ sudo raspi-config nonint do_net_names <0/1>
 * `0`: enable predictable network interface names
 * `1`: disable predictable network interface names
 
-===== Network proxy settings
+==== Network proxy settings
 
 Configure the network's proxy settings.
 
@@ -724,9 +720,9 @@ Configure the network's proxy settings.
 $ sudo raspi-config nonint do_proxy <SCHEMES> <ADDRESS>
 ----
 
-===== Boot order
+==== Boot order
 
-On the Raspberry Pi 4 and 5, you can specify whether to boot from USB or network if the SD card isn't inserted. See the xref:raspberry-pi.adoc#raspberry-pi-bootloader-configuration[bootloader configuration] section for more information.
+On the Raspberry Pi 4 and later, specify whether to boot from USB or network if the SD card isn't inserted. See the xref:raspberry-pi.adoc#raspberry-pi-bootloader-configuration[bootloader configuration] section for more information.
 
 [source,console]
 ----
@@ -739,9 +735,9 @@ Depending on your device, you can choose from the following options:
 * `B2`: NVMe/USB boot - boot from NVMe if available, otherwise boot from USB if available, otherwise boot from SD card
 * `B3`: Network boot - boot from SD card _if inserted_, otherwise boot from network
 
-===== Bootloader version
+==== Bootloader version
 
-On the Raspberry Pi 4 and later, you can switch to the latest boot ROM software. Alternatively, you can revert to the factory default if the latest version causes problems.
+On the Raspberry Pi 4 and later, switch to the latest boot ROM software. Alternatively, you can revert to the factory default if the latest version causes problems.
 
 [source,console]
 ----
@@ -751,9 +747,9 @@ $ sudo raspi-config nonint do_boot_rom <E1/E2>
 * `E1`: use the latest boot ROM
 * `E2`: use the factory default
 
-===== Wayland
+==== Wayland
 
-Use this option to switch between the X11 and Wayland backends. On the Raspberry Pi 4 and 5, Wayland is used by default; on other models of Raspberry Pi, X11 is used by default. 
+Switch between the X11 and Wayland backends. Raspberry Pi 4 and later use Wayland by default; other models of Raspberry Pi use X11 by default.
 
 [source,console]
 ----
@@ -763,9 +759,11 @@ $ sudo raspi-config nonint do_wayland <W1/W2>
 * `W1`: use the X11 backend
 * `W2`: use the Wayland backend
 
-===== Audio config
+NOTE: To use Wayland on Raspberry Pi models prior to Raspberry Pi 4, you must also add `wayland=on` to `/boot/firmware/cmdline.txt`.
 
-Use this option to switch between the PulseAudio and PipeWire audio backends.
+==== Audio config
+
+Use this option to switch between the PulseAudio and PipeWire audio backends. Prior to Raspberry Pi OS Bookworm, Raspberry Pi OS used PulseAudio.
 
 [source,console]
 ----
@@ -776,7 +774,7 @@ $ sudo raspi-config nonint do_audioconf <1/2>
 * `2`: use the PipeWire backend
 
 [[update-nonint]]
-==== Update
+=== Update
 
 Update this tool to the latest version.
 

--- a/documentation/asciidoc/computers/configuration/raspi-config.adoc
+++ b/documentation/asciidoc/computers/configuration/raspi-config.adoc
@@ -543,7 +543,7 @@ Enable or disable shell and kernel messages on the serial connection.
 
 [source,console]
 ----
-$ raspi-config nonint do_serial_cons <0/1/2>
+$ sudo raspi-config nonint do_serial_cons <0/1/2>
 ----
 
 * `0`: enable console over serial port
@@ -692,7 +692,7 @@ For a full list of possible `<country>` values, see the abbreviations used in th
 
 Expand your OS partition to fill the whole storage device, giving you more space to use for files. Reboot the Raspberry Pi to complete this action. Normally, Raspberry Pi OS runs this action on first boot. This option can be useful if you clone your OS to a separate storage device with more storage than the original.
 
-WARNING: There is no confirmation step: selecting the option begins the partition expansion immediately.
+WARNING: There is no confirmation step. Selecting the option begins the partition expansion immediately.
 
 [source,console]
 ----

--- a/documentation/asciidoc/computers/configuration/raspi-config.adoc
+++ b/documentation/asciidoc/computers/configuration/raspi-config.adoc
@@ -37,10 +37,11 @@ Configure Wi-Fi SSID and passphrase.
 
 Specify the audio output destination.
 
-[[change-user-password]]
 ==== Password
 
 Change your password.
+
+For more information, see xref:configuration.adoc#change-user-password[Change a user's password].
 
 [[hostname]]
 ==== Hostname
@@ -317,6 +318,8 @@ For a full list of possible `<N>` values, see the numbers used in the interactiv
 ==== Password
 
 Change your password.
+
+For more information, see xref:configuration.adoc#change-user-password[Change a user's password].
 
 [source,console]
 ----

--- a/documentation/asciidoc/computers/configuration/securing-the-raspberry-pi.adoc
+++ b/documentation/asciidoc/computers/configuration/securing-the-raspberry-pi.adoc
@@ -2,6 +2,7 @@
 
 Here, we describe some common ways to improve the security of your Raspberry Pi.
 
+[[change-user-password]]
 === Change a user's password
 
 You can change the password for the current user account via the `raspi-config` application on from the command line:


### PR DESCRIPTION
* Brings syntax highlighting to these snippets, which were previously unmarked.
* Adds information about NVMe boot to the noninteractive boot order options list.
* Clarifies previously confusing noninteractive wifi connection instruction.