### PR TITLE
Add support for basic markup in box section display

### DIFF
--- a/jekyll-assets/_layouts/boxes.html
+++ b/jekyll-assets/_layouts/boxes.html
@@ -26,7 +26,7 @@
             <a class="box" href="{{ entry.url }}">
             {% endif %}
               <span><img src="{{ site.baseurl }}{{ entry.imagepath }}" width="121" height="121" alt=""></span>
-              <span class="title">{{ entry.title }}</span>
+              <span class="title">{{ entry.title | markdownify }}</span>
               <span>{{ entry.description }}</span>
             </a>
             {% endfor %}


### PR DESCRIPTION
Noticed that the 'box' pages containing docs sections didn't support monospace text added to the section titles. Added handling to those pages.