### PR TITLE
Strip paragraph tags from interior of markdownified h1 page tags so we preserve h1 formatting

### DIFF
--- a/jekyll-assets/_layouts/docs.html
+++ b/jekyll-assets/_layouts/docs.html
@@ -13,7 +13,7 @@
       {% include nav.html %}
 
       <section id="content">
-        <h1>{{ page.sub_title | markdownify }}</h1>
+        <h1>{{ page.sub_title | markdownify | remove: '<p>' | remove: '</p>'}}</h1>
         {{ content }}
       </section>
     </div>


### PR DESCRIPTION
Current site:

<img width="1105" alt="Screenshot 2024-06-03 at 09 22 43" src="https://github.com/raspberrypi/documentation/assets/10657588/87254adc-ce3a-454d-9c52-1f7a426b4052">

Updated version:

<img width="1148" alt="Screenshot 2024-06-03 at 09 22 29" src="https://github.com/raspberrypi/documentation/assets/10657588/7f140452-87d9-4c2c-bff4-c3d96e127d19">


TL;DR: When I introduced markup formatting to page titles with `markdownify`, I didn't realise that it always wraps the produced HTML in a `<p>...</p>` tag. That's usually fine, except for the fact that we apply formatting to the `p` tag that overrode font weight (and a couple of other) styles that we apply to `h1`.

This removes that top-level paragraph tag in a way that shouldn't cause any issues if `markdownify` changes to no longer use the `p` tag or something, since we're just manually stripping out that tag. Unfortunately jekyll doesn't include a way to tell `markdownify` "I already have enclosing HTML, don't wrap it in `<p>`", so this is the next best solution.