### PR TITLE
Fix broken external anchor points

### DIFF
--- a/documentation/asciidoc/computers/compute-module/cm-emmc-flashing.adoc
+++ b/documentation/asciidoc/computers/compute-module/cm-emmc-flashing.adoc
@@ -1,5 +1,5 @@
 [[flash-compute-module-emmc]]
-== Flash an image to a Compute Module
+== [[flashing-the-compute-module-emmc]]Flash an image to a Compute Module
 
 The Compute Module has an on-board eMMC device connected to the primary SD card interface. This guide explains how to flash (write) an operating system image to the eMMC storage of a single Compute Module.
 

--- a/documentation/asciidoc/computers/os/using-python.adoc
+++ b/documentation/asciidoc/computers/os/using-python.adoc
@@ -22,7 +22,7 @@ $ sudo apt install python3-build-hat
 
 To find Python packages distributed with `apt`, xref:os.adoc#search-for-software[use `apt search`]. In most cases, Python packages use the prefix `python-` or `python3-`: for instance, you can find the `numpy` package under the name `python3-numpy`.
 
-=== [[about-python-virtual-environments]]Install Python libraries using `pip`
+=== [[python-on-raspberry-pi]]Install Python libraries using `pip`
 
 ==== Bookworm changes to `pip` installation
 


### PR DESCRIPTION
Uses special AsciiDoc anchors that we can't link to internally in the docs. However, these points WILL work if you manually enter the URL. This means these sections technically have two anchor points -- the implicit one generated by the section title, and this new anchor point. This prevents us from linking to the old version of a page name.

Fixes https://github.com/raspberrypi/documentation/issues/3692
Annoyingly, I already added a similar anchor for this same purpose, but I used the wrong one and couldn't find the rptl link. D'oh. That's my bad.

Also fixes a broken link for Compute Module eMMC flashing.

This _shouldn't_ happen too often if I remember to manually check external links when I refactor. Internal links get checked automatically by AsciiDoc, but external ones are tough to check. Honestly I should just get check for requests that frequently 404 so when a lot of users try to use a link that I break, I can fix it. That'll also help with, say, docs sections linked from Stack Overflow, blog posts, etc that we don't even know about.