### PR TITLE
Add instruction for installing build hat library pre-bookworm

### DIFF
--- a/documentation/asciidoc/accessories/build-hat/py-installing-software.adoc
+++ b/documentation/asciidoc/accessories/build-hat/py-installing-software.adoc
@@ -2,11 +2,18 @@
 
 === Install the Build HAT Python Library
 
-Install the Build HAT Python library. Open a Terminal window and type,
+To install the Build HAT Python library, open a terminal window and run the following command:
 
 [source,console]
 ----
 $ sudo apt install python3-build-hat 
+----
+
+Raspberry Pi OS versions prior to _Bookworm_ do not have access to the library with `apt`. Instead, run the following command to install the library using `pip`:
+
+[source,console]
+----
+$ sudo pip3 install buildhat
 ----
 
 For more information about the Build HAT Python Library see https://buildhat.readthedocs.io/[ReadTheDocs].


### PR DESCRIPTION
* Fixes https://github.com/raspberrypi/documentation/issues/3275