### PR TITLE
Copy edit linux kernel section

### DIFF
--- a/documentation/asciidoc/computers/compute-module/cm-peri-sw-guide.adoc
+++ b/documentation/asciidoc/computers/compute-module/cm-peri-sw-guide.adoc
@@ -6,7 +6,7 @@ Most of the pins of the SoC (GPIO, two CSI camera interfaces, two DSI display in
 
 Compute Modules with the DDR2 SODIMM form factor can use any DDR2 SODIMM socket. However, the pinout is not the same as SODIMM memory modules.
 
-To use the Compute Module, a user must design a motherboard that:
+To use a Compute Module, a user must design a motherboard that:
 
 * provides power to the Compute Module (3.3V and 1.8V at minimum)
 * connects the pins to the required peripherals for the user's application
@@ -27,9 +27,9 @@ Then, we'll explain how to attach an I2C and an SPI peripheral to an IO Board. F
 
 === BCM283x GPIOs
 
-BCM283x has three banks of general-purpose input/output (GPIO) pins: 28 pins on BANK0, 18 pins on BANK1, and 8 pins on BANK2, for a total of 54 pins. These pins can be used as true GPIO pins: software can set them as inputs or outputs, read and/or set state, and use them as interrupts. They also can run alternate functions such as I2C, SPI, I2S, UART, SD card, and others.
+BCM283x has three banks of general-purpose input/output (GPIO) pins: 28 pins on Bank 0, 18 pins on Bank 1, and 8 pins on Bank 2, for a total of 54 pins. These pins can be used as true GPIO pins: software can set them as inputs or outputs, read and/or set state, and use them as interrupts. They also can run alternate functions such as I2C, SPI, I2S, UART, SD card, and others.
 
-You can use BANK0 or BANK1 on any Compute Module. Don't use BANK2: it controls eMMC, HDMI hot plug detect, and ACT LED/USB boot control.
+You can use Bank 0 or Bank 1 on any Compute Module. Don't use Bank 2: it controls eMMC, HDMI hot plug detect, and ACT LED/USB boot control.
 
 Use `pinctrl` to check the voltage and function of the GPIO pins to see if your Device Tree is working as expected.
 
@@ -67,7 +67,7 @@ You can create a full Device Tree for a Compute Module product, but we recommend
 
 Use the `dtoverlay` parameter in `config.txt` to load Device Tree overlays. Raspberry Pi OS assumes that all overlays are located in the `/overlays` directory and use the suffix `-overlay.dtb`. For example, the line `dtoverlay=myoverlay` loads the overlay `/overlays/myoverlay-overlay.dtb`.
 
-To wire peripherals to a Compute Module, describe all hardware attached to the BANK0 and BANK1 GPIOs in an overlay. This allows you to use standard Raspberry Pi OS images, since the overlay is merged into the standard base Device Tree. Alternatively, you can define a custom Device Tree for your application, but you won't be able to use standard Raspberry Pi OS images. Instead, you must create a modified Raspberry Pi OS image that includes your custom device tree for every OS update you wish to distribute. If the base overlay changes, you might need to update your customised Device Tree.
+To wire peripherals to a Compute Module, describe all hardware attached to the Bank 0 and Bank 1 GPIOs in an overlay. This allows you to use standard Raspberry Pi OS images, since the overlay is merged into the standard base Device Tree. Alternatively, you can define a custom Device Tree for your application, but you won't be able to use standard Raspberry Pi OS images. Instead, you must create a modified Raspberry Pi OS image that includes your custom device tree for every OS update you wish to distribute. If the base overlay changes, you might need to update your customised Device Tree.
 
 === `dt-blob.bin`
 
@@ -153,9 +153,9 @@ Use the https://forums.raspberrypi.com/viewforum.php?f=107[Device Tree Raspberry
 
 The following examples use an IO Board with peripherals attached via jumper wires. We assume a CM1+CMIO or CM3+CMIO3, running a clean install of Raspberry Pi OS Lite. The examples here require internet connectivity, so we recommend a USB hub, keyboard, and wireless LAN or Ethernet dongle plugged into the IO Board USB port.
 
-==== Attach an I2C RTC to BANK1 pins
+==== Attach an I2C RTC to Bank 1 pins
 
-In this example, we wire an NXP PCF8523 real time clock (RTC) to the IO Board BANK1 GPIO pins: 3V3, GND, I2C1_SDA on GPIO44 and I2C1_SCL on GPIO45.
+In this example, we wire an NXP PCF8523 real time clock (RTC) to the IO Board Bank 1 GPIO pins: 3V3, GND, I2C1_SDA on GPIO44 and I2C1_SCL on GPIO45.
 
 Download https://datasheets.raspberrypi.com/cm/minimal-cm-dt-blob.dts[`minimal-cm-dt-blob.dts`] and copy it to the boot partition in `/boot/firmware/`.
 
@@ -216,9 +216,9 @@ Once rebooted, you should see an `rtc0` entry in `/dev`. Run the following comma
 $ sudo hwclock
 ----
 
-==== Attach an ENC28J60 SPI Ethernet controller on BANK0
+==== Attach an ENC28J60 SPI Ethernet controller on Bank 0
 
-In this example, we use an overlay already defined in `/boot/firmware/overlays` to add an ENC28J60 SPI Ethernet controller to BANK0. The Ethernet controller uses SPI pins CE0, MISO, MOSI and SCLK (GPIO8-11 respectively), GPIO25 for a falling edge interrupt, in addition to GND and 3.3V.
+In this example, we use an overlay already defined in `/boot/firmware/overlays` to add an ENC28J60 SPI Ethernet controller to Bank 0. The Ethernet controller uses SPI pins CE0, MISO, MOSI and SCLK (GPIO8-11 respectively), GPIO25 for a falling edge interrupt, in addition to GND and 3.3V.
 
 In this example, we won't change `dt-blob.bin`. Instead, add the following line to `/boot/firmware/config.txt`:
 

--- a/documentation/asciidoc/computers/linux_kernel/about-kernel.adoc
+++ b/documentation/asciidoc/computers/linux_kernel/about-kernel.adoc
@@ -1,12 +1,12 @@
 == Kernel
 
-The Raspberry Pi kernel is https://github.com/raspberrypi/linux[hosted on GitHub]; updates lag behind the upstream https://github.com/torvalds/linux[Linux kernel]. The upstream kernel is continuously updating; we take long-term releases of the kernel, which are mentioned on the front page, and integrate the changes into our own Raspberry Pi kernel. We then create a 'next' branch which contains an unstable port of the kernel, and after extensive testing and discussion, we push this to the main branch of our repository.
+The Raspberry Pi kernel is https://github.com/raspberrypi/linux[hosted on GitHub]; updates lag behind the upstream https://github.com/torvalds/linux[Linux kernel]. The upstream kernel updates continuously, whereas Raspberry Pi integrates **long-term releases** of the Linux kernel into the Raspberry Pi kernel. We generate a `next` branch in the Raspberry Pi kernel for each long-term Linux kernel release. After extensive testing and discussion, we merge each `next` branch into the main branch of our repository.
 
-=== Updating your kernel
+=== Update
 
-If you use the standard Raspberry Pi OS xref:os.adoc#update-software[update and upgrade process], this will automatically update the kernel to the latest stable version of our kernel. This is the recommended procedure. However, in certain circumstances, you may wish to update to the latest "bleeding edge" or test kernel. You should only do this if recommended to do so by a Raspberry Pi engineer, or if there is a specific feature only available in this latest software.
+The usual Raspberry Pi OS xref:os.adoc#update-software[update process] automatically updates your kernel to the latest stable release. If you want to try the latest unstable test kernel, you can xref:os.adoc#rpi-update[manually update].
 
-=== Getting your code into the kernel
+=== Contribute
 
 There are many reasons you may want to put something into the kernel:
 
@@ -15,9 +15,14 @@ There are many reasons you may want to put something into the kernel:
 * You've fixed a generic kernel bug
 * You've fixed a Raspberry Pi-specific kernel bug
 
-Initially, you should fork the https://github.com/raspberrypi/linux[Linux repository] and clone that on your build system; this can be either on your Raspberry Pi or on a Linux machine you're using for cross-compiling. You can then make your changes, test them, and commit them into your fork.
+==== Contribute to the Linux kernel
 
-Next, depending upon whether the code is Raspberry Pi-specific or not:
+First, fork the https://github.com/torvalds/linux[Linux kernel repository] and clone it to your development device. You can then make your changes, test them, and commit them into your fork.
 
-* For Raspberry Pi-specific changes or bug fixes, submit a pull request to the kernel.
-* For general Linux kernel changes (i.e. a new driver), these need to be submitted upstream first. Once they've been submitted upstream and accepted, submit the pull request and we'll receive it.
+Then, submit a pull request containing your changes to the https://github.com/torvalds/linux[Linux kernel repository]. Linux kernel contributors will review your contribution and suggest improvements. Once approved, they'll merge in your changes. Eventually, they'll make their way into a long-term release of the Linux kernel. Once we've tested that long-term release for compatibility with the Raspberry Pi kernel, your changes will make their way into a stable release of the Raspberry Pi kernel.
+
+==== Contribute to the Raspberry Pi Kernel
+
+First, fork the https://github.com/raspberrypi/linux[Raspberry Pi kernel repository] and clone it to your development device. You can then make your changes, test them, and commit them into your fork.
+
+Then, submit a pull request containing your changes to the https://github.com/raspberrypi/linux[Raspberry Pi kernel repository]. Raspberry Pi engineers will review your contribution and suggest improvements. Once approved, we'll merge in your changes, and they'll eventually make their way to the stable release of the Raspberry Pi kernel.

--- a/documentation/asciidoc/computers/linux_kernel/building.adoc
+++ b/documentation/asciidoc/computers/linux_kernel/building.adoc
@@ -1,266 +1,361 @@
 [[building]]
-== Building the kernel
+== Build the kernel
 
-The default compilers and linkers that come with an OS are configured to build executables to run on that OS - they are native tools - but that doesn't have to be the case. A cross-compiler is configured to build code for a target other than the one running the build process, and using it is called cross-compilation.
+The default compilers and linkers distributed with an OS are configured to build executables to run on that OS. **Cross-compilation** is the process of building code for a target other than the one running the build process.
 
-Cross-compilation of the Raspberry Pi kernel is useful for two reasons: it allows a 64-bit kernel to be built using a 32-bit OS, and vice versa. It also means that even a modest laptop can cross-compile a Raspberry Pi kernel significantly faster than the Raspberry Pi itself.
+Cross-compilation of the Raspberry Pi kernel allows you to build a 64-bit kernel from a 32-bit OS, and vice versa. Alternatively, you can cross-compile a 32-bit or 64-bit Raspberry Pi kernel from a device other than a Raspberry Pi.
 
-The instructions below are divided into native builds and cross-compilation. Choose the section appropriate for your situation; although there are many common steps between the two, there are also some important differences.
+[NOTE]
+====
+The 32-bit distribution of Raspberry Pi OS on a Raspberry Pi 4B, 5, 400, Compute Module 4, or Compute Module 4S uses a 32-bit userland, but a _64-bit kernel_. To build a 32-bit kernel, set `ARCH=arm`. To boot a 32-bit kernel, set `arm_64bit=0` in `config.txt`.
+====
 
-=== Building the kernel locally
+The instructions below are divided into native builds and cross-compilation. Choose the section appropriate for your situation; although the two processes share many steps, there are also some important differences.
 
-IMPORTANT: Building the 64-bit kernel on the 32-bit distribution of Raspberry Pi OS is a cross-compilation exercise because it requires the installation of the cross-compiler (`gcc-aarch64-linux-gnu`). If you're running the 32-bit distribution of Raspberry Pi OS on a Pi 4B, Pi 400, CM4 or CM4S then you'll be running a 32-bit userland, and 64-bit kernel — so if you want to explicitly build a 32-bit kernel you should set `ARCH=arm`, and to boot this kernel you'll need to set `arm_64bit=0` in `config.txt`. We provide instructions for <<cross-compiling-the-kernel,cross-compiling the kernel>>.  
+=== Native builds
 
-On a Raspberry Pi, first install the latest version of https://www.raspberrypi.com/software/operating-systems/#raspberry-pi-os-32-bit[Raspberry Pi OS]. Then boot your Raspberry Pi, log in, and ensure you're connected to the internet to give you access to the sources.
+On a Raspberry Pi, install the latest version of xref:os.adoc[Raspberry Pi OS]. Boot your Raspberry Pi, log in, and connect to the Internet.
 
-First install Git and the build dependencies:
+First, install Git and the build dependencies:
 
-[,bash]
+[source,console]
 ----
-sudo apt install git bc bison flex libssl-dev make
-----
-
-Next get the sources, which will take some time:
-
-[,bash]
-----
-git clone --depth=1 https://github.com/raspberrypi/linux
+$ sudo apt install git bc bison flex libssl-dev make
 ----
 
-[[choosing_sources]]
-==== Choosing sources
+==== Download kernel source
 
-The `git clone` command above will download the current active branch (the one we are building Raspberry Pi OS images from) without any history. Omitting the `--depth=1` will download the entire repository, including the full history of all branches, but this takes much longer and occupies much more storage.
+Next, download the source code for the latest Raspberry Pi kernel:
 
-To download a different branch (again with no history), use the `--branch` option:
-
-[,bash]
+[source,console]
 ----
-git clone --depth=1 --branch <branch> https://github.com/raspberrypi/linux
+$ git clone --depth=1 https://github.com/raspberrypi/linux
 ----
 
-where `<branch>` is the name of the branch that you wish to download.
+This can take several minutes.
 
-Refer to the https://github.com/raspberrypi/linux[original GitHub repository] for information about the available branches.
+[TIP]
+====
+The `git clone` command above downloads the current active branch, which we build Raspberry Pi OS images from, without any history. Omit `--depth=1` to download the entire repository, including the full history of all branches. This takes much longer and occupies much more storage.
 
-==== Kernel configuration
+To download a different branch with no history, add the `--branch` option to the command above, replacing `<branch>` with the name of the branch you wish to download:
 
-Configure the kernel; as well as the default configuration, you may wish to xref:linux_kernel.adoc#configuring-the-kernel[configure your kernel in more detail] or xref:linux_kernel.adoc#patching-the-kernel[apply patches from another source], to add or remove required functionality.
-
-[[default_configuration]]
-===== Apply the default configuration
-
-First, prepare the default configuration by running the following commands, depending on your Raspberry Pi model.
-
-For Raspberry Pi 1, Zero and Zero W, and Raspberry Pi Compute Module 1 default (32-bit only) build configuration:
-
-[,bash]
+[source,console]
 ----
-cd linux
-KERNEL=kernel
-make bcmrpi_defconfig
+$ git clone --depth=1 --branch <branch> https://github.com/raspberrypi/linux
 ----
 
-For Raspberry Pi 2, 3, 3+ and Zero 2 W, and Raspberry Pi Compute Modules 3 and 3+ default 32-bit build configuration:
+For a full list of available branches, see the https://github.com/raspberrypi/linux[the Raspberry Pi kernel repository].
+====
 
-[,bash]
-----
-cd linux
-KERNEL=kernel7
-make bcm2709_defconfig
-----
+==== Apply configuration
 
-For Raspberry Pi 4 and 400, and Raspberry Pi Compute Module 4 default 32-bit build configuration:
+[TIP]
+====
+This section describes how to apply the default configuration when you build a kernel. You can also configure your kernel in the following ways:
 
-[,bash]
-----
-cd linux
-KERNEL=kernel7l
-make bcm2711_defconfig
-----
+* xref:linux_kernel.adoc#configure-the-kernel[enable and disable kernel features]
+* xref:linux_kernel.adoc#patch-the-kernel[apply patches from another source]
+====
 
-For Raspberry Pi 3, 3+, 4, 400 and Zero 2 W, and Raspberry Pi Compute Modules 3, 3+ and 4 default 64-bit build configuration:
-[,bash]
-----
-cd linux
-KERNEL=kernel8
-make bcm2711_defconfig
-----
+To prepare the default configuration, run the appropriate commands from the table below for your Raspberry Pi model.
 
-For Raspberry Pi 5 default 64-bit build configuration:
-[,bash]
-----
-cd linux
-KERNEL=kernel_2712
-make bcm2712_defconfig
-----
+[cols="1,2a,6a"]
+|===
+| Architecture | Model | Command
 
-===== Customising the kernel version using `LOCALVERSION`
+.14+^.^| 32-bit
+| Raspberry Pi 1
+.4+.^|
+[source,console]
+----
+$ cd linux
+$ KERNEL=kernel
+$ make bcmrpi_defconfig
+----
+| Raspberry Pi Zero
+| Raspberry Pi Zero W
+| Raspberry Pi Compute Module 1
 
-In addition to your kernel configuration changes, you may wish to adjust `LOCALVERSION` to ensure your new kernel does not receive the same version string as the upstream kernel. This clarifies that you are running your own kernel in the output of `uname`, and ensures that existing modules in `/lib/modules` are not overwritten.
+
+| Raspberry Pi 2
+.6+.^|
+[source,console]
+----
+$ cd linux
+$ KERNEL=kernel7
+$ make bcm2709_defconfig
+----
+| Raspberry Pi 3
+| Raspberry Pi 3+
+| Raspberry Pi Zero 2 W
+| Raspberry Pi Compute Module 3
+| Raspberry Pi Compute Module 3+
+
+
+| Raspberry Pi 4
+.4+.^|
+[source,console]
+----
+$ cd linux
+$ KERNEL=kernel7l
+$ make bcm2711_defconfig
+----
+| Raspberry Pi 400
+| Raspberry Pi Compute Module 4S
+| Raspberry Pi Compute Module 4
+
+
+.10+^.^| 64-bit
+| Raspberry Pi 3
+.9+.^|
+[source,console]
+----
+$ cd linux
+$ KERNEL=kernel8
+$ make bcm2711_defconfig
+----
+| Raspberry Pi 3+
+| Raspberry Pi 4
+| Raspberry Pi 400
+| Raspberry Pi Zero 2 W
+| Raspberry Pi Compute Module 3
+| Raspberry Pi Compute Module 3+
+| Raspberry Pi Compute Module 4S
+| Raspberry Pi Compute Module 4
+
+
+| Raspberry Pi 5
+.1+.^|
+[source,console]
+----
+$ cd linux
+$ KERNEL=kernel_2712
+$ make bcm2712_defconfig
+----
+|===
+
+===== Customise the kernel version using `LOCALVERSION`
+
+Adjust `LOCALVERSION` to clarify that you are running your own kernel in the output of `uname` and prevent the kernel from overwriting existing modules in `/lib/modules`.
 
 To adjust `LOCALVERSION`, change the following line in `.config`:
 
+[source,ini]
 ----
 CONFIG_LOCALVERSION="-v7l-MY_CUSTOM_KERNEL"
 ----
 
-You can also change this setting graphically as shown in xref:linux_kernel.adoc#configuring-the-kernel[the kernel configuration instructions]. It is located in "General setup" \=> "Local version - append to kernel release".
+You can also change this setting graphically with `menuconfig` at *General setup* > *Local version - append to kernel release*. For more information about `menuconfig`, see xref:linux_kernel.adoc#configure-the-kernel[the kernel configuration instructions].
 
-==== Building the kernel
+==== Build and install the kernel natively
 
-Build and install the kernel, modules, and Device Tree blobs. This step can take a long time depending on the Raspberry Pi model you are using.  For the 32-bit kernel:
+Next, build and install the kernel, modules, and Device Tree blobs into the boot partition of your Raspberry Pi. This step can take a long time depending on the Raspberry Pi model you are using.
 
-[,bash]
+TIP: If you don't want to install the freshly-compiled kernel onto the Raspberry Pi where you run this command, copy the compiled kernel to the boot partition of a separate boot media instead of `/boot/firmware/`.
+
+To build and install the 64-bit kernel, run the following commands:
+
+[source,console]
 ----
-make -j4 zImage modules dtbs
-sudo make modules_install
-# Choose one of the following based on the kernel version
-  # For kernels up to 6.4:
-  sudo cp arch/arm/boot/dts/*.dtb /boot/firmware/
-  # For kernel 6.5 and above:
-  sudo cp arch/arm/boot/dts/broadcom/*.dtb /boot/firmware/
-sudo cp arch/arm/boot/dts/overlays/*.dtb* /boot/firmware/overlays/
-sudo cp arch/arm/boot/dts/overlays/README /boot/firmware/overlays/
-sudo cp arch/arm/boot/zImage /boot/firmware/$KERNEL.img
-----
-
-For the 64-bit kernel:
-
-[,bash]
-----
-make -j4 Image.gz modules dtbs
-sudo make modules_install
-sudo cp arch/arm64/boot/dts/broadcom/*.dtb /boot/firmware/
-sudo cp arch/arm64/boot/dts/overlays/*.dtb* /boot/firmware/overlays/
-sudo cp arch/arm64/boot/dts/overlays/README /boot/firmware/overlays/
-sudo cp arch/arm64/boot/Image.gz /boot/firmware/$KERNEL.img
+$ make -j4 Image.gz modules dtbs
+$ sudo make modules_install
+$ sudo cp arch/arm64/boot/dts/broadcom/*.dtb /boot/firmware/
+$ sudo cp arch/arm64/boot/dts/overlays/*.dtb* /boot/firmware/overlays/
+$ sudo cp arch/arm64/boot/dts/overlays/README /boot/firmware/overlays/
+$ sudo cp arch/arm64/boot/Image.gz /boot/firmware/$KERNEL.img
 ----
 
-NOTE: On Raspberry Pi 2, 3, 4 and 5, the `-j4` flag splits the work between all four cores, speeding up compilation significantly.
+To build the 32-bit kernel:
 
-If you now reboot, your Raspberry Pi should be running your freshly-compiled kernel.
+. Run the following commands to build the modules and Device tree blobs:
++
+[source,console]
+----
+$ make -j4 zImage modules dtbs
+$ sudo make modules_install
+----
 
-=== Cross-compiling the kernel
+. Depending on your kernel version, run the following command:
+  * For kernels up to version 6.4:
++
+[source,console]
+----
+$ sudo cp arch/arm/boot/dts/*.dtb /boot/firmware/
+----
+* For kernels version 6.5 and above:
++
+[source,console]
+----
+$ sudo cp arch/arm/boot/dts/broadcom/*.dtb /boot/firmware/
+----
+. Finally, copy over the overlays, README, and image:
++
+[source,console]
+----
+$ sudo cp arch/arm/boot/dts/overlays/*.dtb* /boot/firmware/overlays/
+$ sudo cp arch/arm/boot/dts/overlays/README /boot/firmware/overlays/
+$ sudo cp arch/arm/boot/zImage /boot/firmware/$KERNEL.img
+----
 
-First, you will need a suitable Linux cross-compilation host. We tend to use Ubuntu; since Raspberry Pi OS is also a Debian distribution, it means many aspects are similar, such as the command lines.
+TIP: On multi-core Raspberry Pi models, the `-j <n>` option distributes work between cores. This can speed up compilation significantly. Run `nproc` to see how many processors you have; we recommend passing a number 1.5x your number of processors.
 
-You can either do this using VirtualBox (or VMWare) on Windows, or install it directly onto your computer. 
+Run the following command to reboot your Raspberry Pi and run your freshly-compiled kernel:
+
+[source,console]
+----
+$ sudo reboot
+----
+
+=== Cross-compiled builds
+
+First, you will need a suitable Linux cross-compilation host. We tend to use Ubuntu; since Raspberry Pi OS is also a Debian distribution, compilation commands are similar.
 
 ==== Install required dependencies and toolchain
 
-To build the sources for cross-compilation, make sure you have the dependencies needed on your machine by executing:
+To build the sources for cross-compilation, install the required dependencies onto your device. Run the following command to install most dependencies:
 
-[,bash]
+[source,console]
 ----
-sudo apt install git bc bison flex libssl-dev make libc6-dev libncurses5-dev
-----
-
-===== Install the 32-bit toolchain for a 32-bit kernel
-
-[,bash]
-----
-sudo apt install crossbuild-essential-armhf
+$ sudo apt install git bc bison flex libssl-dev make libc6-dev libncurses5-dev
 ----
 
-===== Install the 64-bit toolchain for a 64-bit kernel
+Then, install the proper toolchain for the kernel architecture you wish to build:
 
-[,bash]
+* To install the 64-bit toolchain to build a 64-bit kernel, run the following command:
++
+[source,console]
 ----
-sudo apt install crossbuild-essential-arm64
-----
-
-==== Get the kernel sources
-
-To download the minimal source tree for the current branch, run:
-
-[,bash]
-----
-git clone --depth=1 https://github.com/raspberrypi/linux
+$ sudo apt install crossbuild-essential-arm64
 ----
 
-See <<choosing_sources,*Choosing sources*>> above for instructions on how to choose a different branch.
+* To install the 32-bit toolchain to build a 32-bit kernel, run the following command:
++
+[source,console]
+----
+$ sudo apt install crossbuild-essential-armhf
+----
+
+==== Download kernel source
+
+Next, download the source code for the latest Raspberry Pi kernel:
+
+[source,console]
+----
+$ git clone --depth=1 https://github.com/raspberrypi/linux
+----
+
+This can take several minutes.
+
+[TIP]
+====
+The `git clone` command above downloads the current active branch, which we build Raspberry Pi OS images from, without any history. Omit `--depth=1` to download the entire repository, including the full history of all branches. This takes much longer and occupies much more storage.
+
+To download a different branch with no history, add the `--branch` option to the command above, replacing `<branch>` with the name of the branch you wish to download:
+
+[source,console]
+----
+$ git clone --depth=1 --branch <branch> https://github.com/raspberrypi/linux
+----
+
+For a full list of available branches, see the https://github.com/raspberrypi/linux[the Raspberry Pi kernel repository].
+====
 
 ==== Build sources
 
 Enter the following commands to build the sources and Device Tree files:
 
-===== 32-bit configs
+[cols="1,2a,6a"]
+|===
+| Target Architecture | Model | Command
 
-For Raspberry Pi 1, Zero and Zero W, and for Raspberry Pi Compute Module 1:
+.14+^.^| 32-bit
 
-[,bash]
+| Raspberry Pi 1
+.4+.^| [source,console]
 ----
-cd linux
-KERNEL=kernel
-make ARCH=arm CROSS_COMPILE=arm-linux-gnueabihf- bcmrpi_defconfig
+$ cd linux
+$ KERNEL=kernel
+$ make ARCH=arm CROSS_COMPILE=arm-linux-gnueabihf- bcmrpi_defconfig
+----
+| Raspberry Pi Zero
+| Raspberry Pi Zero W
+| Raspberry Pi Compute Module 1
+
+| Raspberry Pi 2
+.6+.^|
+[source,console]
+----
+$ cd linux
+$ KERNEL=kernel7
+$ make ARCH=arm CROSS_COMPILE=arm-linux-gnueabihf- bcm2709_defconfig
+----
+| Raspberry Pi 3
+| Raspberry Pi 3+
+| Raspberry Pi Zero 2 W
+| Raspberry Pi Compute Module 3
+| Raspberry Pi 3+:
+
+| Raspberry Pi 4
+.4+.^|
+[source,console]
+----
+$ cd linux
+$ KERNEL=kernel7l
+$ make ARCH=arm CROSS_COMPILE=arm-linux-gnueabihf- bcm2711_defconfig
+----
+| Raspberry Pi 400
+| Raspberry Pi Compute Module 4
+| Raspberry Pi Compute Module 4S
+
+
+.8+^.^| 64-bit
+| Raspberry Pi 3
+.8+.^| [source,console]
+----
+$ cd linux
+$ KERNEL=kernel8
+$ make ARCH=arm64 CROSS_COMPILE=aarch64-linux-gnu- bcm2711_defconfig
+----
+| Raspberry Pi 3+
+| Raspberry Pi 4
+| Raspberry Pi 400
+| Raspberry Pi Zero 2 W
+| Raspberry Pi Compute Modules 3
+| Raspberry Pi Compute Module 4
+| Raspberry Pi Compute Module 4S
+
+| Raspberry Pi 5
+.1+.^|
+[source,console]
+----
+$ cd linux
+$ KERNEL=kernel_2712
+$ make ARCH=arm64 CROSS_COMPILE=aarch64-linux-gnu- bcm2712_defconfig
+----
+|===
+
+==== Build with modules and Device Tree
+
+For 64-bit kernels, pass the image modules and DTB files like so:
+
+[source,console]
+----
+$ make ARCH=arm64 CROSS_COMPILE=aarch64-linux-gnu- Image modules dtbs
 ----
 
-For Raspberry Pi 2, 3, 3+ and Zero 2 W, and Raspberry Pi Compute Modules 3 and 3+:
+For 32-bit kernels, pass the image modules and DTB files like so, prefixing each image module with `z`:
 
-[,bash]
+[source,console]
 ----
-cd linux
-KERNEL=kernel7
-make ARCH=arm CROSS_COMPILE=arm-linux-gnueabihf- bcm2709_defconfig
+$ make ARCH=arm CROSS_COMPILE=arm-linux-gnueabihf- zImage modules dtbs
 ----
 
-For Raspberry Pi 4 and 400, and Raspberry Pi Compute Module 4:
+==== Install the kernel
 
-[,bash]
-----
-cd linux
-KERNEL=kernel7l
-make ARCH=arm CROSS_COMPILE=arm-linux-gnueabihf- bcm2711_defconfig
-----
+Having built the kernel, you need to copy it onto your Raspberry Pi boot media (likely an SD card or SSD) and install the modules.
 
-===== 64-bit configs
-
-For Raspberry Pi 3, 3+, 4, 400 and Zero 2 W, and Raspberry Pi Compute Modules 3, 3+ and 4:
-
-[,bash]
-----
-cd linux
-KERNEL=kernel8
-make ARCH=arm64 CROSS_COMPILE=aarch64-linux-gnu- bcm2711_defconfig
-----
-
-For Raspberry Pi 5:
-
-[,bash]
-----
-cd linux
-KERNEL=kernel_2712
-make ARCH=arm64 CROSS_COMPILE=aarch64-linux-gnu- bcm2712_defconfig
-----
-
-NOTE: The standard, `bcm2711_defconfig`-based kernel (`kernel8.img`) also runs on Raspberry Pi 5. For best performance you should use `kernel_2712.img`, but for situations where a 4KB page size is required then `kernel8.img` (`kernel=kernel8.img`) should be used.
-
-===== Build with configs
-
-NOTE: To speed up compilation on multiprocessor systems, and get some improvement on single-processor devices, use `-j n`, where n is the number of processors × 1.5. You can use the `nproc` command to see how many processors you have. 
-
-====== For all 32-bit builds
-
-[,bash]
-----
-make ARCH=arm CROSS_COMPILE=arm-linux-gnueabihf- zImage modules dtbs
-----
-
-====== For all 64-bit builds
-
-NOTE: Note the difference between Image target between 32- and 64-bit.
-
-[,bash]
-----
-make ARCH=arm64 CROSS_COMPILE=aarch64-linux-gnu- Image modules dtbs
-----
-
-==== Install directly onto the SD card
-
-Having built the kernel, you need to copy it onto your Raspberry Pi and install the modules. This is best done directly using an SD card reader.
-
-First, use `lsblk` before and after plugging in your SD card to identify it. You should end up with something a lot like this:
+First, run `lsblk`. Then, connect your boot media. Run `lsblk` again; the new device represents your boot media. You should see output similar to the following:
 
 ----
 sdb
@@ -268,75 +363,100 @@ sdb
    sdb2
 ----
 
-with `sdb1` being the `FAT` filesystem (boot) partition, and `sdb2` being the `ext4` filesystem (root) partition.
+If `sdb` represents your boot media, `sdb1` represents the the `FAT32`-formatted **boot partition** and `sdb2` represents the (likely `ext4`-formatted) **root partition**.
 
-Mount these first, adjusting the partition letter as necessary:
+First, mount these partitions as `/mnt/boot` and `/mnt/root`, adjusting the partition letter to match the location of your boot media:
 
-[,bash]
+[source,console]
 ----
-mkdir mnt
-mkdir mnt/fat32
-mkdir mnt/ext4
-sudo mount /dev/sdb1 mnt/fat32
-sudo mount /dev/sdb2 mnt/ext4
-----
-
-NOTE: You should adjust the drive letter appropriately for your setup, e.g. if your SD card appears as `/dev/sdc` instead of `/dev/sdb`.
-
-Next, install the kernel modules onto the SD card:
-
-===== For 32-bit
-
-[,bash]
-----
-sudo env PATH=$PATH make ARCH=arm CROSS_COMPILE=arm-linux-gnueabihf- INSTALL_MOD_PATH=mnt/ext4 modules_install
+$ mkdir mnt
+$ mkdir mnt/boot
+$ mkdir mnt/root
+$ sudo mount /dev/sdb1 mnt/boot
+$ sudo mount /dev/sdb2 mnt/root
 ----
 
-===== For 64-bit
+Next, install the kernel modules onto the boot media:
 
-[,bash]
+* For 64-bit kernels:
++
+[source,console]
 ----
-sudo env PATH=$PATH make ARCH=arm64 CROSS_COMPILE=aarch64-linux-gnu- INSTALL_MOD_PATH=mnt/ext4 modules_install
-----
-
-Finally, copy the kernel and Device Tree blobs onto the SD card, making sure to back up your old kernel:
-
-===== For 32-bit
-
-[,bash]
-----
-sudo cp mnt/fat32/$KERNEL.img mnt/fat32/$KERNEL-backup.img
-sudo cp arch/arm/boot/zImage mnt/fat32/$KERNEL.img
-# Choose one of the following based on the kernel version
-  # For kernels up to 6.4:
-  sudo cp arch/arm/boot/dts/*.dtb mnt/fat32/
-  # For kernel 6.5 and above:
-  sudo cp arch/arm/boot/dts/broadcom/*.dtb mnt/fat32/
-sudo cp arch/arm/boot/dts/overlays/*.dtb* mnt/fat32/overlays/
-sudo cp arch/arm/boot/dts/overlays/README mnt/fat32/overlays/
-sudo umount mnt/fat32
-sudo umount mnt/ext4
+$ sudo env PATH=$PATH make ARCH=arm64 CROSS_COMPILE=aarch64-linux-gnu- INSTALL_MOD_PATH=mnt/root modules_install
 ----
 
-===== For 64-bit
-
-[,bash]
+* For 32-bit kernels:
++
+[source,console]
 ----
-sudo cp mnt/fat32/$KERNEL.img mnt/fat32/$KERNEL-backup.img
-sudo cp arch/arm64/boot/Image mnt/fat32/$KERNEL.img
-sudo cp arch/arm64/boot/dts/broadcom/*.dtb mnt/fat32/
-sudo cp arch/arm64/boot/dts/overlays/*.dtb* mnt/fat32/overlays/
-sudo cp arch/arm64/boot/dts/overlays/README mnt/fat32/overlays/
-sudo umount mnt/fat32
-sudo umount mnt/ext4
+$ sudo env PATH=$PATH make ARCH=arm CROSS_COMPILE=arm-linux-gnueabihf- INSTALL_MOD_PATH=mnt/root modules_install
 ----
 
-Another option is to copy the kernel into the same place, but with a different filename - for instance, using `kernel-myconfig.img` - rather than overwriting the `kernel.img` file. You can then edit the `config.txt` file to select the kernel that the Raspberry Pi will boot:
+Next, build and install the kernel, modules, and Device Tree blobs into the boot partition, backing up your original kernel.
 
+* To build and install the 64-bit kernel image, overlays, README, and unmount the partitions, run the following commands:
++
+[source,console]
+----
+$ sudo cp mnt/boot/$KERNEL.img mnt/boot/$KERNEL-backup.img
+$ sudo cp arch/arm64/boot/Image mnt/boot/$KERNEL.img
+$ sudo cp arch/arm64/boot/dts/broadcom/*.dtb mnt/boot/
+$ sudo cp arch/arm64/boot/dts/overlays/*.dtb* mnt/boot/overlays/
+$ sudo cp arch/arm64/boot/dts/overlays/README mnt/boot/overlays/
+$ sudo umount mnt/boot
+$ sudo umount mnt/root
+----
+
+* To build the 32-bit kernel:
++
+. Run the following commands to build the modules and Device tree blobs:
++
+[source,console]
+----
+$ sudo cp mnt/boot/$KERNEL.img mnt/boot/$KERNEL-backup.img
+$ sudo cp arch/arm/boot/zImage mnt/boot/$KERNEL.img
+----
+
+. Depending on your kernel version, run the following command:
+  * For kernels up to version 6.4:
++
+[source,console]
+----
+$ sudo cp arch/arm/boot/dts/*.dtb mnt/boot/
+----
+* For kernels version 6.5 and above:
++
+[source,console]
+----
+$ sudo cp arch/arm/boot/dts/broadcom/*.dtb mnt/boot/
+----
+. Finally, copy over the overlays, README, and image, and unmount the partitions:
++
+[source,console]
+----
+$ sudo cp arch/arm/boot/dts/overlays/*.dtb* mnt/boot/overlays/
+$ sudo cp arch/arm/boot/dts/overlays/README mnt/boot/overlays/
+$ sudo umount mnt/boot
+$ sudo umount mnt/root
+----
+
+TIP: On multi-core Raspberry Pi models, the `-j <n>` option distributes work between cores. This can speed up compilation significantly. Run `nproc` to see how many processors you have; we recommend passing a number 1.5x your number of processors.
+
+[TIP]
+====
+Alternatively, copy the kernel with a different filename (e.g. `kernel-myconfig.img`) instead of overwriting the `kernel.img` file. Then, edit `config.txt` in the boot partition to select your kernel:
+
+[source,ini]
 ----
 kernel=kernel-myconfig.img
 ----
 
-This has the advantage of keeping your custom kernel separate from the stock kernel image managed by the system and any automatic update tools, and allowing you to easily revert to a stock kernel in the event that your kernel cannot boot.
+This has the advantage of keeping your custom kernel separate from the stock kernel image managed by the system. With this arrangement, you can quickly revert to a stock kernel in the event that your kernel cannot boot.
+====
 
-Finally, plug the card into the Raspberry Pi and boot it.
+Connect the boot media to your Raspberry Pi and connect it to power to run your freshly-compiled kernel:
+
+[source,console]
+----
+$ sudo reboot
+----

--- a/documentation/asciidoc/computers/linux_kernel/configuring.adoc
+++ b/documentation/asciidoc/computers/linux_kernel/configuring.adoc
@@ -1,49 +1,54 @@
-== Configuring the kernel
+== Configure the kernel
 
 The Linux kernel is highly configurable. Advanced users may wish to modify the default configuration to customise it to their needs, such as enabling a new or experimental network protocol, or enabling support for new hardware.
 
-Configuration is most commonly done through the `make menuconfig` interface. Alternatively, you can modify your `.config` file manually, but this can be more difficult for new users.
+Configuration is most commonly done through the `make menuconfig` interface. Alternatively, you can modify your `.config` file manually, but this can be more difficult.
 
-=== Preparing to configure
+=== Prepare to configure
 
-The `menuconfig` tool requires the `ncurses` development headers to compile properly. These can be installed with the following command:
+The `menuconfig` tool requires the `ncurses` development headers to compile properly. To install these headers, run the following command:
 
-[,bash]
+[source,console]
 ----
- sudo apt install libncurses5-dev
-----
-
-You'll also need to download and prepare your kernel sources, as described in the xref:linux_kernel.adoc#choosing_sources[build guide]. In particular, ensure you have installed the xref:linux_kernel.adoc#default_configuration[default configuration].
-
-=== Using `menuconfig`
-
-Once you've got everything set up and ready to go, you can compile and run the `menuconfig` utility as follows:
-
-[,bash]
-----
- make menuconfig
+$ sudo apt install libncurses5-dev
 ----
 
-If you're cross-compiling a 32-bit kernel:
+Next, xref:linux_kernel.adoc#download-kernel-source[download your kernel sources]. In particular, ensure you have installed the xref:linux_kernel.adoc#apply-configuration[default configuration].
 
-[,bash]
-----
-make ARCH=arm CROSS_COMPILE=arm-linux-gnueabihf- menuconfig
-----
+=== `menuconfig`
 
-Or, if you are cross-compiling a 64-bit kernel:
+Once you've got everything set up, you can compile and run the `menuconfig` utility as follows:
 
-[,bash]
+[source,console]
 ----
-make ARCH=arm64 CROSS_COMPILE=aarch64-linux-gnu- menuconfig
+$ make menuconfig
 ----
 
-The `menuconfig` utility has simple keyboard navigation. After a brief compilation, you'll be presented with a list of submenus containing all the options you can configure. There are many options, so take your time to read through them and get acquainted.
+To cross-compile a 64-bit kernel:
 
-Use the arrow keys to navigate, the Enter key to enter a submenu (indicated by `+--->+`), Escape twice to go up a level or exit, and the space bar to cycle the state of an option. Some options have multiple choices, in which case they'll appear as a submenu and the Enter key will select an option. You can press `h` on most entries to get help about that specific option or menu.
+[source,console]
+----
+$ make ARCH=arm64 CROSS_COMPILE=aarch64-linux-gnu- menuconfig
+----
 
-Resist the temptation to enable or disable a lot of things on your first attempt; it's relatively easy to break your configuration, so start small and get comfortable with the configuration and build process.
+To cross-compile a 32-bit kernel:
 
-=== Saving your changes
+[source,console]
+----
+$ make ARCH=arm CROSS_COMPILE=arm-linux-gnueabihf- menuconfig
+----
 
-Once you're done making the changes you want, press Escape until you're prompted to save your new configuration. By default, this will save to the `.config` file. You can save and load configurations by copying this file.
+To navigate the `menuconfig` utility, use your keyboard:
+
+* to navigate directionally, use the *arrow keys*
+* to enter a submenu (indicated by `--->`), press the *Enter* key
+* to go up a level or exit, press *Escape* twice
+* to cycle the state of a binary option, press the *space bar*
+* to select the state of a multiple choice option, press *Enter* to open a submenu, the *arrow keys* to navigate the submenu, and press *Enter* again to select a state
+* to get help about with an option or menu, press the *H* key
+
+After a brief compilation, `menuconfig` presents a list of submenus containing all the options you can configure. There are many options, so take your time to read through them. Resist the temptation to enable or disable a lot of things on your first attempt; it's relatively easy to break your configuration, so start small and get comfortable with the configuration and build process.
+
+=== Save your changes
+
+Once you're done making changes, press *Escape* until you're prompted to save your new configuration. By default, this saves to the `.config` file. You can save and load configurations by copying this file.

--- a/documentation/asciidoc/computers/linux_kernel/headers.adoc
+++ b/documentation/asciidoc/computers/linux_kernel/headers.adoc
@@ -1,23 +1,23 @@
 == Kernel headers
 
-If you are compiling a kernel module or similar, you will need the Linux kernel headers. These provide the various function and structure definitions required when compiling code that interfaces with the kernel.
+To compile a kernel module, you need the Linux kernel headers. These provide the function and structure definitions required to compile code that interfaces with the kernel.
 
-If you have cloned the entire kernel from GitHub, the headers are already included in the source tree. If you don't need all the extra files, it is possible to install only the kernel headers from the Raspberry Pi OS repo.
+If you cloned the entire kernel from GitHub, the headers are already included in the source tree. If you don't need all the extra files, you can instead install only the kernel headers with `apt`.
 
-If you are using the 32-bit version of Raspberry Pi OS, run:
+TIP: When a new kernel releases, you need the headers that match that kernel version. It can take several weeks to update the `apt` package to reflect the latest kernel version. For the latest header versions, xref:linux_kernel.adoc#building[clone the kernel].
 
-[,bash]
+If you use a 64-bit version of Raspberry Pi OS, run the following command to install the kernel headers:
+
+[source,console]
 ----
- sudo apt install linux-headers-rpi-{v6,v7,v7l}
-----
-
-Or if you are using the 64-bit version of Raspberry Pi OS, run:
-
-[,bash]
-----
- sudo apt install linux-headers-rpi-v8
+$ sudo apt install linux-headers-rpi-v8
 ----
 
-NOTE: It can take quite a while for this command to complete, as it installs a lot of small files. There is no progress indicator.
+If you use a 32-bit version of Raspberry Pi OS, run the following command to install the kernel headers:
 
-When a new kernel release is made, you will need the headers that match that kernel version. It can take several weeks for the repo to be updated to reflect the latest kernel version. If this happens, the best approach is to xref:linux_kernel.adoc#building[clone the kernel].
+[source,console]
+----
+$ sudo apt install linux-headers-rpi-{v6,v7,v7l}
+----
+
+NOTE: Installation can take several minutes. There is no progress indicator.

--- a/documentation/asciidoc/computers/linux_kernel/patching.adoc
+++ b/documentation/asciidoc/computers/linux_kernel/patching.adoc
@@ -1,48 +1,66 @@
-== Patching the kernel
+== Patch the kernel
 
-When xref:linux_kernel.adoc#building[building] your custom kernel you may wish to apply patches, or collections of patches (patchsets), to the Linux kernel.
+When building your custom kernel, you may wish to apply patches or collections of patches (patchsets) to the Linux kernel.
 
-Patchsets are often provided with newer hardware as a temporary measure, before the patches are applied to the upstream (mainline) Linux kernel and then propagated down to the Raspberry Pi kernel sources. However, patchsets for other purposes exist, for instance to enable a fully preemptible kernel for real-time usage.
+We often provide patchsets as a temporary measure to support new hardware before the patches make it into the Linux kernel and the Raspberry Pi kernel. However, patchsets for other purposes exist, for instance to enable a fully pre-emptible kernel for real-time usage.
 
-=== Version identification
+=== Identify your kernel version
 
-It's important to check what version of the kernel you have when downloading and applying patches. In a kernel source directory, running `head Makefile -n 3` will show you the version the sources relate to:
+Always check your version of the kernel before applying patches. In a kernel source directory, run the following command to see the kernel version:
 
-[source]
+[source,console]
+----
+$ head Makefile -n 3
+----
+
+You should see output similar to the following:
+
 ----
 VERSION = 6
 PATCHLEVEL = 1
 SUBLEVEL = 38
 ----
 
-In this instance, the sources are for a 6.1.38 kernel. You can see what version you're running on your system with the `uname -r` command.
+In this instance, the sources are for a 6.1.38 kernel.
 
-=== Applying patches
+To check the kernel version currently running on your device, run the following command:
 
-How you apply patches depends on the format in which the patches are made available. Most patches are a single file, and are applied with the `patch` utility. To download and patch our example kernel version with the real-time kernel patches:
-
-[,bash]
+[source,console]
 ----
- wget https://www.kernel.org/pub/linux/kernel/projects/rt/6.1/patch-6.1.38-rt13-rc1.patch.gz
- gunzip patch-6.1.38-rt13-rc1.patch.gz
- cat patch-6.1.38-rt13-rc1.patch | patch -p1
+$ uname -r
 ----
 
-In our example we simply download the file, uncompress it, and then pass it to the `patch` utility using the `cat` tool and a Unix pipe.
+=== Apply patches
 
-Some patchsets come as mailbox-format patchsets, arranged as a folder of patch files. We can use Git to apply these patches to our kernel, but first we must configure Git to let it know who we are when we make these changes:
+Patch application depends on the format used to distribute the patch.
 
-[,bash]
+Kernel developers distribute most patches as a single file. Use the `patch` utility to apply these patches. The following commands download, uncompress, and patch our example kernel version with real-time kernel patches:
+
+[source,console]
 ----
- git config --global user.name "Your name"
- git config --global user.email "your email in here"
-----
-
-Once we've done this we can apply the patches:
-
-[,bash]
-----
- git am -3 /path/to/patches/*
+$ wget https://www.kernel.org/pub/linux/kernel/projects/rt/6.1/patch-6.1.38-rt13-rc1.patch.gz
+$ gunzip patch-6.1.38-rt13-rc1.patch.gz
+$ cat patch-6.1.38-rt13-rc1.patch | patch -p1
 ----
 
-If in doubt, consult with the distributor of the patches, who should tell you how to apply them. Some patchsets will require a specific commit to patch against; follow the details provided by the patch distributor.
+Some kernel developers distribute patches in the *mailbox format*, a folder containing multiple patch files. Use Git to apply these patches.
+
+[NOTE]
+====
+Before using Git to apply mailbox patches, configure your local Git installation with a name and email:
+
+[source,console]
+----
+$ git config --global user.name "Your name"
+$ git config --global user.email "your email in here"
+----
+====
+
+To apply the mailbox formatted patches with Git, run the following command:
+
+[source,console]
+----
+$ git am -3 /path/to/patches/*
+----
+
+Always follow the instructions provided by the patch distributor. For instance, some patchsets require patching at specific commits.


### PR DESCRIPTION
* Convert confusing architecture/model/command bullet points into compact, readable tables
* Copy edit all prose to ensure it meets documentation style guide standards
* Trim and reorganise content into the most streamlined, readable format possible.