### PR TITLE
Fix issue where the docs site doesn't always scroll to the correct anchor location

### DIFF
--- a/jekyll-assets/_includes/scripts.html
+++ b/jekyll-assets/_includes/scripts.html
@@ -46,8 +46,6 @@
     try {
       var target = document.querySelector(selector);
       if (target) {
-        var bbox = target.getBoundingClientRect();
-        var myid = target.getAttribute("id");
         setTimeout(function () {
             target.scrollIntoView();
         },2);

--- a/jekyll-assets/_includes/scripts.html
+++ b/jekyll-assets/_includes/scripts.html
@@ -44,17 +44,14 @@
 
   function scrollToElement(selector) {
     try {
-      // if found, scroll to that id hash
-      console.log("Scrolling to ", selector);
       var target = document.querySelector(selector);
       if (target) {
         var bbox = target.getBoundingClientRect();
         var myid = target.getAttribute("id");
-        window.scrollTo({
-          top: bbox.top,
-          left: 0,
-          behavior: "smooth",
-        });
+        setTimeout(function () {
+            target.scrollIntoView();
+        },2);
+        
       } else {
         console.log("Target not found :(");
       }

--- a/jekyll-assets/_includes/scripts.html
+++ b/jekyll-assets/_includes/scripts.html
@@ -47,8 +47,12 @@
       var target = document.querySelector(selector);
       if (target) {
         setTimeout(function () {
-            target.scrollIntoView();
-        },2);
+          target.scrollIntoView({ behavior: "instant" });
+          setTimeout(function () {
+            target.scrollIntoView({ behavior: "instant" });
+          },100);
+        },1);
+        
         
       } else {
         console.log("Target not found :(");


### PR DESCRIPTION
I noticed that this issue usually happens when you try to load an anchor point deep within a long page -- some of our docs pages have hundreds of anchor points and the equivalent of a novel's worth of text. My _suspicion_ is that the browser behaves badly when you try to `scrollTo` a coordinate that doesn't exist yet; some browsers just seem to ignore the request.

* Removed a console log that probably isn't necessary?
* Switched `scrollTo` to `scrollIntoView` because it's simpler and seems to fix the issue in local testing. Why calculate the scroll coordinates when you can just command the browser to scroll to the element you care about? It's hard to say without digging deep into browser implementation code, but I suspect the browser handles `scrollIntoView` a bit differently than `scrollTo`. Maybe there are some safeguards in place to handle elements deep down on a long page?

Regardless, I've tested in multiple browsers (and OSes!), with developer tools configured to slow my network speeds, and I can't reproduce the scroll issue locally with this change. I _know_ this issue effects our production site, so I figure it's worth taking a chance on unless we have a good reason to avoid `scrollIntoView`!