### PR TITLE
Update patching.adoc use of `head` to show correct output

### DIFF
--- a/documentation/asciidoc/computers/linux_kernel/patching.adoc
+++ b/documentation/asciidoc/computers/linux_kernel/patching.adoc
@@ -17,12 +17,13 @@ Always check your version of the kernel before applying patches. In a kernel sou
 
 [source,console]
 ----
-$ head Makefile -n 3
+$ head Makefile -n 4
 ----
 
 You should see output similar to the following:
 
 ----
+# SPDX-License-Identifier: GPL-2.0
 VERSION = 6
 PATCHLEVEL = 1
 SUBLEVEL = 38


### PR DESCRIPTION
Linux (unsure as of when) puts `# SPDX-License-Identifier: GPL-2.0`  as the first line of Makefile, so having head print only 3 lines would not show the sublevel. Changing to 4 lines fixes this.

Left the rest of the output unchanged to avoid breaking other parts of the example.