### PR TITLE
Remove cmake references from rpicam build instructions

### DIFF
--- a/documentation/asciidoc/computers/camera/rpicam_apps_building.adoc
+++ b/documentation/asciidoc/computers/camera/rpicam_apps_building.adoc
@@ -67,7 +67,7 @@ First, install the following `libcamera` dependencies:
 $ sudo apt install -y libboost-dev
 $ sudo apt install -y libgnutls28-dev openssl libtiff5-dev pybind11-dev
 $ sudo apt install -y qtbase5-dev libqt5core5a libqt5gui5 libqt5widgets5
-$ sudo apt install -y meson
+$ sudo apt install -y meson cmake
 $ sudo apt install -y python3-yaml python3-ply
 $ sudo apt install -y libglib2.0-dev libgstreamer-plugins-base1.0-dev
 ----
@@ -121,7 +121,7 @@ First fetch the necessary dependencies for `rpicam-apps`.
 
 [source,console]
 ----
-$ sudo apt install -y libboost-program-options-dev libdrm-dev libexif-dev
+$ sudo apt install -y cmake libboost-program-options-dev libdrm-dev libexif-dev
 $ sudo apt install -y meson ninja-build
 ----
 

--- a/documentation/asciidoc/computers/camera/rpicam_apps_building.adoc
+++ b/documentation/asciidoc/computers/camera/rpicam_apps_building.adoc
@@ -67,7 +67,7 @@ First, install the following `libcamera` dependencies:
 $ sudo apt install -y libboost-dev
 $ sudo apt install -y libgnutls28-dev openssl libtiff5-dev pybind11-dev
 $ sudo apt install -y qtbase5-dev libqt5core5a libqt5gui5 libqt5widgets5
-$ sudo apt install -y meson cmake
+$ sudo apt install -y meson
 $ sudo apt install -y python3-yaml python3-ply
 $ sudo apt install -y libglib2.0-dev libgstreamer-plugins-base1.0-dev
 ----
@@ -121,7 +121,7 @@ First fetch the necessary dependencies for `rpicam-apps`.
 
 [source,console]
 ----
-$ sudo apt install -y cmake libboost-program-options-dev libdrm-dev libexif-dev
+$ sudo apt install -y libboost-program-options-dev libdrm-dev libexif-dev
 $ sudo apt install -y meson ninja-build
 ----
 

--- a/documentation/asciidoc/computers/camera/rpicam_apps_post_processing_writing.adoc
+++ b/documentation/asciidoc/computers/camera/rpicam_apps_post_processing_writing.adoc
@@ -18,8 +18,6 @@ All post-processing stages must implement the following member functions:
 
 In any stage implementation, call `RegisterStage` to register your stage with the system.
 
-Don't forget to add your stage to the post-processing folder's `CMakeLists.txt` too!
-
 When writing your own stages, keep these tips in mind:
 
 * The `Process` method blocks the imaging pipeline. If it takes too long, the pipeline will stutter. **Always delegate time-consuming algorithms to an asynchronous thread.**

--- a/documentation/asciidoc/computers/camera/rpicam_apps_post_processing_writing.adoc
+++ b/documentation/asciidoc/computers/camera/rpicam_apps_post_processing_writing.adoc
@@ -18,6 +18,7 @@ All post-processing stages must implement the following member functions:
 
 In any stage implementation, call `RegisterStage` to register your stage with the system.
 
+Don't forget to add your stage to `meson.build` in the post-processing folder.
 When writing your own stages, keep these tips in mind:
 
 * The `Process` method blocks the imaging pipeline. If it takes too long, the pipeline will stutter. **Always delegate time-consuming algorithms to an asynchronous thread.**

--- a/documentation/asciidoc/computers/camera/rpicam_detect.adoc
+++ b/documentation/asciidoc/computers/camera/rpicam_detect.adoc
@@ -1,6 +1,6 @@
 === `rpicam-detect`
 
-NOTE: Raspberry Pi OS does not include `rpicam-detect`. However, you can build `rpicam-detect` if you have xref:camera_software.adoc#post-processing-with-tensorflow-lite[installed TensorFlow Lite]. For more information, see the xref:camera_software.adoc#build-libcamera-and-rpicam-apps[`rpicam-apps` build instructions]. Don't forget to pass `-DENABLE_TFLITE=1` when you run `meson`.
+NOTE: Raspberry Pi OS does not include `rpicam-detect`. However, you can build `rpicam-detect` if you have xref:camera_software.adoc#post-processing-with-tensorflow-lite[installed TensorFlow Lite]. For more information, see the xref:camera_software.adoc#build-libcamera-and-rpicam-apps[`rpicam-apps` build instructions]. Don't forget to pass `-Denable_tflite=enabled` when you run `meson`.
 
 `rpicam-detect` displays a preview window and monitors the contents using a Google MobileNet v1 SSD (Single Shot Detector) neural network trained to identify about 80 classes of objects using the Coco dataset. `rpicam-detect` recognises people, cars, cats and many other objects.
 

--- a/documentation/asciidoc/computers/camera/rpicam_detect.adoc
+++ b/documentation/asciidoc/computers/camera/rpicam_detect.adoc
@@ -1,6 +1,6 @@
 === `rpicam-detect`
 
-NOTE: Raspberry Pi OS does not include `rpicam-detect`. However, you can build `rpicam-detect` if you have xref:camera_software.adoc#post-processing-with-tensorflow-lite[installed TensorFlow Lite]. For more information, see the xref:camera_software.adoc#build-libcamera-and-rpicam-apps[`rpicam-apps` build instructions]. Don't forget to pass `-DENABLE_TFLITE=1` when you run `cmake`.
+NOTE: Raspberry Pi OS does not include `rpicam-detect`. However, you can build `rpicam-detect` if you have xref:camera_software.adoc#post-processing-with-tensorflow-lite[installed TensorFlow Lite]. For more information, see the xref:camera_software.adoc#build-libcamera-and-rpicam-apps[`rpicam-apps` build instructions]. Don't forget to pass `-DENABLE_TFLITE=1` when you run `meson`.
 
 `rpicam-detect` displays a preview window and monitors the contents using a Google MobileNet v1 SSD (Single Shot Detector) neural network trained to identify about 80 classes of objects using the Coco dataset. `rpicam-detect` recognises people, cars, cats and many other objects.
 


### PR DESCRIPTION
* Closes https://github.com/raspberrypi/documentation/issues/3325
* One cmake mention remains on this page: in "Use libcamera with Qt", "If your project uses cmake, add SET(QT_NO_KEYWORDS ON)." That mention is still relevant since it refers to projects other than rpicam that use cmake.