### PR TITLE
Broaden Connect's remote access heading

### DIFF
--- a/documentation/asciidoc/computers/remote-access/raspberry-pi-connect.adoc
+++ b/documentation/asciidoc/computers/remote-access/raspberry-pi-connect.adoc
@@ -1,5 +1,5 @@
 [[raspberry-pi-connect]]
-== Screen share with Raspberry Pi Connect
+== Remote access with Raspberry Pi Connect
 
 You can access a Raspberry Pi remotely from a browser on another device using Raspberry Pi Connect. Connect handles configuration automatically, so you don't have to find your Raspberry Pi's local IP address, your network's public IP address, or modify your local network firewall to enable external access.
 


### PR DESCRIPTION
Given Connect now offers remote shell as well as screen sharing, update the heading to match.
