### PR TITLE
Add md5 hash query param to images to bust the cache when we update one inplace

### DIFF
--- a/documentation/asciidoc/services/connect/use.adoc
+++ b/documentation/asciidoc/services/connect/use.adoc
@@ -103,7 +103,7 @@ image::images/screen-sharing-end.png[width="80%"]
 
 To turn off screen sharing, click the Connect system tray icon and unselect **Allow screen sharing**.  Your Raspberry Pi remains signed into Connect, but you won't be able to create a screen sharing session from the Connect dashboard.
 
-image:images/screen-sharing-disabled-desktop.png[width="80%"]
+image::images/screen-sharing-disabled-desktop.png[width="80%"]
 
 Alternatively, you can disable screen sharing with the following command:
 
@@ -168,7 +168,7 @@ image::images/remote-shell-end.png[width="80%"]
 
 To turn off remote shell access, click the Connect system tray icon and unselect **Allow remote shell**. Your Raspberry Pi remains signed into Connect, but you won't be able to create a remote shell session from the Connect dashboard.
 
-image:images/remote-shell-disabled-desktop.png[width="80%"]
+image::images/remote-shell-disabled-desktop.png[width="80%"]
 
 Alternatively, you can disable remote shell access with the following command:
 

--- a/scripts/create_auto_ninjabuild.py
+++ b/scripts/create_auto_ninjabuild.py
@@ -5,7 +5,6 @@ import sys
 import json
 import re
 import yaml
-import hashlib
 
 import ninja_syntax
 

--- a/scripts/create_auto_ninjabuild.py
+++ b/scripts/create_auto_ninjabuild.py
@@ -5,6 +5,7 @@ import sys
 import json
 import re
 import yaml
+import hashlib
 
 import ninja_syntax
 
@@ -30,7 +31,10 @@ def scan_adoc(adoc_filename, apparent_filename, includes, src_images, dest_image
         for image in re.findall(r'image::?(.+?)\[.*\]', contents):
             if not (image.startswith('http:') or image.startswith('https:')):
                 image_filename = resolve_url(adoc_filename, image)
-                dest_image = resolve_url(apparent_filename, image)
+                # append a hash to the end of the image file name to bust the cache when we change the image
+                image_hash = hashlib.md5(open(os.path.join(input_dir, image_filename),'rb').read()).hexdigest()
+                image_name, image_extension = os.path.splitext(image_filename)
+                dest_image = image_name + "-" + image_hash + image_extension
                 if dest_image in dest_images and dest_images[dest_image] != image_filename:
                     raise Exception("{} and {} would both end up as {}".format(dest_images[dest_image], image_filename, dest_image))
                 src_images[image_filename] = dest_image
@@ -44,7 +48,10 @@ def add_entire_directory(tab_dir, dir_path, pages_set, src_images, dest_images):
                 pages_set.add(os.path.join(dir_path, f))
             elif f.endswith(".png"):
                 image_filename = os.path.join(dir_path, f)
-                dest_image = image_filename
+                # append a hash to the end of the image file name to bust the cache when we change the image
+                image_hash = hashlib.md5(open(os.path.join(input_dir, image_filename),'rb').read()).hexdigest()
+                image_name, image_extension = os.path.splitext(image_filename)
+                dest_image = image_name + "-" + image_hash + image_extension
                 if dest_image in dest_images and dest_images[dest_image] != image_filename:
                     raise Exception("{} and {} would both end up as {}".format(dest_images[dest_image], image_filename, dest_image))
                 src_images[image_filename] = dest_image

--- a/scripts/create_auto_ninjabuild.py
+++ b/scripts/create_auto_ninjabuild.py
@@ -31,10 +31,7 @@ def scan_adoc(adoc_filename, apparent_filename, includes, src_images, dest_image
         for image in re.findall(r'image::?(.+?)\[.*\]', contents):
             if not (image.startswith('http:') or image.startswith('https:')):
                 image_filename = resolve_url(adoc_filename, image)
-                # append a hash to the end of the image file name to bust the cache when we change the image
-                image_hash = hashlib.md5(open(os.path.join(input_dir, image_filename),'rb').read()).hexdigest()
-                image_name, image_extension = os.path.splitext(resolve_url(apparent_filename, image))
-                dest_image = image_name + "-" + image_hash + image_extension
+                dest_image = resolve_url(apparent_filename, image)
                 if dest_image in dest_images and dest_images[dest_image] != image_filename:
                     raise Exception("{} and {} would both end up as {}".format(dest_images[dest_image], image_filename, dest_image))
                 src_images[image_filename] = dest_image
@@ -48,10 +45,7 @@ def add_entire_directory(tab_dir, dir_path, pages_set, src_images, dest_images):
                 pages_set.add(os.path.join(dir_path, f))
             elif f.endswith(".png"):
                 image_filename = os.path.join(dir_path, f)
-                # append a hash to the end of the image file name to bust the cache when we change the image
-                image_hash = hashlib.md5(open(os.path.join(input_dir, image_filename),'rb').read()).hexdigest()
-                image_name, image_extension = os.path.splitext(f)
-                dest_image = image_name + "-" + image_hash + image_extension
+                dest_image = image_filename
                 if dest_image in dest_images and dest_images[dest_image] != image_filename:
                     raise Exception("{} and {} would both end up as {}".format(dest_images[dest_image], image_filename, dest_image))
                 src_images[image_filename] = dest_image

--- a/scripts/create_auto_ninjabuild.py
+++ b/scripts/create_auto_ninjabuild.py
@@ -33,7 +33,7 @@ def scan_adoc(adoc_filename, apparent_filename, includes, src_images, dest_image
                 image_filename = resolve_url(adoc_filename, image)
                 # append a hash to the end of the image file name to bust the cache when we change the image
                 image_hash = hashlib.md5(open(os.path.join(input_dir, image_filename),'rb').read()).hexdigest()
-                image_name, image_extension = os.path.splitext(image_filename)
+                image_name, image_extension = os.path.splitext(resolve_url(apparent_filename, image))
                 dest_image = image_name + "-" + image_hash + image_extension
                 if dest_image in dest_images and dest_images[dest_image] != image_filename:
                     raise Exception("{} and {} would both end up as {}".format(dest_images[dest_image], image_filename, dest_image))
@@ -50,7 +50,7 @@ def add_entire_directory(tab_dir, dir_path, pages_set, src_images, dest_images):
                 image_filename = os.path.join(dir_path, f)
                 # append a hash to the end of the image file name to bust the cache when we change the image
                 image_hash = hashlib.md5(open(os.path.join(input_dir, image_filename),'rb').read()).hexdigest()
-                image_name, image_extension = os.path.splitext(image_filename)
+                image_name, image_extension = os.path.splitext(f)
                 dest_image = image_name + "-" + image_hash + image_extension
                 if dest_image in dest_images and dest_images[dest_image] != image_filename:
                     raise Exception("{} and {} would both end up as {}".format(dest_images[dest_image], image_filename, dest_image))

--- a/scripts/create_build_adoc.py
+++ b/scripts/create_build_adoc.py
@@ -21,7 +21,6 @@ def check_no_markdown(filename):
         if re.search(r'(\[.+?\]\(.+?\))', asciidoc):
             raise Exception("{} contains a Markdown-style link (i.e. '[title](url)' rather than 'url[title]')".format(filename))
 
-
 if __name__ == "__main__":
     index_json = sys.argv[1]
     config_yaml = sys.argv[2]

--- a/scripts/create_build_adoc.py
+++ b/scripts/create_build_adoc.py
@@ -71,6 +71,12 @@ if __name__ == "__main__":
                 m = re.match(r'^(include::)(.+)(\[\]\n?)$', line)
                 if m:
                     line = m.group(1) + os.path.join('{includedir}/{parentdir}', m.group(2)) + m.group(3)
+                # find all image references, append md5 hash at end to bust the cache if we change the image
+                m = re.match(r'^(image::)(.+)(\[(.+)]\n?)$', line)
+                if m:
+                    directory = os.path.dirname(os.path.abspath(src_adoc))
+                    image_hash = hashlib.md5(open(os.path.join(directory, m.group(2)),'rb').read()).hexdigest()
+                    line = m.group(1) + m.group(2) + '?hash=' + image_hash + m.group(3) + "\n"
             new_contents += line
 
     with open(build_adoc, 'w') as out_fh:

--- a/scripts/create_build_adoc_include.py
+++ b/scripts/create_build_adoc_include.py
@@ -4,6 +4,7 @@ import sys
 import os
 import re
 import yaml
+import hashlib
 
 
 def check_no_markdown(filename):
@@ -48,6 +49,15 @@ if __name__ == "__main__":
                     seen_header = True
                     if github_edit is not None:
                         line += edit_text + "\n\n"
+            else:
+                # find all image references, append md5 hash at end to bust the cache if we change the image
+                m = re.match(r'^(image::)(.+)(\[(.+)]\n?)$', line)
+                if m:
+                    directory = os.path.dirname(os.path.abspath(src_adoc))
+                    image_hash = hashlib.md5(open(os.path.join(directory, m.group(2)),'rb').read()).hexdigest()
+                    image_name, image_extension = os.path.splitext(m.group(2))
+                    line = m.group(1) + image_name + '-' + image_hash + image_extension + m.group(3) + "\n"
+                    #print(m.group(2) + " replaced with " + line)
             new_contents += line
 
         with open(build_adoc, 'w') as out_fh:

--- a/scripts/create_build_adoc_include.py
+++ b/scripts/create_build_adoc_include.py
@@ -57,7 +57,6 @@ if __name__ == "__main__":
                     image_hash = hashlib.md5(open(os.path.join(directory, m.group(2)),'rb').read()).hexdigest()
                     image_name, image_extension = os.path.splitext(m.group(2))
                     line = m.group(1) + image_name + '-' + image_hash + image_extension + m.group(3) + "\n"
-                    #print(m.group(2) + " replaced with " + line)
             new_contents += line
 
         with open(build_adoc, 'w') as out_fh:

--- a/scripts/create_build_adoc_include.py
+++ b/scripts/create_build_adoc_include.py
@@ -55,8 +55,7 @@ if __name__ == "__main__":
                 if m:
                     directory = os.path.dirname(os.path.abspath(src_adoc))
                     image_hash = hashlib.md5(open(os.path.join(directory, m.group(2)),'rb').read()).hexdigest()
-                    image_name, image_extension = os.path.splitext(m.group(2))
-                    line = m.group(1) + image_name + '-' + image_hash + image_extension + m.group(3) + "\n"
+                    line = m.group(1) + m.group(2) + '?hash=' + image_hash + m.group(3) + "\n"
             new_contents += line
 
         with open(build_adoc, 'w') as out_fh:


### PR DESCRIPTION
Works like the title says.