### PR TITLE
Fix broken link to Get Started with MicroPython on Pico

### DIFF
--- a/documentation/asciidoc/microcontrollers/micropython/micropython-documentation.adoc
+++ b/documentation/asciidoc/microcontrollers/micropython/micropython-documentation.adoc
@@ -7,11 +7,9 @@ https://datasheets.raspberrypi.com/picow/connecting-to-the-internet-with-pico-w.
 https://docs.micropython.org/en/latest/rp2/quickref.html[RP2 Quick Reference]:: The official documentation around the RP2040 port of MicroPython
 https://docs.micropython.org/en/latest/library/rp2.html[RP2 Library]:: The official documentation about the `rp2` module in MicroPython
 
-[.booklink, booktype="buy", link=https://store.rpipress.cc/products/get-started-with-micropython-on-raspberry-pi-pico,image=image::images/micropython_book_thumb.png[]]
-
 === Further reading
 
-Check out https://store.rpipress.cc/collections/getting-started/products/get-started-with-micropython-on-raspberry-pi-pico[_Get Started with MicroPython on Raspberry Pi Pico_] to learn how to use the beginner-friendly language MicroPython to make your Raspberry Pi Pico interact with the world around it. Using these skills, you can create your own electro-mechanical projects, whether for fun or to make your life easier.
+Check out https://store.rpipress.cc/collections/getting-started/products/get-started-with-micropython-on-raspberry-pi-pico-2nd-edition[_Get Started with MicroPython on Raspberry Pi Pico_] to learn how to use the beginner-friendly language MicroPython to make your Raspberry Pi Pico interact with the world around it. Using these skills, you can create your own electro-mechanical projects, whether for fun or to make your life easier.
 
 * Set up your Raspberry Pi Pico and start using it
 * Start writing programs using MicroPython


### PR DESCRIPTION
Additionally, remove the (also broken) `booklink` that doesn't display anyway.

Closes https://github.com/raspberrypi/documentation/issues/3756