### PR TITLE
Add imx519 in Third-party sensor

### DIFF
--- a/documentation/asciidoc/computers/camera/rpicam_apps_intro.adoc
+++ b/documentation/asciidoc/computers/camera/rpicam_apps_intro.adoc
@@ -40,6 +40,7 @@ Raspberry Pi's implementation of `libcamera` supports the following cameras:
 ** IMX290
 ** IMX327
 ** IMX378
+** IMX519
 ** OV9281
 
 To extend support to a new sensor, https://git.linuxtv.org/libcamera.git/[contribute to `libcamera`].


### PR DESCRIPTION
see also <https://git.linuxtv.org/libcamera.git/commit/?id=e3b26b4c4eb2582ea778a38545a8ac7801384db2>

see also <https://github.com/raspberrypi/linux/pull/4548>

on RPI 5, see also <https://forums.raspberrypi.com/viewtopic.php?t=360329>