### PR TITLE
Update building.adoc

### DIFF
--- a/documentation/asciidoc/computers/linux_kernel/building.adoc
+++ b/documentation/asciidoc/computers/linux_kernel/building.adoc
@@ -223,7 +223,7 @@ $ sudo cp arch/arm/boot/dts/*.dtb /boot/firmware/
 +
 [source,console]
 ----
-$ sudo cp arch/arm/boot/dts/broadcom/*.dtb /boot/firmware/
+$ sudo cp arch/arm64/boot/dts/broadcom/*.dtb /boot/firmware/
 ----
 . Finally, copy over the overlays and README:
 +


### PR DESCRIPTION
path to broadcom/*.dtb fixed for 64-bit (6.5+), could you check and validate this?
native rpi5 build