### PR TITLE
Remove lingering apt-get mentions

### DIFF
--- a/documentation/asciidoc/computers/camera/rpicam_apps_building.adoc
+++ b/documentation/asciidoc/computers/camera/rpicam_apps_building.adoc
@@ -18,7 +18,7 @@ Raspberry Pi OS includes a pre-installed copy of `rpicam-apps`. Before building 
 
 [source,console]
 ----
-$ sudo apt-get remove --purge rpicam-apps
+$ sudo apt remove --purge rpicam-apps
 ----
 
 ==== Building `rpicam-apps` without building `libcamera`

--- a/documentation/asciidoc/computers/os/updating.adoc
+++ b/documentation/asciidoc/computers/os/updating.adoc
@@ -171,7 +171,7 @@ If you update your firmware to the latest release and experience an issue, use t
 
 [source,console]
 ----
-$ sudo apt-get update
+$ sudo apt update
 $ sudo apt install --reinstall raspi-firmware
 ----
 

--- a/documentation/asciidoc/computers/remote-access/network-boot-ipv6.adoc
+++ b/documentation/asciidoc/computers/remote-access/network-boot-ipv6.adoc
@@ -62,7 +62,7 @@ Alternatively you can use a standalone TFTP server like `tftpd-hpa`.
 
 [,bash]
 ----
-$ sudo apt-get install tftpd-hpa
+$ sudo apt install tftpd-hpa
 $ sudo systemctl start tftpd-hpa
 ----
 
@@ -72,7 +72,7 @@ DHCP in IPv6 has changed a lot. We need DHCP to at least tell us the address of 
 
 [,bash]
 ----
-$ sudo apt-get install isc-dhcp-server
+$ sudo apt install isc-dhcp-server
 ----
 
 Modify the configuration in `/etc/default/isc-dhcp-server`
@@ -133,7 +133,7 @@ To use IPv6 you really need a router and ISP that supports IPv6. There are sites
 
 [,bash]
 ----
-sudo apt-get install ndisc6
+sudo apt install ndisc6
 rdisc6 -1 eth0
 ----
 


### PR DESCRIPTION
There's no real need to use `apt-get` in any of these situations, so we should always just use `apt` for simplicity and consistency.

We can always use `apt-get` if an example truly requires it. But I haven't come across any of those!