### PR TITLE
fix "ffmpeg -codec" to "ffmpeg -codecs"

### DIFF
--- a/documentation/asciidoc/computers/camera/rpicam_options_libav.adoc
+++ b/documentation/asciidoc/computers/camera/rpicam_options_libav.adoc
@@ -28,7 +28,7 @@ Enables audio recording. When enabled, you must also specify an xref:camera_soft
 
 Default value: `aac`
 
-Selects an audio codec for output. For a list of available codecs, run `ffmpeg -codec`.
+Selects an audio codec for output. For a list of available codecs, run `ffmpeg -codecs`.
 
 ==== `audio-bitrate`
 


### PR DESCRIPTION
the "s" was missing in the flag to list available codec

using ffmpeg -codec returns:
Missing argument for option 'codec'.
Error splitting the argument list: Invalid argument
