### PR TITLE
Changed misleading video option for single HDMI models

### DIFF
--- a/documentation/asciidoc/computers/configuration/kernel-command-line-config.adoc
+++ b/documentation/asciidoc/computers/configuration/kernel-command-line-config.adoc
@@ -62,7 +62,7 @@ Possible options for the display type - the first part of the `video=` entry - i
 | Video Option | Display
 
 | HDMI-A-1
-| HDMI 1 (HDMI 0 on silkscreen of Raspberry Pi 4B, HDMI on single HDMI boards)
+| HDMI 1 (HDMI 0 on silkscreen of Raspberry Pi 4B, use HDMI-A-1 on single HDMI boards)
 
 | HDMI-A-2
 | HDMI 2 (HDMI 1 on silkscreen of Raspberry Pi 4B)


### PR DESCRIPTION
With fkms/kms it is `HDMI-A-1` on a Rpi3 b+ and not `HDMI` as stated before.