### PR TITLE
Remove context tags from toc links/urls

### DIFF
--- a/scripts/create_nav.py
+++ b/scripts/create_nav.py
@@ -17,6 +17,8 @@ def heading_to_anchor(filepath, heading, anchor):
     if anchor is None:
         # The replace(' -- ', '') is needed because AsciiDoc transforms ' -- ' to '&#8201;&#8212;&#8201;' (narrow-space, em-dash, narrow-space) which then collapses down to '' when calculating the anchor
         anchor = re.sub(r'\-+', '-', re.sub(r'[^-\w]', '', heading.lower().replace(' -- ', '').replace(' ', '-').replace('.', '-')))
+        # remove any context tags that slipped into the anchor
+        anchor = re.sub(r'(strong-classcontexttag-)(rp\d+)(rp\d+strong)', '\\2', anchor)
     if filepath not in file_headings:
         file_headings[filepath] = set()
     proposed_anchor = anchor


### PR DESCRIPTION
Fixes this:

<img width="1047" alt="Screenshot 2024-08-08 at 10 02 00 AM" src="https://github.com/user-attachments/assets/66ef9ff6-82be-4c60-baed-813a76a33d08">
