### PR TITLE
Update Pico 2 Design Files description to reflect correct software

### DIFF
--- a/documentation/asciidoc/microcontrollers/pico-series/about_pico.adoc
+++ b/documentation/asciidoc/microcontrollers/pico-series/about_pico.adoc
@@ -46,7 +46,7 @@ NOTE: Both boards have a three pin Serial Wire Debug (SWD) header. However, the 
 image::images/pico-2-r4-pinout.svg[]
 
 * Download the https://datasheets.raspberrypi.com/pico/Pico-2-Pinout.pdf[Pinout Diagram] (PDF)
-* Download https://datasheets.raspberrypi.com/pico/RPi-Pico-2-PUBLIC-20240708.zip[Design Files] (Cadence Allegro)
+* Download https://datasheets.raspberrypi.com/pico/RPi-Pico-2-PUBLIC-20240708.zip[Design Files] (KiCad)
 * Download https://datasheets.raspberrypi.com/pico/Pico-2-step-20240708.zip[STEP File]
 * Download https://datasheets.raspberrypi.com/pico/Pico-2-Fritzing-20240708.fzpz[Fritzing Part] for Raspberry Pi Pico
 


### PR DESCRIPTION
The provided files are for KiCad, not Cadence Allegro, so I corrected the description.