### PR TITLE
Fix overlays README link

### DIFF
--- a/documentation/asciidoc/computers/configuration/device-tree.adoc
+++ b/documentation/asciidoc/computers/configuration/device-tree.adoc
@@ -824,7 +824,7 @@ The loading of overlays at runtime is a recent addition to the kernel, and at th
 [[part3.6]]
 ==== Supported overlays and parameters
 
-Please refer to the https://github.com/raspberrypi/firmware/blob/master/boot/firmware/overlays/README[README] file found alongside the overlay `.dtbo` files in `/boot/firmware/overlays`. It is kept up-to-date with additions and changes.
+For a list of supported overlays and parameters, see the https://github.com/raspberrypi/firmware/blob/master/boot/overlays/README[firmware README] file found alongside the overlay `.dtbo` files in `/boot/overlays`. It is kept up-to-date with additions and changes.
 
 [[part4]]
 === Firmware parameters

--- a/documentation/asciidoc/computers/configuration/device-tree.adoc
+++ b/documentation/asciidoc/computers/configuration/device-tree.adoc
@@ -824,7 +824,7 @@ The loading of overlays at runtime is a recent addition to the kernel, and at th
 [[part3.6]]
 ==== Supported overlays and parameters
 
-For a list of supported overlays and parameters, see the https://github.com/raspberrypi/firmware/blob/master/boot/overlays/README[firmware README] file found alongside the overlay `.dtbo` files in `/boot/overlays`. It is kept up-to-date with additions and changes.
+For a list of supported overlays and parameters, see the https://github.com/raspberrypi/firmware/blob/master/boot/overlays/README[firmware README] file found alongside the overlay `.dtbo` files in `/boot/firmware/overlays`. It is kept up-to-date with additions and changes.
 
 [[part4]]
 === Firmware parameters

--- a/documentation/asciidoc/computers/configuration/device-tree.adoc
+++ b/documentation/asciidoc/computers/configuration/device-tree.adoc
@@ -824,7 +824,7 @@ The loading of overlays at runtime is a recent addition to the kernel, and at th
 [[part3.6]]
 ==== Supported overlays and parameters
 
-For a list of supported overlays and parameters, see the https://github.com/raspberrypi/firmware/blob/master/boot/overlays/README[firmware README] file found alongside the overlay `.dtbo` files in `/boot/firmware/overlays`. It is kept up-to-date with additions and changes.
+For a list of supported overlays and parameters, see the https://github.com/raspberrypi/firmware/blob/master/boot/overlays/README[README] file found alongside the overlay `.dtbo` files in `/boot/firmware/overlays`. It is kept up-to-date with additions and changes.
 
 [[part4]]
 === Firmware parameters


### PR DESCRIPTION
Fixes https://github.com/raspberrypi/documentation/issues/3822

~I'm not sure why the GitHub repo path doesn't use `/boot/firmware/` like Bookworm, but the link doesn't lie.~
Explanation: `/boot/firmware` is the mountpoint for the first FAT partition, so something in `/overlays/README` on the first partition will be visible at `/boot/firmware/overlays/README` from within Raspberry Pi OS.






