### PR TITLE
Small correction in Connect usage docs

### DIFF
--- a/documentation/asciidoc/services/connect/use.adoc
+++ b/documentation/asciidoc/services/connect/use.adoc
@@ -184,7 +184,7 @@ In the Connect dashboard, the **Remote shell** badge and the **Remote shell** op
 
 image::images/remote-shell-disabled.png[width="80%"]
 
-To re-enable screen sharing, do one of the following:
+To re-enable remote shell access, do one of the following:
 
 * click the Connect system tray icon and select **Allow remote shell**
 * run the following command:


### PR DESCRIPTION
It mistakenly said "to re-enable screen sharing" in the part about re-enabling remote shell access