### PR TITLE
Update doc to reflect correct number of options avilable for two configuration setting.

### DIFF
--- a/documentation/asciidoc/computers/configuration/raspi-config.adoc
+++ b/documentation/asciidoc/computers/configuration/raspi-config.adoc
@@ -551,7 +551,7 @@ Enable or disable the serial connection hardware.
 
 [source,console]
 ----
-$ sudo raspi-config nonint do_serial_hw <0/1/2>
+$ sudo raspi-config nonint do_serial_hw <0/1>
 ----
 
 * `0`: enable serial port
@@ -564,7 +564,7 @@ Enable or disable shell and kernel messages on the serial connection.
 
 [source,console]
 ----
-$ sudo raspi-config nonint do_serial_cons <0/1/2>
+$ sudo raspi-config nonint do_serial_cons <0/1>
 ----
 
 * `0`: enable console over serial port


### PR DESCRIPTION
The config option raspi-config 'do_serial' got split up into two commands with the release of the PI 5.
It looks like someone forgot to remove the '2' from the "<0/1/2>" after the split and copied it to both of the new settings

Was:
raspi-config nonint do_serial 2

Now:
raspi-config nonint do_serial_hw 0
raspi-config nonint do_serial_cons 1"


There is also this PR https://github.com/raspberrypi/pico-setup/pull/30 to apply this change for a pico setup script. just gonna post it here in hopes of getting some movement:)
