### PR TITLE
correct root of SD card to first partition

### DIFF
--- a/documentation/asciidoc/computers/configuration/headless.adoc
+++ b/documentation/asciidoc/computers/configuration/headless.adoc
@@ -26,14 +26,14 @@ NOTE: Previous versions of Raspberry Pi OS made use of a `wpa_supplicant.conf` f
 With no keyboard or monitor, you need a way to xref:remote-access.adoc[remotely control] your headless Raspberry Pi. On first boot, the only option is SSH. To enable SSH on a fresh installation of Raspberry Pi OS, choose one of the following methods:
 
 * enable SSH in the OS customisation menu in Raspberry Pi Imager, then enter a username and password
-* create a file named `ssh` at the root of the SD card, then configure a user manually with `userconf.txt` following the instructions in the section below
+* create a file named `ssh` at the root of the first partition of the SD card (labeled bootfs), then configure a user manually with `userconf.txt` following the instructions in the section below
 
 For more information, see xref:remote-access.adoc#ssh[set up an SSH server]. Once you've connected over SSH, you can use `raspi-config` to xref:remote-access.adoc#vnc[enable VNC] if you'd prefer a graphical desktop environment.
 
 [[configuring-a-user]]
 ==== Configure a user manually
 
-At the root of your SD card, create a file named `userconf.txt`.
+At the root of the first partion of your SD card (the filesystem labeled bootfs), create a file named `userconf.txt`.
 
 This file should contain a single line of text, consisting of `<username>:<password>`: your desired username, followed immediately by a colon, followed immediately by an *encrypted* representation of the password you want to use.
 

--- a/documentation/asciidoc/computers/configuration/headless.adoc
+++ b/documentation/asciidoc/computers/configuration/headless.adoc
@@ -33,7 +33,7 @@ For more information, see xref:remote-access.adoc#ssh[set up an SSH server]. Onc
 [[configuring-a-user]]
 ==== Configure a user manually
 
-At the root of the first partion of your SD card (the filesystem labeled bootfs), create a file named `userconf.txt`.
+At the root of the first partion of your SD card (the filesystem labeled `bootfs`), create a file named `userconf.txt`.
 
 This file should contain a single line of text, consisting of `<username>:<password>`: your desired username, followed immediately by a colon, followed immediately by an *encrypted* representation of the password you want to use.
 

--- a/documentation/asciidoc/computers/configuration/headless.adoc
+++ b/documentation/asciidoc/computers/configuration/headless.adoc
@@ -26,7 +26,7 @@ NOTE: Previous versions of Raspberry Pi OS made use of a `wpa_supplicant.conf` f
 With no keyboard or monitor, you need a way to xref:remote-access.adoc[remotely control] your headless Raspberry Pi. On first boot, the only option is SSH. To enable SSH on a fresh installation of Raspberry Pi OS, choose one of the following methods:
 
 * enable SSH in the OS customisation menu in Raspberry Pi Imager, then enter a username and password
-* create a file named `ssh` at the root of the first partition of the SD card (labeled bootfs), then configure a user manually with `userconf.txt` following the instructions in the section below
+* create a file named `ssh` at the root of the first partition of the SD card (labeled `bootfs`), then configure a user manually with `userconf.txt` following the instructions in the section below
 
 For more information, see xref:remote-access.adoc#ssh[set up an SSH server]. Once you've connected over SSH, you can use `raspi-config` to xref:remote-access.adoc#vnc[enable VNC] if you'd prefer a graphical desktop environment.
 


### PR DESCRIPTION
Change confusing wording of location for headless config file