### PR TITLE
cm-emmc-flashing: Update to refer to the mass-storage-gadget

### DIFF
--- a/documentation/asciidoc/computers/compute-module/cm-emmc-flashing.adoc
+++ b/documentation/asciidoc/computers/compute-module/cm-emmc-flashing.adoc
@@ -103,7 +103,10 @@ To set up software on a Windows host device:
 
 . Connect the IO Board to power. Windows should discover the hardware and configure the required drivers.
 
-. Double-click on `RPiBoot.exe` to run it. After a few seconds, the Compute Module eMMC should appear as a USB mass storage device.
+. On CM4 or CM5 run the 'Raspberry Pi - Mass Storage Gadget - 64-bit' from the start menu. After a few seconds, the Compute Module eMMC or NVMe will appear as USB mass storage devices. This also provides a debug console as a serial port gadget.
+
+. On CM3 or older select 'rpiboot' Double-click on `RPiBoot.exe` to run it. After a few seconds, the Compute Module eMMC should appear as a USB mass storage device.
+
 
 TIP: Alternatively, you can https://github.com/raspberrypi/usbboot[build `rpiboot` from source].
 

--- a/documentation/asciidoc/computers/compute-module/cm-emmc-flashing.adoc
+++ b/documentation/asciidoc/computers/compute-module/cm-emmc-flashing.adoc
@@ -103,9 +103,9 @@ To set up software on a Windows host device:
 
 . Connect the IO Board to power. Windows should discover the hardware and configure the required drivers.
 
-. On CM4 and later devices, select 'Raspberry Pi - Mass Storage Gadget - 64-bit' from the start menu. After a few seconds, the Compute Module eMMC or NVMe will appear as USB mass storage devices. This also provides a debug console as a serial port gadget.
+. On CM4 and later devices, select **Raspberry Pi - Mass Storage Gadget - 64-bit** from the start menu. After a few seconds, the Compute Module eMMC or NVMe will appear as USB mass storage devices. This also provides a debug console as a serial port gadget.
 
-. On CM3 or older devices, select 'rpiboot'. Double-click on `RPiBoot.exe` to run it. After a few seconds, the Compute Module eMMC should appear as a USB mass storage device.
+. On CM3 and older devices, select **rpiboot**. Double-click on `RPiBoot.exe` to run it. After a few seconds, the Compute Module eMMC should appear as a USB mass storage device.
 
 
 TIP: Alternatively, you can https://github.com/raspberrypi/usbboot[build `rpiboot` from source].

--- a/documentation/asciidoc/computers/compute-module/cm-emmc-flashing.adoc
+++ b/documentation/asciidoc/computers/compute-module/cm-emmc-flashing.adoc
@@ -103,9 +103,9 @@ To set up software on a Windows host device:
 
 . Connect the IO Board to power. Windows should discover the hardware and configure the required drivers.
 
-. On CM4 or CM5 run the 'Raspberry Pi - Mass Storage Gadget - 64-bit' from the start menu. After a few seconds, the Compute Module eMMC or NVMe will appear as USB mass storage devices. This also provides a debug console as a serial port gadget.
+. On CM4 and later devices, select 'Raspberry Pi - Mass Storage Gadget - 64-bit' from the start menu. After a few seconds, the Compute Module eMMC or NVMe will appear as USB mass storage devices. This also provides a debug console as a serial port gadget.
 
-. On CM3 or older select 'rpiboot' Double-click on `RPiBoot.exe` to run it. After a few seconds, the Compute Module eMMC should appear as a USB mass storage device.
+. On CM3 or older devices, select 'rpiboot'. Double-click on `RPiBoot.exe` to run it. After a few seconds, the Compute Module eMMC should appear as a USB mass storage device.
 
 
 TIP: Alternatively, you can https://github.com/raspberrypi/usbboot[build `rpiboot` from source].


### PR DESCRIPTION
On CM4 and above the mass storage gadget is much faster than the previous VPU firmware USB MSD gadget implemenation. Point readers towards this first.