### PR TITLE
Use arm-none-eabi-gdb on macOS to support x86 and aarch64 macOS devices

### DIFF
--- a/documentation/asciidoc/microcontrollers/debug-probe/installing-tools.adoc
+++ b/documentation/asciidoc/microcontrollers/debug-probe/installing-tools.adoc
@@ -52,12 +52,10 @@ Run the following command to install `gdb`:
 
 [source,console]
 ----
-$ brew install gdb
+$ brew install arm-none-eabi-gdb
 ----
 
 You can safely ignore the request for "special privileges" messages on installation.
-
-IMPORTANT: GDB does not support `gdb` Arm-based Macs. Instead, either https://gist.github.com/m0sys/711d0ec5e52102c6ba44451caf38bd38[install `gdb` from source] or use `lldb` instead of `gdb`. There is https://inbox.sourceware.org/gdb/3185c3b8-8a91-4beb-a5d5-9db6afb93713@Spark/[no official support] from the developers for running GDB on Arm-based Macs. Support for GDB can be found on the https://inbox.sourceware.org/gdb/[GDB mailing list] on Sourceware.org. `lldb` is installed as part of the Xcode Command Line Tools.
 
 ==== MS Windows
 

--- a/documentation/asciidoc/microcontrollers/debug-probe/swd-connection.adoc
+++ b/documentation/asciidoc/microcontrollers/debug-probe/swd-connection.adoc
@@ -59,4 +59,4 @@ $ gdb blink.elf
 GDB doesn't work on all platforms. Use one of the following alternatives instead of `gdb`, depending on your operating system and device:
 
 * On Linux devices that are _not_ Raspberry Pis, use `gdb-multiarch`.
-* On Arm-based macOS devices, use `lldb`.
+* On macOS devices, use `arm-none-eabi-gdb`.


### PR DESCRIPTION
`arm-none-eabi-gdb` works to debug the RP2040 on both x86 and aarch64 macOS devices.