### PR TITLE
Add rpi-otp-private-key clarification

### DIFF
--- a/documentation/asciidoc/computers/raspberry-pi/raspberry-pi-industrial.adoc
+++ b/documentation/asciidoc/computers/raspberry-pi/raspberry-pi-industrial.adoc
@@ -173,7 +173,7 @@ See https://gitlab.com/cryptsetup/cryptsetup[Cryptsetup] for more information ab
 
 ==== Program a key into OTP with `rpi-otp-private-key`
 
-NOTE: The `rpi-otp-private-key` script only works on devices that use the Broadcom xref:processors.adoc#bcm2711[BCM2711] or xref:processors.adoc#bcm2712[BCM2712]) processors.
+NOTE: The `rpi-otp-private-key` script only works on devices that use the Broadcom xref:processors.adoc#bcm2711[BCM2711] or xref:processors.adoc#bcm2712[BCM2712] processors.
 
 The https://github.com/raspberrypi/rpi-eeprom/blob/master/tools/rpi-otp-private-key[`rpi-otp-private-key`] script wraps the device private key `vcmailbox` APIs to make it easier to read and write a key in the OpenSSL format.
 

--- a/documentation/asciidoc/computers/raspberry-pi/raspberry-pi-industrial.adoc
+++ b/documentation/asciidoc/computers/raspberry-pi/raspberry-pi-industrial.adoc
@@ -172,6 +172,7 @@ secure-boot / file-system encryption is not required, then the device private ke
 See https://gitlab.com/cryptsetup/cryptsetup[Cryptsetup] for more information about open-source disk encryption.
 
 ==== Program a key into OTP with `rpi-otp-private-key`
+NOTE: The `rpi-otp-private-key` script can only be used on devices with the Broadcom BCM2711 or BCM2712 processor.
 
 The https://github.com/raspberrypi/rpi-eeprom/blob/master/tools/rpi-otp-private-key[`rpi-otp-private-key`] script wraps the device private key `vcmailbox` APIs to make it easier to read and write a key in the OpenSSL format.
 

--- a/documentation/asciidoc/computers/raspberry-pi/raspberry-pi-industrial.adoc
+++ b/documentation/asciidoc/computers/raspberry-pi/raspberry-pi-industrial.adoc
@@ -172,7 +172,8 @@ secure-boot / file-system encryption is not required, then the device private ke
 See https://gitlab.com/cryptsetup/cryptsetup[Cryptsetup] for more information about open-source disk encryption.
 
 ==== Program a key into OTP with `rpi-otp-private-key`
-NOTE: The `rpi-otp-private-key` script can only be used on devices with the Broadcom BCM2711 or BCM2712 processor.
+
+NOTE: The `rpi-otp-private-key` script only works on devices that use the Broadcom xref:processors.adoc#bcm2711[BCM2711] or xref:processors.adoc#bcm2712[BCM2712]) processors.
 
 The https://github.com/raspberrypi/rpi-eeprom/blob/master/tools/rpi-otp-private-key[`rpi-otp-private-key`] script wraps the device private key `vcmailbox` APIs to make it easier to read and write a key in the OpenSSL format.
 


### PR DESCRIPTION
See https://github.com/raspberrypi/rpi-eeprom/issues/607. Although the device-specific private key OTP area exists on all Raspberry Pi boards, the `rpi-otp-private-key` script only supports BCM2711 and BCM2712-based boards.