### PR TITLE
configtxt/boot: Update arm_64bit flag

### DIFF
--- a/documentation/asciidoc/computers/config_txt/boot.adoc
+++ b/documentation/asciidoc/computers/config_txt/boot.adoc
@@ -50,6 +50,7 @@ The following Raspberry Pi models support this flag:
 * Compute Module 3
 * Compute Module 3+
 * Compute Module 4
+* Compute Module 4S
 
 Later models, such as Raspberry Pi 5, _only_ support the 64-bit kernel. Such models do not support this flag.
 

--- a/documentation/asciidoc/computers/config_txt/boot.adoc
+++ b/documentation/asciidoc/computers/config_txt/boot.adoc
@@ -25,7 +25,6 @@ The Raspberry Pi 5 firmware defaults to loading `kernel_2712.img` because this i
 
 === `arm_64bit`
 
-NOTE: This flag has been removed from Raspberry Pi 5, as Raspberry Pi 5 only supports a 64-bit kernel.
 
 If set to 1, the kernel will be started in 64-bit mode. Setting to 0 selects 32-bit mode.
 

--- a/documentation/asciidoc/computers/config_txt/boot.adoc
+++ b/documentation/asciidoc/computers/config_txt/boot.adoc
@@ -29,7 +29,7 @@ If set to 1, the kernel will be started in 64-bit mode. Setting to 0 selects 32-
 
 In 64-bit mode, the firmware will choose an appropriate kernel (e.g. `kernel8.img`), unless there is an explicit `kernel` option defined, in which case that is used instead.
 
-Defaults to 1 on Pi 4s (Pi 4B, Pi 400, CM4 and CM4S), and 0 on all other platforms. However, if the name given in an explicit `kernel` option matches one of the known kernels then `arm_64bit` will be set accordingly.
+Defaults to 1 on Raspberry Pi 4, 5, 400 and Compute Module 4, 4S platforms. Defaults to 0 on all other platforms. However, if the name given in an explicit `kernel` option matches one of the known kernels then `arm_64bit` will be set accordingly.
 
 NOTE: 64-bit kernels may be uncompressed image files or a gzip archive of an image (which can still be called kernel8.img; the bootloader will recognize the archive from the signature bytes at the beginning). The 64-bit kernel will only work on the Raspberry Pi 3, 3+, 4, 400, Zero 2 W and 2B rev 1.2, and Raspberry Pi Compute Modules 3, 3+ and 4. Raspberry Pi 5 only supports a 64-bit kernel, so this parameter has been removed for that device.
 

--- a/documentation/asciidoc/computers/config_txt/boot.adoc
+++ b/documentation/asciidoc/computers/config_txt/boot.adoc
@@ -33,7 +33,26 @@ In 64-bit mode, the firmware will choose an appropriate kernel (e.g. `kernel8.im
 
 Defaults to 1 on Raspberry Pi 4, 400 and Compute Module 4, 4S platforms. Defaults to 0 on all other platforms. However, if the name given in an explicit `kernel` option matches one of the known kernels then `arm_64bit` will be set accordingly.
 
-NOTE: 64-bit kernels may be uncompressed image files or a gzip archive of an image (which can still be called kernel8.img; the bootloader will recognize the archive from the signature bytes at the beginning). The 64-bit kernel will only work on the Raspberry Pi 3, 3+, 4, 400, Zero 2 W and 2B rev 1.2, and Raspberry Pi Compute Modules 3, 3+ and 4.
+64-bit kernels come in the following forms:
+
+* uncompressed image files
+* gzip archives of an image
+
+Both forms may use the `img` file extension; the bootloader recognizes archives using signature bytes at the start of the file.
+
+The following Raspberry Pi models support this flag:
+
+* 2B rev 1.2
+* 3
+* 3+
+* 4
+* 400
+* Zero 2 W
+* Compute Module 3
+* Compute Module 3+
+* Compute Module 4
+
+Later models, such as Raspberry Pi 5, _only_ support the 64-bit kernel. Such models do not support this flag.
 
 === `ramfsfile`
 

--- a/documentation/asciidoc/computers/config_txt/boot.adoc
+++ b/documentation/asciidoc/computers/config_txt/boot.adoc
@@ -25,13 +25,15 @@ The Raspberry Pi 5 firmware defaults to loading `kernel_2712.img` because this i
 
 === `arm_64bit`
 
+NOTE: This flag has been removed from Raspberry Pi 5, as Raspberry Pi 5 only supports a 64-bit kernel.
+
 If set to 1, the kernel will be started in 64-bit mode. Setting to 0 selects 32-bit mode.
 
 In 64-bit mode, the firmware will choose an appropriate kernel (e.g. `kernel8.img`), unless there is an explicit `kernel` option defined, in which case that is used instead.
 
-Defaults to 1 on Raspberry Pi 4, 5, 400 and Compute Module 4, 4S platforms. Defaults to 0 on all other platforms. However, if the name given in an explicit `kernel` option matches one of the known kernels then `arm_64bit` will be set accordingly.
+Defaults to 1 on Raspberry Pi 4, 400 and Compute Module 4, 4S platforms. Defaults to 0 on all other platforms. However, if the name given in an explicit `kernel` option matches one of the known kernels then `arm_64bit` will be set accordingly.
 
-NOTE: 64-bit kernels may be uncompressed image files or a gzip archive of an image (which can still be called kernel8.img; the bootloader will recognize the archive from the signature bytes at the beginning). The 64-bit kernel will only work on the Raspberry Pi 3, 3+, 4, 400, Zero 2 W and 2B rev 1.2, and Raspberry Pi Compute Modules 3, 3+ and 4. Raspberry Pi 5 only supports a 64-bit kernel, so this parameter has been removed for that device.
+NOTE: 64-bit kernels may be uncompressed image files or a gzip archive of an image (which can still be called kernel8.img; the bootloader will recognize the archive from the signature bytes at the beginning). The 64-bit kernel will only work on the Raspberry Pi 3, 3+, 4, 400, Zero 2 W and 2B rev 1.2, and Raspberry Pi Compute Modules 3, 3+ and 4.
 
 === `ramfsfile`
 


### PR DESCRIPTION
A casual reader might have previously assumed Raspberry Pi 5 requires this flag to boot in 64-bit mode. That is incorrect - Raspberry Pi 5 follows Raspberry Pi 4 in assuming 64-bit mode by default.

Edit the defaults line to reflect this, and further edit it to include more complete platform names.