### PR TITLE
Only load Google Analytics 4

### DIFF
--- a/jekyll-assets/_includes/head.html
+++ b/jekyll-assets/_includes/head.html
@@ -20,12 +20,10 @@
 <link rel="stylesheet" href="{{ site.baseurl }}/css/tabs.css?ver={{ site.time | date: '%s' }}">
 <link rel="stylesheet" href="{{ site.baseurl }}/css/asciidoctor-tabs.css?ver={{ site.time | date: '%s' }}">
 <link rel="stylesheet" href="{{ site.baseurl }}/css/syntax-highlighting.css?ver={{ site.time | date: '%s' }}">
-<script async src="https://www.googletagmanager.com/gtag/js?id=UA-180927933-8"></script>
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-V8TFXM3BKJ"></script>
 <script>
   window.dataLayer = window.dataLayer || [];
   function gtag(){dataLayer.push(arguments);}
   gtag('js', new Date());
-  gtag('config', 'UA-180927933-8', { 'anonymize_ip': true });
-  gtag('config', 'G-V8TFXM3BKJ');
-  gtag('config', 'G-22FD70LWDS');
+  gtag('config', 'G-V8TFXM3BKJ', { 'anonymize_ip': true });
 </script>


### PR DESCRIPTION
As Universal Analytics has been "sunset" for a while, only send analytics to the www.raspberrypi.com property.
