### PR TITLE
Update Fan Cases with mention of the Pi 4 Case Fan

### DIFF
--- a/documentation/asciidoc/computers/raspberry-pi/frequency-management.adoc
+++ b/documentation/asciidoc/computers/raspberry-pi/frequency-management.adoc
@@ -66,9 +66,9 @@ Raspberry Pi 5 has two official fan options to assist with cooling:
 * https://www.raspberrypi.com/products/active-cooler/[Active Cooler]
 * https://www.raspberrypi.com/products/raspberry-pi-5-case/[Case for Raspberry Pi 5]
 
-Both of these plug into the four-pin JST-SH PWM fan connector located in the upper right of the board between the 40-pin GPIO header and the USB 2 ports. The fan connector pulls from the same current limit as USB peripherals. We recommend the Active Cooler case for overclockers, since it provides better cooling performance.
+Both of the Raspberry Pi 5 fan options plug into the four-pin JST-SH PWM fan connector located in the upper right of the board between the 40-pin GPIO header and the USB 2 ports. The fan connector pulls from the same current limit as USB peripherals. We recommend the Active Cooler case for overclockers, since it provides better cooling performance.
 
-Both of the available official accessories are actively managed by Raspberry Pi firmware. As the temperature of the Raspberry Pi increases, the fan reacts in the following way:
+The fans of the Active Cooler and the Raspberry Pi 5 Case are both actively managed by Raspberry Pi firmware. As the temperature of the Raspberry Pi 5 increases, the fan reacts in the following way:
 
 * below 50°C, the fan does not spin at all (0% speed)
 * at 50°C, the fan turns on at a low speed (30% speed)
@@ -82,7 +82,7 @@ At boot the fan is turned on, and the tachometer input is checked to see if the 
 
 ==== Fan connector pinout
 
-The fan connector is a 1mm pitch JST-SH socket containing the following four pins:
+The Raspberry Pi 5 fan connector is a 1mm pitch JST-SH socket containing the following four pins:
 
 [cols="1,2,2",width="50"%"]
 |===

--- a/documentation/asciidoc/computers/raspberry-pi/frequency-management.adoc
+++ b/documentation/asciidoc/computers/raspberry-pi/frequency-management.adoc
@@ -59,6 +59,8 @@ Thanks to built-in throttling, heatsinks are not necessary to prevent overheatin
 
 === Fan cases
 
+For the Raspberry Pi 4, you have the option of adding the https://www.raspberrypi.com/products/raspberry-pi-4-case-fan/[Raspberry Pi 4 Case Fan] to the lid of the Raspberry Pi 4 case.
+
 Raspberry Pi 5 has two official fan options to assist with cooling:
 
 * https://www.raspberrypi.com/products/active-cooler/[Active Cooler]

--- a/documentation/asciidoc/computers/raspberry-pi/frequency-management.adoc
+++ b/documentation/asciidoc/computers/raspberry-pi/frequency-management.adoc
@@ -59,16 +59,22 @@ Thanks to built-in throttling, heatsinks are not necessary to prevent overheatin
 
 === Fan cases
 
-For the Raspberry Pi 4, you have the option of adding the https://www.raspberrypi.com/products/raspberry-pi-4-case-fan/[Raspberry Pi 4 Case Fan] to the lid of the Raspberry Pi 4 case.
+To ensure the best performance for your Raspberry Pi, use an active cooling solution such as a fan. Raspberry Pi firmware manages fan speeds for all official fans.
 
-Raspberry Pi 5 has two official fan options to assist with cooling:
+==== Raspberry Pi 4 fan
+
+For Raspberry Pi 4, add the https://www.raspberrypi.com/products/raspberry-pi-4-case-fan/[Raspberry Pi 4 Case Fan] to the lid of the Raspberry Pi 4 case.
+
+==== Raspberry Pi 5 fans 
+
+For Raspberry Pi 5, use one of the official fan options:
 
 * https://www.raspberrypi.com/products/active-cooler/[Active Cooler]
 * https://www.raspberrypi.com/products/raspberry-pi-5-case/[Case for Raspberry Pi 5]
 
 Both of the Raspberry Pi 5 fan options plug into the four-pin JST-SH PWM fan connector located in the upper right of the board between the 40-pin GPIO header and the USB 2 ports. The fan connector pulls from the same current limit as USB peripherals. We recommend the Active Cooler case for overclockers, since it provides better cooling performance.
 
-The fans of the Active Cooler and the Raspberry Pi 5 Case are both actively managed by Raspberry Pi firmware. As the temperature of the Raspberry Pi 5 increases, the fan reacts in the following way:
+As the temperature of the Raspberry Pi 5 increases, the fan reacts in the following way:
 
 * below 50°C, the fan does not spin at all (0% speed)
 * at 50°C, the fan turns on at a low speed (30% speed)
@@ -80,7 +86,7 @@ Temperature decreases use the same mapping with a 5°C **hysteresis**; fan speed
 
 At boot the fan is turned on, and the tachometer input is checked to see if the fan is spinning. If it is, then the `cooling_fan` device tree overlay is enabled. This overlay is in `bcm2712-rpi-5-b.dtb` by default, but with `status=disabled`.
 
-==== Fan connector pinout
+==== Raspberry Pi 5 fan connector pinout
 
 The Raspberry Pi 5 fan connector is a 1mm pitch JST-SH socket containing the following four pins:
 

--- a/documentation/asciidoc/computers/raspberry-pi/introduction.adoc
+++ b/documentation/asciidoc/computers/raspberry-pi/introduction.adoc
@@ -189,7 +189,7 @@ a|
 * single-lane https://datasheets.raspberrypi.com/pcie/pcie-connector-standard.pdf[PCIe FFC connector]
 * https://datasheets.raspberrypi.com/debug/debug-connector-specification.pdf[UART connector]
 * RTC battery connector
-* xref:raspberry-pi.adoc#fan-connector-pinout[four-pin JST-SH PWM fan connector]
+* xref:raspberry-pi.adoc#raspberry-pi-5-fan-connector-pinout[four-pin JST-SH PWM fan connector]
 * PoE+-capable Gigabit Ethernet (1Gb/s)
 * 2.4/5GHz dual-band 802.11ac Wi-Fi 5 (300Mb/s)
 * Bluetooth 5, Bluetooth Low Energy (BLE)


### PR DESCRIPTION
Resolves https://github.com/raspberrypi/documentation/issues/3566.

Keeping it minimal here! My thinking (for these types of tickets in general) is that if the current/latest model is already documented, we only need to include previous models for completeness. That means that we won't have the finer details of Pi 4 fan behaviour in the doc (at least until there's a good use case to go around and dig them up!) The assembly and usage instructions for both fans can be found on their respective product pages and product briefs.

Other notes (just general tech writing thoughts):
* Since I chose to keep the Pi 4 fan mention quite short, I didn't create a new section for it. 
* I put the mention at the top of the Fan Cases section, rather than at the bottom. That particular section ends with a table, and in general I'll avoid placing short pieces of information right below tables or graphics, since that makes them somewhat easy to miss.
* I made some small readability updates to reinforce the fact that the detailed information refers to the Pi 5 fan only.