### PR TITLE
Remove book callouts

### DIFF
--- a/documentation/asciidoc/accessories/sense-hat/software.adoc
+++ b/documentation/asciidoc/accessories/sense-hat/software.adoc
@@ -189,8 +189,3 @@ $ sudo ./eepflash.sh -f=sense.eep -t=24c32 -w
 $ i2cset -y -f 1 0x46 0xf3 0
 ----
 
-[.booklink, booktype="free", link=https://github.com/raspberrypipress/released-pdfs/raw/main/experiment-with-the-sense-hat.pdf, image=image::images/experiment-with-the-sense-hat.png[]]
-
-== Further reading
-
-You can find more information on how to use the Sense HAT in the Raspberry Pi Press book https://github.com/raspberrypipress/released-pdfs/raw/main/experiment-with-the-sense-hat.pdf[Experiment with the Sense HAT]. Written by The Raspberry Pi Foundation's Education Team, it is part of the MagPi Essentials series published by Raspberry Pi Press. The book covers the background of the Astro Pi project, and walks you through how to make use of all the Sense HAT features using the xref:sense-hat.adoc#use-the-sense-hat-with-python[Python library].

--- a/documentation/asciidoc/computers/getting-started/wrapping-up.adoc
+++ b/documentation/asciidoc/computers/getting-started/wrapping-up.adoc
@@ -18,20 +18,3 @@ Our tutorials demonstrate various ways you can use your new computer. You can le
 
 For support with official Raspberry Pi products, or to connect with other Raspberry Pi users, visit the https://forums.raspberrypi.com/[Raspberry Pi forums].
 
-
-[.booklink, booktype="buy", link=https://store.rpipress.cc/products/the-official-raspberry-pi-beginners-guide-5th-edition,image=image::images/fifth-editon-cover.png[]]
-=== Further reading
-
-You can find more information on how get started with your Raspberry Pi in the latest edition of https://store.rpipress.cc/collections/latest-releases/products/the-official-raspberry-pi-beginners-guide-5th-edition[Official Raspberry Pi Beginners Guide] by Gareth Halfacree.
-
-Learn how to:
-
-* Set up your Raspberry Pi, install its operating system, and start using this fully functional computer.
-* Start coding projects, with step-by-step guides using the Scratch 3, Python, and MicroPython programming languages.
-* Experiment with connecting electronic components, and have fun creating amazing projects.
-
-New in the 5th edition:
-
-* Updated for the latest Raspberry Pi computers: Raspberry Pi 5 and Raspberry Pi Zero 2 W.
-* Covers the latest Raspberry Pi OS.
-* Includes a new chapter on the Raspberry Pi Pico!

--- a/documentation/asciidoc/computers/os/using-gpio.adoc
+++ b/documentation/asciidoc/computers/os/using-gpio.adoc
@@ -94,8 +94,3 @@ button.when_pressed = led.on
 button.when_released = led.off
 ----
 
-[.booklink, booktype="free", link=https://github.com/raspberrypipress/released-pdfs/raw/main/simple-electronics-with-gpio-zero.pdf, image=image::images/simple-electronics-with-gpio-zero.jpg[]]
-
-==== Going further
-
-You can find more information on how to program electronics connected to your Raspberry Pi with the GPIO Zero Python library in the Raspberry Pi Press book https://github.com/raspberrypipress/released-pdfs/raw/main/simple-electronics-with-gpio-zero.pdf[Simple Electronics with GPIO Zero]. The book gets you started with the GPIO Zero library, and walks you through how to use it by building a series of projects.

--- a/documentation/asciidoc/microcontrollers/micropython/micropython-documentation.adoc
+++ b/documentation/asciidoc/microcontrollers/micropython/micropython-documentation.adoc
@@ -7,15 +7,3 @@ https://datasheets.raspberrypi.com/picow/connecting-to-the-internet-with-pico-w.
 https://docs.micropython.org/en/latest/rp2/quickref.html[RP2 Quick Reference]:: The official documentation around the RP2040 port of MicroPython
 https://docs.micropython.org/en/latest/library/rp2.html[RP2 Library]:: The official documentation about the `rp2` module in MicroPython
 
-=== Further reading
-
-image::images/micropython_book.png[width="70%",float=right]
-
-Check out https://store.rpipress.cc/collections/getting-started/products/get-started-with-micropython-on-raspberry-pi-pico-2nd-edition[_Get Started with MicroPython on Raspberry Pi Pico_] to learn how your Pico can interact with the world around it using the MicroPython programming language. Fully updated for Raspberry Pi Pico W and the latest version of MicroPython, this book shows you how to:
-
-* set up your Pico or Pico W and start using it
-* start writing programs using MicroPython
-* control and sense electronic components
-* discover how to use Pico's unique Programmable IO
-* turn Raspberry Pi Pico W into a network-connected node for the Internet of Things
-* link your Pico W to your smartphone, tablet, or another Pico W with Bluetooth Low Energy (BLE)


### PR DESCRIPTION
These were all I could find with a cursory search, let me know if you know of any others! After this, we should remove the unused custom template code (https://github.com/raspberrypi/documentation/pull/3040).

Context for posterity:
We're not going to continue with book callouts (booklinks) in this format because it doesn't meet our doc standards for maintainability or style. In the future we'll find a better way to gather and present related resources in the docs :)