### PR TITLE
Prevent script injection attack in GitHub Actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,12 +11,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Log current branches and repositories
+        env:
+          REPO_FULL_NAME: ${{ github.event.pull_request.head.repo.full_name }}
         run: |
           echo "Current ref: $GITHUB_REF"
           echo "Base ref: $GITHUB_BASE_REF"
           echo "Head ref: $GITHUB_HEAD_REF"
           echo "Repository: $GITHUB_REPOSITORY"
-          echo "Head repository: ${{ github.event.pull_request.head.repo.full_name }}"
+          echo "Head repository: $REPO_FULL_NAME"
       - name: Only allow pull requests based on master from the develop branch of the current repository
         if: ${{ github.base_ref == 'master' && !(github.head_ref == 'develop' && github.event.pull_request.head.repo.full_name == github.repository) }}
         run: |


### PR DESCRIPTION
Information in the github context should be treated as untrusted user input and is therefore unsafe to interpolate into scripts. Instead, mitigate their damage by using an intermediate environment variable instead.

See https://github.com/advisories/GHSA-7x29-qqmq-v6qc and https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#understanding-the-risk-of-script-injections
