### PR TITLE
Update streaming.adoc for RTSP streaming using Raspberry Pi 5 as a server.

### DIFF
--- a/documentation/asciidoc/computers/camera/streaming.adoc
+++ b/documentation/asciidoc/computers/camera/streaming.adoc
@@ -75,6 +75,13 @@ To suppress the preview window on the server, use xref:camera_software.adoc#nopr
 
 Use the xref:camera_software.adoc#inline[`inline`] flag to force stream header information into every intra frame, which helps clients understand the stream if they miss the beginning.
 
+Streaming via RTSP on a Raspberry Pi 5 also requires the use of libav as covered in the following section.
+
+[source,console]
+----
+$ rpicam-vid -t 0 --inline --libav-format h264 -o - | cvlc stream:///dev/stdin --sout '#rtp{sdp=rtsp://:8554/stream1}' :demux=h264
+----
+
 === `libav`
 
 You can use the `libav` backend as a network streaming source for audio/video.


### PR DESCRIPTION
The suggested commands do not work on a Raspberry Pi 5.

See the discussion here - https://github.com/raspberrypi/rpicam-apps/issues/747