### PR TITLE
Re-order big table in revision-codes.adoc

### DIFF
--- a/documentation/asciidoc/computers/raspberry-pi/revision-codes.adoc
+++ b/documentation/asciidoc/computers/raspberry-pi/revision-codes.adoc
@@ -367,6 +367,8 @@ NOQuuuWuFMMMCCCCPPPPTTTTTTTTRRRR
 
 NOTE: This list is not exhaustive - there may be codes in use that are not in this table. Please see the next section for best practices on using revision codes to identify boards.
 
+// This table is now sorted by Type (from table above), then Revision, then RAM, and finally Code. This is the most likley order-of-manufacture, which means we'll normally just add new revision-codes to the very bottom of the table, without having to worry about re-ordering entries.
+
 |===
 | Code | Model | Revision | RAM | Manufacturer
 
@@ -382,54 +384,6 @@ NOTE: This list is not exhaustive - there may be codes in use that are not in th
 | 512MB
 | Sony UK
 
-| 900092
-| Zero
-| 1.2
-| 512MB
-| Sony UK
-
-| 900093
-| Zero
-| 1.3
-| 512MB
-| Sony UK
-
-| 9000c1
-| Zero W
-| 1.1
-| 512MB
-| Sony UK
-
-| 9020e0
-| 3A+
-| 1.0
-| 512MB
-| Sony UK
-
-| 9020e1
-| 3A+
-| 1.1
-| 512MB
-| Sony UK
-
-| 920092
-| Zero
-| 1.2
-| 512MB
-| Embest
-
-| 920093
-| Zero
-| 1.3
-| 512MB
-| Embest
-
-| 900061
-| CM1
-| 1.1
-| 512MB
-| Sony UK
-
 | a01040
 | 2B
 | 1.0
@@ -442,29 +396,11 @@ NOTE: This list is not exhaustive - there may be codes in use that are not in th
 | 1GB
 | Sony UK
 
-| a02082
-| 3B
-| 1.2
+| a21041
+| 2B
+| 1.1
 | 1GB
-| Sony UK
-
-| a020a0
-| CM3
-| 1.0
-| 1GB
-| Sony UK
-
-| a020d3
-| 3B+
-| 1.3
-| 1GB
-| Sony UK
-
-| a020d4
-| 3B+
-| 1.4
-| 1GB
-| Sony UK
+| Embest
 
 | a02042
 | 2B (with BCM2837)
@@ -472,27 +408,27 @@ NOTE: This list is not exhaustive - there may be codes in use that are not in th
 | 1GB
 | Sony UK
 
-| a21041
-| 2B
-| 1.1
-| 1GB
-| Embest
-
 | a22042
 | 2B (with BCM2837)
 | 1.2
 | 1GB
 | Embest
 
-| a22082
+| 900061
+| CM1
+| 1.1
+| 512MB
+| Sony UK
+
+| a02082
 | 3B
 | 1.2
 | 1GB
-| Embest
+| Sony UK
 
-| a220a0
-| CM3
-| 1.0
+| a22082
+| 3B
+| 1.2
 | 1GB
 | Embest
 
@@ -514,6 +450,72 @@ NOTE: This list is not exhaustive - there may be codes in use that are not in th
 | 1GB
 | Embest
 
+| 900092
+| Zero
+| 1.2
+| 512MB
+| Sony UK
+
+| 920092
+| Zero
+| 1.2
+| 512MB
+| Embest
+
+| 900093
+| Zero
+| 1.3
+| 512MB
+| Sony UK
+
+| 920093
+| Zero
+| 1.3
+| 512MB
+| Embest
+
+| a020a0
+| CM3
+| 1.0
+| 1GB
+| Sony UK
+
+| a220a0
+| CM3
+| 1.0
+| 1GB
+| Embest
+
+| 9000c1
+| Zero W
+| 1.1
+| 512MB
+| Sony UK
+
+| a020d3
+| 3B+
+| 1.3
+| 1GB
+| Sony UK
+
+| a020d4
+| 3B+
+| 1.4
+| 1GB
+| Sony UK
+
+| 9020e0
+| 3A+
+| 1.0
+| 512MB
+| Sony UK
+
+| 9020e1
+| 3A+
+| 1.1
+| 512MB
+| Sony UK
+
 | a02100
 | CM3+
 | 1.0
@@ -532,28 +534,16 @@ NOTE: This list is not exhaustive - there may be codes in use that are not in th
 | 2GB
 | Sony UK
 
-| b03112
-| 4B
-| 1.2
-| 2GB
-| Sony UK
-
-| b03114
-| 4B
-| 1.4
-| 2GB
-| Sony UK
-
-| b03115
-| 4B
-| 1.5
-| 2GB
-| Sony UK
-
 | c03111
 | 4B
 | 1.1
 | 4GB
+| Sony UK
+
+| b03112
+| 4B
+| 1.2
+| 2GB
 | Sony UK
 
 | c03112
@@ -562,15 +552,15 @@ NOTE: This list is not exhaustive - there may be codes in use that are not in th
 | 4GB
 | Sony UK
 
+| b03114
+| 4B
+| 1.4
+| 2GB
+| Sony UK
+
 | c03114
 | 4B
 | 1.4
-| 4GB
-| Sony UK
-
-| c03115
-| 4B
-| 1.5
 | 4GB
 | Sony UK
 
@@ -580,10 +570,28 @@ NOTE: This list is not exhaustive - there may be codes in use that are not in th
 | 8GB
 | Sony UK
 
+| b03115
+| 4B
+| 1.5
+| 2GB
+| Sony UK
+
+| c03115
+| 4B
+| 1.5
+| 4GB
+| Sony UK
+
 | d03115
 | 4B
 | 1.5
 | 8GB
+| Sony UK
+
+| 902120
+| Zero 2 W
+| 1.0
+| 512MB
 | Sony UK
 
 | c03130
@@ -614,12 +622,6 @@ NOTE: This list is not exhaustive - there may be codes in use that are not in th
 | CM4
 | 1.0
 | 8GB
-| Sony UK
-
-| 902120
-| Zero 2 W
-| 1.0
-| 512MB
 | Sony UK
 
 | b04170


### PR DESCRIPTION
The current order is semi-random because some people have added new Pis by alphabetical revision-code, and some people have added new Pis to the bottom of the list. So to solve any conflicts, make it explicitly newest-Pi-at-bottom.

The revision-codes table is now sorted by Type (from the preceding table), then Revision, then RAM, and finally Code. This is the most likely order-of-manufacture, which means we'll normally just add new revision-codes to the very bottom of the table, without having to worry about re-ordering entries.

See comments in #4013 

Ping @JamesH65 and @nathan-contino  (I won't be upset if you decide to reject this).