### PR TITLE
Add instruction to only connect AI Camera while RPi unpowered

### DIFF
--- a/documentation/asciidoc/accessories/ai-camera/getting-started.adoc
+++ b/documentation/asciidoc/accessories/ai-camera/getting-started.adoc
@@ -2,6 +2,8 @@
 
 The instructions below describe how to run the pre-packaged MobileNet SSD and PoseNet neural network models on the Raspberry Pi AI Camera.
 
+IMPORTANT: Before connecting the AI Camera, shut down your Raspberry Pi and disconnect it from external power.
+
 === Prerequisites
 
 These instructions assume you are using the AI Camera attached to either a Raspberry Pi 4 Model B or Raspberry Pi 5 board. With minor changes, you can follow these instructions on other Raspberry Pi models with a camera connector, including the Raspberry Pi Zero 2 W and Raspberry Pi 3 Model B+.


### PR DESCRIPTION
The RPi AI Camera product brief includes a warning to only connect the camera while the RPi is unpowered, and this was missing from the online documentation. It can cause damage to the RPi and/or camera.