### PR TITLE
Fix Raspberry Pi AI Camera terminal command for pose detection.

### DIFF
--- a/documentation/asciidoc/accessories/ai-camera/getting-started.adoc
+++ b/documentation/asciidoc/accessories/ai-camera/getting-started.adoc
@@ -104,7 +104,7 @@ The following command runs `rpicam-hello` with pose estimation post-processing:
 
 [source,console]
 ----
-$ rpicam-hello -t 0s --post-process-file /usr/share/rpi-camera-assets/imx500_posenet.json --viewfinder-width 1920 --viewfinder-height 1080 --framerate 30
+$ rpicam-hello -t 10s --post-process-file /usr/share/rpi-camera-assets/imx500_posenet.json --viewfinder-width 1920 --viewfinder-height 1080 --framerate 30
 ----
 
 image::images/imx500-posenet.jpg[IMX500 PoseNet]


### PR DESCRIPTION
Specifying `0s` causes the program to freeze at `Network Firmware Upload: 0% (0/1624 KB)`