### PR TITLE
Update boot order config process

### DIFF
--- a/documentation/asciidoc/computers/raspberry-pi/boot-nvme.adoc
+++ b/documentation/asciidoc/computers/raspberry-pi/boot-nvme.adoc
@@ -29,21 +29,14 @@ $ sudo apt update && sudo apt full-upgrade
 
 === Edit the bootloader boot priority
 
-Use the Raspberry Pi Configuration CLI to update the bootloader:
+Use the Raspberry Pi Software Configuration Tool to update the bootloader:
 
 [source,console]
 ----
 $ sudo raspi-config
 ----
 
-Under `Advanced Options` > `Bootloader Order`, specify that the bootloader should attempt to boot from `NVMe` first:
-
-[source,console]
-----
-$ sudo rpi-eeprom-update -a
-----
-
-Then, reboot with `sudo reboot`. Your Raspberry Pi should boot from NVMe.
+Under `Advanced Options` > `Boot Order`, specify an option that includes NVMe.  It will then write these changes to the bootloader and return to the Config Tool, in which you can `Finish` and reboot.  Your Raspberry Pi will use the new boot order now.
 
 For CM4, use `rpiboot` to update the bootloader. You can find instructions for building `rpiboot` and configuring the IO board to switch the ROM to usbboot mode in the https://github.com/raspberrypi/usbboot[USB boot GitHub repository].
 


### PR DESCRIPTION
The tool calls itself the Raspberry Pi Software Configuration Tool so I updated that.

The menu option is "Boot Order", not "Bootloader Order".

It appears that after choosing a boot order it immediately drops back to the CLI, writes the bootloader changes (effectively the same as running `sudo rpi-eeprom-update -a`?), and returns back into the Config Tool.  It appears that the manual bootloader write is not necessary.

It is not strictly necessary to boot from NVMe first.  It seems reasonable to me that the average user will know to remove the SD card if they choose the first option: SD Card and then NVMe and then USB.