### PR TITLE
Update Connect troubleshooting guide

### DIFF
--- a/documentation/asciidoc/services/connect/troubleshooting.adoc
+++ b/documentation/asciidoc/services/connect/troubleshooting.adoc
@@ -10,6 +10,8 @@
 
 * Browsers intercept certain keys and key combinations. As a result, you can't type these keys into your Connect window. Screen sharing includes a toolbar to simulate some of the most popular intercepted keys.
 
+* Upgrading `rpi-connect` and `rpi-connect-lite` using Connect is not supported. The upgrade process will terminate all remote shell sessions and drop all connections.
+
 * To upgrade from version 1 to version 2, you must first upgrade the package you currently have installed before switching between `rpi-connect` and `rpi-connect-lite`. This ensures that Connect's services properly migrate to the version 2 format. If you currently have `rpi-connect` installed, run the following command:
 +
 [source,console]
@@ -50,6 +52,7 @@ If all is well, you should see output similar to the following:
 Screen sharing is supported by this version of rpi-connect
 ✓ Wayland compositor available
 ✓ Screen sharing services enabled and active
+✓ Communication with Raspberry Pi Connect WebSocket server
 ✓ Communication with Raspberry Pi Connect API
 ✓ Authentication with Raspberry Pi Connect API
 ✓ Peer-to-peer connection candidate via STUN
@@ -62,6 +65,7 @@ If there is an issue, you will see something like so:
 Screen sharing is supported by this version of rpi-connect
 ✓ Wayland compositor available
 ✗ Screen sharing services enabled and active - Please run rpi-connect on to enable and start all required services
+✓ Communication with Raspberry Pi Connect WebSocket server
 ✓ Communication with Raspberry Pi Connect API
 ✓ Authentication with Raspberry Pi Connect API
 ✓ Peer-to-peer connection candidate via STUN
@@ -109,6 +113,7 @@ If Connect can communicate properly on your network, you should see output simil
 Screen sharing is supported by this version of rpi-connect
 ✓ Wayland compositor available
 ✓ Screen sharing services enabled and active
+✓ Communication with Raspberry Pi Connect WebSocket server
 ✓ Communication with Raspberry Pi Connect API
 ✓ Authentication with Raspberry Pi Connect API
 ✓ Peer-to-peer connection candidate via STUN
@@ -117,7 +122,7 @@ Screen sharing is supported by this version of rpi-connect
 
 If Connect can't communicate properly on your network, you'll see an "x" instead of a check next to the failing test case. Ask your network administrator to enable the following connections on your network:
 
-* HTTPS requests to the Raspberry Pi Connect API on port 443 of `api.connect.raspberrypi.com`
+* HTTPS requests to the Raspberry Pi Connect API and WebSocket server on port 443 of `api.connect.raspberrypi.com` and `ws.connect.raspberrypi.com`
 * requests to Raspberry Pi Connect STUN or TURN servers on UDP port 3478 of all of the following:
 ** `stun.raspberrypi.com`
 ** `turn1.raspberrypi.com`
@@ -145,6 +150,7 @@ You should see output similar to the following:
 
 ----
 Signed in: yes
+Subscribed to events: yes
 Screen sharing: allowed (0 sessions active)
 Remote shell: allowed (0 sessions active)
 ----


### PR DESCRIPTION
Note that upgrading Connect with Connect isn't supported and update console output to reflect changes in v2.5.