### PR TITLE
Remove references to cam1 when setting camera dtoverlays as it doesn'…

### DIFF
--- a/documentation/asciidoc/computers/camera/rpicam_configuration.adoc
+++ b/documentation/asciidoc/computers/camera/rpicam_configuration.adoc
@@ -38,7 +38,7 @@ Raspberry Pi OS recognises the following overlays in `/boot/firmware/config.txt`
 
 To use one of these overlays, you must disable automatic camera detection. To disable automatic detection, set `camera_auto_detect=0` in `/boot/firmware/config.txt`. If `config.txt` already contains a line assigning an `camera_auto_detect` value, change the value to `0`. Reboot your Raspberry Pi with `sudo reboot` to load your changes.
 
-If your Raspberry Pi has two camera connectors (Raspberry Pi 5 or one of the Compute Modules, for example), then you can specify the use of camera 0 by adding `,cam0` to the `dtoverlay` that you used from the table above. If you do not add this, it will default to checking camera connector 1. Note that for official Raspberry Pi camera modules connected to SBCs (not Compute Modules), auto-detection will correctly identify all the cameras connected to your device.
+If your Raspberry Pi has two camera connectors (Raspberry Pi 5 or one of the Compute Modules, for example), then you can specify the use of camera connector 0 by adding `,cam0` to the `dtoverlay` that you used from the table above. If you do not add this, it will default to checking camera connector 1. Note that for official Raspberry Pi camera modules connected to SBCs (not Compute Modules), auto-detection will correctly identify all the cameras connected to your device.
 
 [[tuning-files]]
 ==== Tweak camera behaviour with tuning files

--- a/documentation/asciidoc/computers/camera/rpicam_configuration.adoc
+++ b/documentation/asciidoc/computers/camera/rpicam_configuration.adoc
@@ -38,7 +38,7 @@ Raspberry Pi OS recognises the following overlays in `/boot/firmware/config.txt`
 
 To use one of these overlays, you must disable automatic camera detection. To disable automatic detection, set `camera_auto_detect=0` in `/boot/firmware/config.txt`. If `config.txt` already contains a line assigning an `camera_auto_detect` value, change the value to `0`. Reboot your Raspberry Pi with `sudo reboot` to load your changes.
 
-If your Raspberry Pi has two camera connectors (Raspberry Pi 5 or one of the Compute Modules, for example), then you can specify which one you are referring to by adding `,cam0` or `,cam1` (don't add any spaces) to the `dtoverlay` that you used from the table above. If you do not add either of these, it will default to checking  camera connector 1 (`cam1`). But note that for official Raspberry Pi camera modules, auto-detection will correctly identify all the cameras connected to your device.
+If your Raspberry Pi has two camera connectors (Raspberry Pi 5 or one of the Compute Modules, for example), then you can specify the use of camera 0 by adding `,cam0` to the `dtoverlay` that you used from the table above. If you do not add this, it will default to checking camera connector 1. Note that for official Raspberry Pi camera modules connected to SBCs (not Compute Modules), auto-detection will correctly identify all the cameras connected to your device.
 
 [[tuning-files]]
 ==== Tweak camera behaviour with tuning files

--- a/documentation/asciidoc/computers/compute-module/cmio-camera.adoc
+++ b/documentation/asciidoc/computers/compute-module/cmio-camera.adoc
@@ -65,19 +65,19 @@ dtparam=cam1_reg
 | directive
 
 | v1 camera
-| `dtoverlay=ov5647,cam1`
+| `dtoverlay=ov5647`
 
 | v2 camera
-| `dtoverlay=imx219,cam1`
+| `dtoverlay=imx219`
 
 | v3 camera
-| `dtoverlay=imx708,cam1`
+| `dtoverlay=imx708`
 
 | HQ camera
-| `dtoverlay=imx477,cam1`
+| `dtoverlay=imx477`
 
 | GS camera
-| `dtoverlay=imx296,cam1`
+| `dtoverlay=imx296`
 |===
 
 . Reboot your Compute Module with `sudo reboot`.


### PR DESCRIPTION
…t aactually exist