### PR TITLE
docs: include info on installing network-manager package

### DIFF
--- a/documentation/asciidoc/computers/configuration/host-wireless-network.adoc
+++ b/documentation/asciidoc/computers/configuration/host-wireless-network.adoc
@@ -22,6 +22,8 @@ To create a hosted wireless network on the command line, run the following comma
 $ sudo nmcli device wifi hotspot ssid <example-network-name> password <example-password>
 ----
 
+> Note: If the `sudo nmcli` command fails for you, you must install the network-manager package with `sudo apt install network-manager`.
+
 Use another wireless client, such as a laptop or smartphone, to connect to the network. Look for a network with a SSID matching `<example-network-name>`. Enter your network password, and you should connect successfully to the network. If your Raspberry Pi has internet access via an Ethernet connection or a second wireless adapter, you should be able to access the internet.
 
 === Disable hotspot


### PR DESCRIPTION
After doing a regular `sudo apt update && sudo apt upgrade -y` I couldn't `sudo nmcli ...` so if another user runs into the same issue I put a little note in here on how to continue forward.