### PR TITLE
[Minor] bcm2836.adoc: fix ARM documentation link

### DIFF
--- a/documentation/asciidoc/computers/processors/bcm2836.adoc
+++ b/documentation/asciidoc/computers/processors/bcm2836.adoc
@@ -5,4 +5,4 @@ The Broadcom chip used in the Raspberry Pi 2 Model B. The underlying architectur
 You should refer to:
 
 * https://datasheets.raspberrypi.com/bcm2836/bcm2836-peripherals.pdf[BCM2836 ARM-local peripherals]
-* http://infocenter.arm.com/help/index.jsp?topic=/com.arm.doc.ddi0464f/index.html[Cortex-A7 MPcore Processor Reference Manual]
+* https://developer.arm.com/documentation/ddi0464/f/[Cortex-A7 MPcore Processor Reference Manual]


### PR DESCRIPTION
Fixed link to the ARM [Cortex-A7 MPcore Processor Reference ManuaL](https://developer.arm.com/documentation/ddi0464/f/) - previous link redirected to the ARM documentation site root and not the actual document.