### PR TITLE
conditional: Document the bootvar0 variable

### DIFF
--- a/documentation/asciidoc/computers/config_txt/conditional.adoc
+++ b/documentation/asciidoc/computers/config_txt/conditional.adoc
@@ -174,7 +174,7 @@ The value of the `boot_arg1` variable when the OS was started can be read via xr
 ==== `bootvar0`
 Raspberry Pi 5 and newer devices only.
 
-The `bootvar0` variable is a 32-bit user defined value which is set through rpi-eeprom-config, and then can be used as a conditional variable in config.txt.
+The `bootvar0` variable is a 32-bit user-defined value that is set through `rpi-eeprom-config`, and then can be used as a conditional variable in `config.txt`.
 
 For example, setting `bootvar0` to 42 via `rpi-eeprom-config`:
 [source,ini]

--- a/documentation/asciidoc/computers/config_txt/conditional.adoc
+++ b/documentation/asciidoc/computers/config_txt/conditional.adoc
@@ -182,7 +182,7 @@ For example, setting `bootvar0` to 42 via `rpi-eeprom-config`:
 BOOTVAR0=42
 ----
 
-and then using it conditionally in `config.txt`:
+Using `bootvar0` conditionally in `config.txt`:
 [source,ini]
 ----
 [bootvar0=42]

--- a/documentation/asciidoc/computers/config_txt/conditional.adoc
+++ b/documentation/asciidoc/computers/config_txt/conditional.adoc
@@ -171,6 +171,26 @@ sudo vcmailbox 0x0003008c 8 8 1 0
 ----
 The value of the `boot_arg1` variable when the OS was started can be read via xref:configuration.adoc#part4[device-tree] at `/proc/device-tree/chosen/bootloader/arg1`
 
+==== `bootvar0`
+Raspberry Pi 5 and newer devices only.
+
+The `bootvar0` variable is a 32-bit user defined value which is set through rpi-eeprom-config, and then can be used as a conditional variable in config.txt.
+
+For example, setting `bootvar0` to 42 via `rpi-eeprom-config`:
+[source,ini]
+----
+BOOTVAR0=42
+----
+
+and then using it conditionally in `config.txt`:
+[source,ini]
+----
+[bootvar0=42]
+arm_freq=1000
+----
+
+This allows a common image (i.e. with the same config.txt file) to support different configurations based on the persistent rpi-eeprom-config settings.
+
 ==== `boot_count`
 Raspberry Pi 5 and newer devices only.
 

--- a/documentation/asciidoc/computers/config_txt/conditional.adoc
+++ b/documentation/asciidoc/computers/config_txt/conditional.adoc
@@ -189,7 +189,7 @@ Using `bootvar0` conditionally in `config.txt`:
 arm_freq=1000
 ----
 
-This allows a common image (i.e. with the same config.txt file) to support different configurations based on the persistent rpi-eeprom-config settings.
+This allows a common image (that is, with the same `config.txt` file) to support different configurations based on the persistent `rpi-eeprom-config` settings.
 
 ==== `boot_count`
 Raspberry Pi 5 and newer devices only.

--- a/documentation/asciidoc/computers/raspberry-pi/eeprom-bootloader.adoc
+++ b/documentation/asciidoc/computers/raspberry-pi/eeprom-bootloader.adoc
@@ -568,6 +568,13 @@ During the "partition walk" `autoboot.txt` files are not processed to avoid cycl
 
 Default: `0`
 
+[[BOOTVAR0]]
+==== `BOOTVAR0`
+
+Allows setting the conditional variable bootvar0 used by `config.txt`. See xref:config_txt.adoc#bootvar0[bootvar0].
+
+Default: `0`
+
 [[PSU_MAX_CURRENT]]
 ==== `PSU_MAX_CURRENT`
 

--- a/documentation/asciidoc/computers/raspberry-pi/eeprom-bootloader.adoc
+++ b/documentation/asciidoc/computers/raspberry-pi/eeprom-bootloader.adoc
@@ -571,7 +571,7 @@ Default: `0`
 [[BOOTVAR0]]
 ==== `BOOTVAR0`
 
-Allows setting the conditional variable bootvar0 used by `config.txt`. See xref:config_txt.adoc#bootvar0[bootvar0].
+Allows setting the conditional variable `bootvar0` used by `config.txt`. See xref:config_txt.adoc#bootvar0[bootvar0].
 
 Default: `0`
 


### PR DESCRIPTION
The `bootvar0` variable is a 32-bit user defined value which is set through rpi-eeprom-config, and then can be used as a conditional variable in config.txt