### PR TITLE
Bump Connect's ECMAScript requirement

### DIFF
--- a/documentation/asciidoc/services/connect/troubleshooting.adoc
+++ b/documentation/asciidoc/services/connect/troubleshooting.adoc
@@ -6,7 +6,7 @@
 
 * Connect does not support on-screen keyboards. For full functionality, use a physical keyboard.
 
-* Connect requires a browser that implements https://caniuse.com/?search=es2020[ECMAScript 2020] (ES11) as it makes use of https://caniuse.com/?feats=mdn-javascript_operators_optional_chaining,mdn-javascript_operators_nullish_coalescing,mdn-javascript_builtins_globalthis,es6-module-dynamic-import,bigint,mdn-javascript_builtins_promise_allsettled,mdn-javascript_builtins_string_matchall,mdn-javascript_statements_export_namespace,mdn-javascript_operators_import_meta[features] unavailable in older browsers.
+* Connect requires a browser that implements https://caniuse.com/?search=es2022[ECMAScript 2022] (ES13) as it makes use of features unavailable in older browsers.
 
 * Browsers intercept certain keys and key combinations. As a result, you can't type these keys into your Connect window. Screen sharing includes a toolbar to simulate some of the most popular intercepted keys.
 


### PR DESCRIPTION
Also remove list of features in the version. This list wasn't specific to Connect's implementation and it is unnecessary given the information is in the linked page
