### PR TITLE
Update shortlinks

### DIFF
--- a/documentation/asciidoc/computers/os/playing-audio-and-video.adoc
+++ b/documentation/asciidoc/computers/os/playing-audio-and-video.adoc
@@ -16,7 +16,7 @@ You can also launch VLC from the command line. For the examples below, we used a
 
 [source,console]
 ----
-$ wget --trust-server-names http://rptl.io/big-buck-bunny
+$ wget --trust-server-names http://rpltd.co/big-buck-bunny
 ----
 
 To play the clip in VLC from the command line, run the following command:
@@ -62,7 +62,7 @@ For the examples below, we used a short audio clip. To download this clip from R
 
 [source,console]
 ----
-$ wget --trust-server-names http://rptl.io/startup-music
+$ wget --trust-server-names http://rpltd.co/startup-music
 ----
 
 To play the clip in VLC from the command line, run the following command:

--- a/documentation/asciidoc/microcontrollers/debug-probe/introduction.adoc
+++ b/documentation/asciidoc/microcontrollers/debug-probe/introduction.adoc
@@ -10,7 +10,7 @@ The Raspberry Pi Debug Probe is a USB device that provides both a UART serial po
 * Works with https://openocd.org/[OpenOCD] and other tools supporting CMSIS-DAP
 * Open source, easily upgradeable firmware
 
-NOTE: For more information on the Raspberry Pi three-pin debug connector see the https://rptl.io/debug-spec[specification].
+NOTE: For more information on the Raspberry Pi three-pin debug connector see the https://rpltd.co/debug-spec[specification].
 
 This makes it easy to use a Raspberry Pi Pico on platforms such as Windows, macOS, and Linux that lack a GPIO header to connect directly to the Pico's serial UART or SWD port.
 
@@ -32,7 +32,7 @@ Orange:: TX/SC (Output from Probe)
 Black:: GND
 Yellow:: RX/SD (Input to Probe or I/O)
 
-While the cable with three-pin JST-SH connectors is intended to be used with the https://rptl.io/debug-spec[standard three-pin connector] which newer Raspberry Pi boards use for the SWD debug port and UART connectors.
+While the cable with three-pin JST-SH connectors is intended to be used with the https://rpltd.co/debug-spec[standard three-pin connector] which newer Raspberry Pi boards use for the SWD debug port and UART connectors.
 
 The Debug Probe has five LEDs, a red LED to indicate power, and four more activity indicator LEDs
 

--- a/documentation/asciidoc/microcontrollers/microcontroller_docs.adoc
+++ b/documentation/asciidoc/microcontrollers/microcontroller_docs.adoc
@@ -46,5 +46,5 @@ https://datasheets.raspberrypi.com/pico/raspberry-pi-pico-c-sdk.pdf[Raspberry Pi
 
 https://datasheets.raspberrypi.com/pico/raspberry-pi-pico-python-sdk.pdf[Raspberry Pi Pico Python SDK]:: A MicroPython environment for RP2040 microcontrollers
 
-The API level Doxygen documentation for the Raspberry Pi Pico C/{cpp} SDK is also available https://rptl.io/pico-doxygen[as a micro-site].
+The API level Doxygen documentation for the Raspberry Pi Pico C/{cpp} SDK is also available https://rpltd.co/pico-doxygen[as a micro-site].
 


### PR DESCRIPTION
Both forms of shortlink work, but we now prefer rpltd.co over rptl.io