### PR TITLE
Add warning for signal line connections on debug probe

### DIFF
--- a/documentation/asciidoc/microcontrollers/debug-probe/introduction.adoc
+++ b/documentation/asciidoc/microcontrollers/debug-probe/introduction.adoc
@@ -32,7 +32,7 @@ Orange:: TX/SC (Output from Probe)
 Black:: GND
 Yellow:: RX/SD (Input to Probe or I/O)
 
-While the cable with three-pin JST-SH connectors is intended to be used with the https://rpltd.co/debug-spec[standard three-pin connector] which newer Raspberry Pi boards use for the SWD debug port and UART connectors.
+The cable with three-pin JST-SH connectors is intended to be used with the https://rpltd.co/debug-spec[standard three-pin connector] that newer Raspberry Pi boards use for the SWD debug port and UART connectors.
 
 WARNING: When the target is powered from a separate power source or computer, ensure a common reference before connecting signal lines. Either remove power from the target or connect GND between the target and the Raspberry Pi Debug Probe first; you can attach RX, TX, SC, and SD after GND is connected. Potential voltage differences between the two systems can cause damage to the probe.
 


### PR DESCRIPTION
Added a warning about connecting signal lines when using separate power sources. In the following forum entry, Raspberry Pi engineer "jdb" confirmed the issue. As I got not response about adding a warning, I opened this pull request.

https://forums.raspberrypi.com/viewtopic.php?p=2342625&hilit=debug+probe+AC#p2342625