### PR TITLE
Flag enable_rp1_uart as being Pi5-only

### DIFF
--- a/documentation/asciidoc/computers/config_txt/boot.adoc
+++ b/documentation/asciidoc/computers/config_txt/boot.adoc
@@ -165,6 +165,8 @@ Default: `0x0`
 [[enable_rp1_uart]]
 ==== `enable_rp1_uart`
 
+Raspberry Pi 5 only.
+
 When set to `1`, firmware initialises RP1 UART0 to 115200bps and doesn't reset RP1 before starting the OS (separately configurable using `pciex4_reset=1`).
 This makes it easier to get UART output on the 40-pin header in early boot-code, for instance during bare-metal debug.
 


### PR DESCRIPTION
...as only Pi 5 has an RP1 chip!

(Note that in these docs, "Raspberry Pi 5" is generally used to mean "any device with a BCM2712 SoC")