### PR TITLE
Update Raspberry Pi SSD documentation for the 1TB model

### DIFF
--- a/documentation/asciidoc/accessories/ssds/about.adoc
+++ b/documentation/asciidoc/accessories/ssds/about.adoc
@@ -10,6 +10,7 @@ Raspberry Pi SSDs are available in the following sizes:
 
 * 256GB
 * 512GB
+* 1TB
 
 To use an SSD with your Raspberry Pi, you need a Raspberry Pi 5-compatible M.2 adapter, such as the xref:../accessories/m2-hat-plus.adoc[Raspberry Pi M.2 HAT+ or M.2 HAT+ Compact].
 
@@ -21,7 +22,7 @@ Raspberry Pi SSDs use the NVMe 1.4 register interface and command set.
 
 Raspberry Pi SSDs use the M.2 2230 form factor.
 
-The following table describes the read and write speeds of Raspberry Pi SSDs using 4KB of random data:
+The following table describes the read and write speeds of Raspberry Pi SSDs using 4kB of random data:
 
 [cols="1,2,2"]
 |===
@@ -29,4 +30,5 @@ The following table describes the read and write speeds of Raspberry Pi SSDs usi
 
 | 256GB | 40,000 IOPS | 70,000 IOPS
 | 512GB | 50,000 IOPS | 90,000 IOPS
+| 1TB   | 90,000 IOPS | 90,000 IOPS
 |===


### PR DESCRIPTION
I also fixed capitalization: `KB` -> `kB`. Kilo is always abbreviated with a lowercase `k`