### PR TITLE
Update window manager options in raspi-config documentation

### DIFF
--- a/documentation/asciidoc/computers/configuration/raspi-config.adoc
+++ b/documentation/asciidoc/computers/configuration/raspi-config.adoc
@@ -221,7 +221,7 @@ On the Raspberry Pi 4 and later, switch to the latest boot ROM software. Alterna
 
 ==== Wayland
 
-Switch between the X11 and Wayland backends, and choose a window manager. Since Raspberry Pi OS _Bookworm_, all Raspberry Pi models run Wayland using labwc by default.
+Switch between the X11 and Wayland backends. Since Raspberry Pi OS _Bookworm_, all Raspberry Pi models run Wayland using labwc by default.
 
 NOTE: To use Wayland on Raspberry Pi models prior to Raspberry Pi 4 running a version of Raspberry Pi OS earlier than _Bookworm_, add `wayland=on` to `/boot/firmware/cmdline.txt`.
 
@@ -779,7 +779,7 @@ $ sudo raspi-config nonint do_boot_rom <E1/E2>
 
 ==== Wayland
 
-Switch between the X11 and Wayland backends, and choose a window manager. Since Raspberry Pi OS _Bookworm_, all Raspberry Pi models run Wayland using the labwc window manager by default.
+Switch between the X11 and Wayland backends. Since Raspberry Pi OS _Bookworm_, all Raspberry Pi models run Wayland using the labwc window manager by default.
 
 NOTE: To use Wayland on Raspberry Pi models prior to Raspberry Pi 4 running a version of Raspberry Pi OS earlier than _Bookworm_, add `wayland=on` to `/boot/firmware/cmdline.txt`.
 


### PR DESCRIPTION
For raspi-config nonint do_wayland,
W2 option is now labwc
W3 option has been removed