### PR TITLE
docs: annotate Raspberry Pi Zero / Zero W with Type 9

### DIFF
--- a/documentation/asciidoc/computers/raspberry-pi/revision-codes.adoc
+++ b/documentation/asciidoc/computers/raspberry-pi/revision-codes.adoc
@@ -455,25 +455,25 @@ NOTE: This list is not exhaustive - there may be codes in use that are not in th
 | Embest
 
 | 900092
-| Zero
+| Zero (Type 9)
 | 1.2
 | 512 MB
 | Sony UK
 
 | 920092
-| Zero
+| Zero (Type 9)
 | 1.2
 | 512 MB
 | Embest
 
 | 900093
-| Zero
+| Zero (Type 9)
 | 1.3
 | 512 MB
 | Sony UK
 
 | 920093
-| Zero
+| Zero (Type 9)
 | 1.3
 | 512 MB
 | Embest
@@ -491,7 +491,7 @@ NOTE: This list is not exhaustive - there may be codes in use that are not in th
 | Embest
 
 | 9000c1
-| Zero W
+| Zero W (Type 9)
 | 1.1
 | 512 MB
 | Sony UK


### PR DESCRIPTION
This PR annotates Raspberry Pi Zero and Zero W entries with their Type number (9) in the new-style revision codes table, making the documentation clearer and consistent with the revision-code specification.
Fixes #4267
