### PR TITLE
Clarify Wi-Fi instructions to explain how to skip.

### DIFF
--- a/documentation/asciidoc/computers/getting-started/install.adoc
+++ b/documentation/asciidoc/computers/getting-started/install.adoc
@@ -97,7 +97,7 @@ image::images/imager/os-customisation-locale.png[alt="Imager OS Customisation Lo
 +
 image::images/imager/os-customisation-user.png[alt="Imager OS Customisation User tab.",width="80%"]
 
-. In the *Customisation > Wi-Fi* tab, on first use, Imager pre-fills the SSID (name) and password of the Wi-Fi network you're currently connected to.
+. In the *Customisation > Wi-Fi* tab, on first use, Imager pre-fills the SSID (name) and password of the Wi-Fi network you're currently connected to. If you don't want your Raspberry Pi to connect to a wifi network clear the SSID to continue.
 +
 .. Select whether to connect to a *Secure network* or an *Open network*.
 .. If there's no pre-filled information or if you want to change it, enter the SSID (name) of your wireless network. For secure networks, enter and confirm the password for the network.


### PR DESCRIPTION
Currently if you don't want to setup wi-fi on your Raspberry Pi, but are using the imager from a device with wi-fi the Image will prefill the wi-fi SSID and make it appear that wi-fi is required to continue. There is an [issue on the rpi-imager](https://github.com/raspberrypi/rpi-imager/issues/1373)  to improve this, however until that is resolved I believe the documentation can be improved.

This not being clear, even as I followed the instructions, nearly made me stop using the imager/skip all customisation since I do not want my Raspberry Pi to have any network access.

This change addresses the above concerns by updating the wi-fi customisation instructions to explain how to skip setting up wifi.