### PR TITLE
Update conditional.adoc to support the cust_otp variable

### DIFF
--- a/documentation/asciidoc/computers/config_txt/conditional.adoc
+++ b/documentation/asciidoc/computers/config_txt/conditional.adoc
@@ -127,7 +127,7 @@ The raw value of the `PM_RSTS` register at bootup is available via `/proc/device
 
 The expression filter provides support for comparing unsigned integer "boot variables" to constants using a simple set of operators. It is intended to support OTA update mechanisms, debug and test.
 
-* The "boot variables" are `boot_arg1`, `boot_count`, `boot_partition` and `partition`.
+* The "boot variables" are `boot_arg1`, `cust_otpN`, `boot_count`, `boot_partition` and `partition`.
 * Boot variables are always lower case.
 * Integer constants may either be written as decimal or as hex.
 * Expression conditional filters have no side-effects e.g. no assignment operators.
@@ -173,6 +173,22 @@ sudo vcmailbox 0x0003008c 8 8 1 0
 # 0x00000020 0x80000000 0x0003008c 0x00000008 0x80000008 0x00000001 0x0000002a 0x0000000
 ----
 The value of the `boot_arg1` variable when the OS was started can be read via xref:configuration.adoc#part4[device-tree] at `/proc/device-tree/chosen/bootloader/arg1`
+
+==== `cust_otpN`
+
+The `cust_otpN` boot variable, where `N` is in the range 0–7, corresponds to the eight customer OTP rows.
+This allows different configurations to be selected based on persistent values stored in customer OTP.
+
+Example `config.txt` — apply settings only when bit 0 of customer OTP row 0 is set:
+
+[source,ini]
+----
+[cust_otp0&0x1]
+cmdline=cmdline_product1.txt
+----
+
+For more information on programming customer OTP rows, see
+xref:raspberry-pi.adoc#write-and-read-customer-otp-values[Writing and reading customer OTP values].
 
 ==== `bootvar0`
 Raspberry Pi 4 and newer devices only.


### PR DESCRIPTION
The cust_otpN boot variable, where N ranges from 0–7, correspond to the eight customer OTP rows, and then can be used as a conditional variable in config.txt to select different configurations.