### PR TITLE
Add a link to a CM5 testpoints visualisation

### DIFF
--- a/documentation/asciidoc/computers/compute-module/datasheet.adoc
+++ b/documentation/asciidoc/computers/compute-module/datasheet.adoc
@@ -6,6 +6,7 @@ To learn more about Compute Module 5 (CM5) and its corresponding IO Board, see t
 
 * https://pip.raspberrypi.com/documents/RP-008180-DS[CM5 datasheet]
 * https://rpltd.co/cm5-design-files[CM5 design files]
+* https://kovirobi.github.io/rpi-cm5-testpoints[CM5 testpoints visualisation]
 
 === Compute Module 5 IO Board datasheet
 


### PR DESCRIPTION
I wanted to use the UART testpoints (accidentally torn off the JST header I soldered, by trying to unplug the connector), and it was hard to know which one is which.

Thought it might be useful for others, feel free to just vendor the SVG or otherwise request changes (including license changes or repo moves). It's more or less just a scatter plot example using the table from the schematic PDF plus a photo. But might be useful for others.