### PR TITLE
Fix link to RP2040 Datasheet in Pico documentation

### DIFF
--- a/documentation/asciidoc/microcontrollers/pico-series/about_pico.adoc
+++ b/documentation/asciidoc/microcontrollers/pico-series/about_pico.adoc
@@ -159,7 +159,7 @@ For more information about the wireless hardware and functionality of Raspberry 
 
 Raspberry Pi offers additional technical documentation relevant to Raspberry Pi Pico W and Pico WH:
 
-* https://pip.raspberrypi.com/documents/RP-008373-DS[RP2040 Datasheet: A microcontroller by Raspberry Pi]
+* https://pip.raspberrypi.com/documents/RP-008371-DS[RP2040 Datasheet: A microcontroller by Raspberry Pi]
 * https://pip.raspberrypi.com/documents/RP-008312-DS[Raspberry Pi Pico W Datasheet: An RP2040-based microcontroller board]
 * https://pip.raspberrypi.com/documents/RP-008279-DS[Hardware design with RP2040: Using RP2040 microcontrollers to build boards and products]
 * https://pip.raspberrypi.com/documents/RP-008257-DS[Connecting to the Internet with Raspberry Pi Pico W-series: Getting online with C/{cpp} or MicroPython on W-series devices]


### PR DESCRIPTION
Updated the RP2040 datasheet link to point to the correct document (`RP-008371-DS`) instead of the previous `RP-008373-DS`, which incorrectly referenced the RP2350 datasheet. This fixes the documentation mismatch and ensures the link now directs to the proper RP2040 reference.