### PR TITLE
Fix grammar in Samba documentation

### DIFF
--- a/documentation/asciidoc/computers/remote-access/samba.adoc
+++ b/documentation/asciidoc/computers/remote-access/samba.adoc
@@ -81,7 +81,7 @@ $ ls windowshare/
 
 ==== "Host is down" error
 
-This error occurs when SMB protocol version do not match and the Linux Samba client returns a misleading error message. By default Raspberry Pi OS uses versions 2.1 and above, compatible with Windows 7 and later. Older devices, including some NAS, may require version 1.0. To fix this error, append a version entry (e.g. `,vers=1.0`) to your mount command:
+This error occurs when SMB protocol versions do not match and the Linux Samba client returns a misleading error message. By default Raspberry Pi OS uses versions 2.1 and above, compatible with Windows 7 and later. Older devices, including some NAS, may require version 1.0. To fix this error, append a version entry (e.g. `,vers=1.0`) to your mount command:
 
 [source,console]
 ----


### PR DESCRIPTION
This PR fixes a small grammar issue in the Samba documentation.

The sentence previously used the singular "version" with "do not match". This updates it to "versions do not match" for grammatical agreement.