### PR TITLE
fix: BOOT_UART on Raspberry Pi 5 does not use GPIO 14/15

### DIFF
--- a/documentation/asciidoc/computers/configuration/interfaces.adoc
+++ b/documentation/asciidoc/computers/configuration/interfaces.adoc
@@ -225,7 +225,7 @@ The available UART interfaces vary by Raspberry Pi model. The following table su
   `UART2` through to `UART5`: PL011 (disabled by default)
 
 | Raspberry Pi 5, 500, 500+, and Compute Module 5
-| `UART0` through to `UART4`: PL011 (disabled by default) +
+| `UART0` through to `UART4` and `UART10` (also called `debug uart`): PL011 (disabled by default) +
   No mini UART
 |===
 

--- a/documentation/asciidoc/computers/raspberry-pi/eeprom-bootloader.adoc
+++ b/documentation/asciidoc/computers/raspberry-pi/eeprom-bootloader.adoc
@@ -27,7 +27,7 @@ This section describes all the configuration items available in the bootloader. 
 [[BOOT_UART]]
 ==== `BOOT_UART`
 
-If `1` then enable UART debug output on GPIO 14 and 15. Configure the receiving debug terminal at 115200bps, 8 bits, no parity bits, 1 stop bit.
+If `1` then enable UART debug output on the primary UART. On the Raspberry Pi 5 this is `UART10`, which is exposed on the debug UART connector. On all older Raspberry Pi models the primary UART is exposed on GPIO 14 and 15. Configure the receiving debug terminal at 115200bps, 8 bits, no parity bits, 1 stop bit.
 
 Default: `0`
 


### PR DESCRIPTION
Related to https://github.com/raspberrypi/documentation/issues/3239 and https://github.com/raspberrypi/documentation/issues/3938 .

We were pulling our hair out at getting UART to work on the Raspberry Pi 5 Compute Module. After a lot of trying around we concluded that there are mistakes in:
- the docs, which this PR fix,
- the [datasheet](https://pip-assets.raspberrypi.com/categories/944-raspberry-pi-compute-module-5/documents/RP-008180-DS-6-cm5-datasheet.pdf) and
- raspi-config.

I wrote an article explaining this in-depth: https://chris-besch.com/articles/raspberry_pi_5_uart
We're not entirely sure our understanding of all this is completely correct and we base our explanation on some tests we did only with a Raspberry Pi 5 Compute Module IO Board. We'd of course be very interested in any mistakes we might have done.