### PR TITLE
Add note to IMAGER_REPO_URL section as not working

### DIFF
--- a/documentation/asciidoc/computers/raspberry-pi/eeprom-bootloader.adoc
+++ b/documentation/asciidoc/computers/raspberry-pi/eeprom-bootloader.adoc
@@ -469,6 +469,8 @@ Default: `""` (not set)
 [[IMAGER_REPO_URL]]
 ==== `IMAGER_REPO_URL`
 
+NOTE: This use of the `IMAGER_REPO_URL` configuration is not currently respected by the network install Raspberry Pi Imager due to a https://github.com/raspberrypi/rpi-imager/issues/894[known issue].
+
 The Raspberry Pi Imager application is configured with a JSON file downloaded at startup. By default, Raspberry Pi Imager uses the JSON at https://downloads.raspberrypi.com/os_list_imagingutility_v4.json.
 
 Set `IMAGER_REPO_URL` in the EEPROM configuration to specify the location of the JSON file to use during a network install with the embedded Raspberry Pi Imager.


### PR DESCRIPTION
The `IMAGER_REPO_URL` eeprom option currently isn't respected by imager (and hasn't been for 2+ years now). Until the net install imager has been updated with the fix that has already been implemented, a note should be added. 

Having spent a reasonable amount of time trying to figure out why it wasn't working, this will hopefully save the next person the time, until the issue is resolved.

When the issue is resolved, this can be removed. 

https://github.com/raspberrypi/rpi-imager/issues/894